### PR TITLE
.idea in .gitignore AND fix markdown inside multiline comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ Icon?
 ehthumbs.db
 Thumbs.db
 
+/.idea/
+!/.idea/codeStyleSettings.xml

--- a/src/examples/gcmol.cpp
+++ b/src/examples/gcmol.cpp
@@ -41,33 +41,33 @@ int main() {
 }
 
 /**
- * @page example_GCMolecular Example: Grand Canonical Water
- *
- * This is a example of Grand Canonical Monte Carlo simulation
- * of rigid water molecules. The specified water activity corresponds
- * to the water vapour pressure in which with the liquid phase is in
- * equilibrium.
- *
- * ![Grand canonical water](NmuT.png)
- *
- * Run the example directly from the faunus directory:
- *
- *     $ make
- *     $ cd src/examples/
- *     $ ./gcmol.run
- *
- * Input
- * =====
- * All listed files including the above C++ and python programs can be found in `src/examples/`
- *
- * gcmol.json
- * ----------
- * State atom types
- * @include gcmol.json
- *
- * gcmol.cpp
- * ---------
- * @include gcmol.cpp
+@page example_GCMolecular Example: Grand Canonical Water
+
+This is a example of Grand Canonical Monte Carlo simulation
+of rigid water molecules. The specified water activity corresponds
+to the water vapour pressure in which with the liquid phase is in
+equilibrium.
+
+![Grand canonical water](NmuT.png)
+
+Run the example directly from the faunus directory:
+
+    $ make
+    $ cd src/examples/
+    $ ./gcmol.run
+
+Input
+=====
+All listed files including the above C++ and python programs can be found in `src/examples/`
+
+gcmol.json
+----------
+State atom types
+@include gcmol.json
+
+gcmol.cpp
+---------
+@include gcmol.cpp
  */
 
 

--- a/src/examples/polymers.cpp
+++ b/src/examples/polymers.cpp
@@ -68,34 +68,34 @@ int main() {
   return test.numFailed();
 }
 /** 
- * @page example_polymers Example: Polymers
- *
- * This will simulate an arbitrary number of linear polymers in the NPT ensemble
- * with explicit salt particles and implicit solvent (dielectric continuum).
- * We include the following Monte Carlo moves:
- *
- * - salt translation
- * - monomer translation
- * - polymer translation and rotation
- * - polymer crankshaft and pivot rotations
- * - isobaric volume move (NPT ensemble)
- *
- * ![Hardsphere polyelectrolytes with counter ions](polymers.png)
- *
- * Run this example from the `examples` directory:
- *
- * ~~~~~~~~~~~~~~~~~~~
- * $ make
- * $ cd src/examples
- * $ python ./polymers.py
- * ~~~~~~~~~~~~~~~~~~~
- *
- * polymers.py
- * ===========
- * This is a python run-script that generates all required
- * input as well as run the main program. This is also used
- * for running the unittest when running `make test`. 
- *
- * @include polymers.py
+@page example_polymers Example: Polymers
+
+This will simulate an arbitrary number of linear polymers in the NPT ensemble
+with explicit salt particles and implicit solvent (dielectric continuum).
+We include the following Monte Carlo moves:
+
+- salt translation
+- monomer translation
+- polymer translation and rotation
+- polymer crankshaft and pivot rotations
+- isobaric volume move (NPT ensemble)
+
+![Hardsphere polyelectrolytes with counter ions](polymers.png)
+
+Run this example from the `examples` directory:
+
+~~~~~~~~~~~~~~~~~~~
+$ make
+$ cd src/examples
+$ python ./polymers.py
+~~~~~~~~~~~~~~~~~~~
+
+polymers.py
+===========
+This is a python run-script that generates all required
+input as well as run the main program. This is also used
+for running the unittest when running `make test`. 
+
+@include polymers.py
  */
 

--- a/src/examples/seawater.cpp
+++ b/src/examples/seawater.cpp
@@ -24,13 +24,13 @@ int main() {
   cout << spc.info() + loop.info() + pot.info() + mv.info() + widom.info();
 }
 /**
- * @page example_seawater Example: Activity Coefficients in Seawater
- *
- * @includelineno seawater.cpp
- *
- * Run the code directly from the faunus directory:
- *
- *     $ make example_seawater
- *     $ cd src/examples/
- *     $ ./seawater.sh
+@page example_seawater Example: Activity Coefficients in Seawater
+
+@includelineno seawater.cpp
+
+Run the code directly from the faunus directory:
+
+    $ make example_seawater
+    $ cd src/examples/
+    $ ./seawater.sh
  */

--- a/src/examples/twobody.cpp
+++ b/src/examples/twobody.cpp
@@ -53,101 +53,101 @@ int main(int argc, char** argv) {
 }
 
 /**
- * @page example_twobody Example: Osmotic Second Virial Coefficient
- *
- * In this example we calculate the potential of mean force between
- * two rigid bodies with a fluctuating charge distribution. Salt and
- * solvent are implicitly treated using a Debye-Huckel potential and
- * the rigid bodies (here proteins) are kept on a line and allowed to
- * translate, rotate, and protons are kept in equilibrium with bulk
- * using particle swap moves.
- *
- * During simulation we simply sample the probability of observing
- * the two bodies at a specific separation
- * (using `Faunus::Analysis::LineDistribution`).
- * As the proteins are confined onto a line, each volume element along
- * `r` is constant and there's thus no need to normalize with a spherical
- * shell as done for freely moving particles.
- * The minimum and maximum allowed distance between the two bodies can
- * specified via the `Faunus::Energy::MassCenterConstrain` term in the
- * Hamiltonian.
- *
- * ![Two rigid molecules kept on a line inside a cylinder](twobody.png)
- *
- * Run this example from the `examples` directory:
- * The python script `twobody.py` generates the simulation input files
- * and all changes to the simulation setup should be done from inside
- * the script.
- * This example can run with the following (the first, optional
- * command checks out a specific commit with which this tutorial was created),
- *
- * ~~~~~~~~~~~~~~~~~~~
- * $ (git checkout 10e9a0b)
- * $ make example_twobody
- * $ cd src/examples
- * $ python twobody.py
- * ~~~~~~~~~~~~~~~~~~~
- *
- * For calculating the virial coefficient, @f$B_2@f$, the angularly averaged
- * radial distribution function, g(r), must be integrated according to,
- *
- * @f[ B_2 = -2\pi \int_0^{\infty} [ g(r) -1 ] r^2 dr @f]
- *
- * where it should be noted that noise at large separations is strongly
- * amplified. To fix this, the tail of the g(r) can be fitted to
- * a Yukawa potential of the form (see [doi:10/xqw](http://dx.doi.org/10/xqw)),
- *
- * @f[ w(r)/k_BT = -\ln g(r) = \lambda_B s^2 z_iz_j / r \exp{(-\kappa r )}  @f]
- *
- * where @f$ s=\sinh{(a\kappa)}/a\kappa @f$ scales the charges due to spreading
- * them over a sphere with effective radius, `a`.
- * The fitting can be done using the supplied python script `twobody.virial.py` which
- * require information about protein charges, fitting range, and Debye length.
- * Edit and run with,
- *
- * ~~~~
- * $ python twobody.virial.py
- * ~~~~
- * (requires `scipy` and `matplotlib`)
- *
- * The output could look like below, and it is important to ensure
- * that the fitted parameters (Debye length or effective radius or both)
- * are in the vicinity of the simulated system.
- * Note that in the
- * limit @f$ a\kappa \rightarrow 0 @f$, i.e. when the Debye length
- * is much bigger then the particle size, @f$ s \rightarrow 1 @f$
- * and fitting via the effective radius, @f$ a @f$, is unfeasible
- * and should be disabled in the script.
- * 
- * ~~~~
- * Excecuting python script to analyse the virial coeffient...
- * Loaded g(r) file      =  rdf.dat
- * Saved w(r) file       =  wofr.dat
- * Particle charges      =  [7.1, 7.1]
- * Particle weights      =  [6520.0, 6520.0] g/mol
- * Fit range [rmin,rmax] =  40.0 90.0 A
- * Fitted Debye length   =  12.1634707424 A
- * Fitted ionic strength =  62.4643374077 mM
- * Fitted radius         =  14.4531689553 A
- * Virial coefficient (cubic angstrom):
- * Hard sphere  [    0:   19] =  14365.4560073
- * Loaded data  [   19:   40] =  72438.2668732
- * Debye-Huckel [   40:  500] =  74969.9046117
- * TOTAL        [    0:  500] =  161773.627492 A^3
- *                            =  0.0229167635392 ml*mol/g^2
- * Reduced, B2/B2_HS          =  11.2612942749
- * ~~~~
- *
- * If `matplotlib` is installed, the python script will offer to
- * visualize the fit.
- *
- * ![Fitting of the PMF tail to a Yukawa potential](twobody-plot.png)
- *
- * twobody.cpp
- * ===========
- * This is the underlying C++ program where one should note that the
- * pair potential is hard coded but can naturally be customised to
- * any potential from namespace `Faunus::Potential`.
- *
- * @includelineno examples/twobody.cpp
+@page example_twobody Example: Osmotic Second Virial Coefficient
+
+In this example we calculate the potential of mean force between
+two rigid bodies with a fluctuating charge distribution. Salt and
+solvent are implicitly treated using a Debye-Huckel potential and
+the rigid bodies (here proteins) are kept on a line and allowed to
+translate, rotate, and protons are kept in equilibrium with bulk
+using particle swap moves.
+
+During simulation we simply sample the probability of observing
+the two bodies at a specific separation
+(using `Faunus::Analysis::LineDistribution`).
+As the proteins are confined onto a line, each volume element along
+`r` is constant and there's thus no need to normalize with a spherical
+shell as done for freely moving particles.
+The minimum and maximum allowed distance between the two bodies can
+specified via the `Faunus::Energy::MassCenterConstrain` term in the
+Hamiltonian.
+
+![Two rigid molecules kept on a line inside a cylinder](twobody.png)
+
+Run this example from the `examples` directory:
+The python script `twobody.py` generates the simulation input files
+and all changes to the simulation setup should be done from inside
+the script.
+This example can run with the following (the first, optional
+command checks out a specific commit with which this tutorial was created),
+
+~~~~~~~~~~~~~~~~~~~
+$ (git checkout 10e9a0b)
+$ make example_twobody
+$ cd src/examples
+$ python twobody.py
+~~~~~~~~~~~~~~~~~~~
+
+For calculating the virial coefficient, @f$B_2@f$, the angularly averaged
+radial distribution function, g(r), must be integrated according to,
+
+@f[ B_2 = -2\pi \int_0^{\infty} [ g(r) -1 ] r^2 dr @f]
+
+where it should be noted that noise at large separations is strongly
+amplified. To fix this, the tail of the g(r) can be fitted to
+a Yukawa potential of the form (see [doi:10/xqw](http://dx.doi.org/10/xqw)),
+
+@f[ w(r)/k_BT = -\ln g(r) = \lambda_B s^2 z_iz_j / r \exp{(-\kappa r )}  @f]
+
+where @f$ s=\sinh{(a\kappa)}/a\kappa @f$ scales the charges due to spreading
+them over a sphere with effective radius, `a`.
+The fitting can be done using the supplied python script `twobody.virial.py` which
+require information about protein charges, fitting range, and Debye length.
+Edit and run with,
+
+~~~~
+$ python twobody.virial.py
+~~~~
+(requires `scipy` and `matplotlib`)
+
+The output could look like below, and it is important to ensure
+that the fitted parameters (Debye length or effective radius or both)
+are in the vicinity of the simulated system.
+Note that in the
+limit @f$ a\kappa \rightarrow 0 @f$, i.e. when the Debye length
+is much bigger then the particle size, @f$ s \rightarrow 1 @f$
+and fitting via the effective radius, @f$ a @f$, is unfeasible
+and should be disabled in the script.
+
+~~~~
+Excecuting python script to analyse the virial coeffient...
+Loaded g(r) file      =  rdf.dat
+Saved w(r) file       =  wofr.dat
+Particle charges      =  [7.1, 7.1]
+Particle weights      =  [6520.0, 6520.0] g/mol
+Fit range [rmin,rmax] =  40.0 90.0 A
+Fitted Debye length   =  12.1634707424 A
+Fitted ionic strength =  62.4643374077 mM
+Fitted radius         =  14.4531689553 A
+Virial coefficient (cubic angstrom):
+Hard sphere  [    0:   19] =  14365.4560073
+Loaded data  [   19:   40] =  72438.2668732
+Debye-Huckel [   40:  500] =  74969.9046117
+TOTAL        [    0:  500] =  161773.627492 A^3
+                           =  0.0229167635392 ml*mol/g^2
+Reduced, B2/B2_HS          =  11.2612942749
+~~~~
+
+If `matplotlib` is installed, the python script will offer to
+visualize the fit.
+
+![Fitting of the PMF tail to a Yukawa potential](twobody-plot.png)
+
+twobody.cpp
+===========
+This is the underlying C++ program where one should note that the
+pair potential is hard coded but can naturally be customised to
+any potential from namespace `Faunus::Potential`.
+
+@includelineno examples/twobody.cpp
  */

--- a/src/playground/heyda/polymers.cpp
+++ b/src/playground/heyda/polymers.cpp
@@ -69,34 +69,34 @@ int main() {
   return test.numFailed();
 }
 /** 
- * @page example_polymers Example: Polymers
- *
- * This will simulate an arbitrary number of linear polymers in the NPT ensemble
- * with explicit salt particles and implicit solvent (dielectric continuum).
- * We include the following Monte Carlo moves:
- *
- * - salt translation
- * - monomer translation
- * - polymer translation and rotation
- * - polymer crankshaft and pivot rotations
- * - isobaric volume move (NPT ensemble)
- *
- * ![Hardsphere polyelectrolytes with counter ions](polymers.png)
- *
- * Run this example from the `examples` directory:
- *
- * ~~~~~~~~~~~~~~~~~~~
- * $ make
- * $ cd src/examples
- * $ python ./polymers.py
- * ~~~~~~~~~~~~~~~~~~~
- *
- * polymers.py
- * ===========
- * This is a python run-script that generates all required
- * input as well as run the main program. This is also used
- * for running the unittest when running `make test`. 
- *
- * @include polymers.py
+@page example_polymers Example: Polymers
+
+This will simulate an arbitrary number of linear polymers in the NPT ensemble
+with explicit salt particles and implicit solvent (dielectric continuum).
+We include the following Monte Carlo moves:
+
+- salt translation
+- monomer translation
+- polymer translation and rotation
+- polymer crankshaft and pivot rotations
+- isobaric volume move (NPT ensemble)
+
+![Hardsphere polyelectrolytes with counter ions](polymers.png)
+
+Run this example from the `examples` directory:
+
+~~~~~~~~~~~~~~~~~~~
+$ make
+$ cd src/examples
+$ python ./polymers.py
+~~~~~~~~~~~~~~~~~~~
+
+polymers.py
+===========
+This is a python run-script that generates all required
+input as well as run the main program. This is also used
+for running the unittest when running `make test`. 
+
+@include polymers.py
  */
 


### PR DESCRIPTION
Hej Mikael, 

I fixed some (small) issues that I encountered trying to run the examples

* I added the .idea folder to .gitignore . (It seems that someone has used an IntelliJ editor before on this project, so that seems sensible)
* I noticed some markdown parsing errors in the documentation that were caused by leading "*" in multiline comments

Kind regards,
Niels Kouwenhoven