### PR TITLE
I made a start to fix #78

### DIFF
--- a/include/faunus/analysis.h
+++ b/include/faunus/analysis.h
@@ -213,9 +213,9 @@ namespace Faunus {
         VirialPressure( Tmjson &j, Tpotential &pot, Tspace &spc, string pfx="virial" )
           : spc(&spc), pot(&pot), AnalysisBase( j["analysis"], pfx ) {
           auto _j = j["analysis"][pfx];
-          dim = _j["dim"] | 3;
-          area = _j["area"] | 0.0;
-          noMolecularPressure = _j["noMolecularPressure"] | false;
+          dim = _j.value("dim", 3);
+          area = _j.value("area", 0.0);
+          noMolecularPressure = _j.value("noMolecularPressure", false);
           name="Virial Pressure";
           T.setZero();
         }
@@ -2005,11 +2005,11 @@ namespace Faunus {
             : spc(&spc), data(0.2), AnalysisBase( j["analysis"], pfx ) {
               name="Cylindrical Density";
               auto _j = j["analysis"][pfx];
-              zmin    = _j["zmin"] | 0.0;
-              zmax    = _j["zmax"] | -zmin;
-              dz      = _j["dz"] | 0.2;
+              zmin    = _j.value("zmin", 0.0);
+              zmax    = _j.value("zmax", -zmin);
+              dz      = _j.value("dz", 0.2);
 
-              string atomtype = _j["atomtype"] | string();
+              string atomtype = _j.value("atomtype", string());
               cout << "atomtype = " << atomtype << endl;
               id      = atom[ atomtype ].id;
 
@@ -2146,9 +2146,9 @@ namespace Faunus {
           VirtualVolumeMove( Tmjson &js, Tenergy &pot, Tspace &spc,
               string sec="virtualvolume") : AnalysisBase(js["analysis"], sec), spc(&spc), pot(&pot) {
             auto &j = js["analysis"][sec];
-            dV = j["dV"] | 0.1;
+            dV = j.value("dV", 0.1);
             dir = {1,1,1};  // scale directions
-            fullenergy = j["fullenergy"] | false;
+            fullenergy = j.value("fullenergy", false);
             AnalysisBase::name = "Virtual Volume Move";
             AnalysisBase::cite = "doi:10.1063/1.472721";
           }

--- a/include/faunus/energy.h
+++ b/include/faunus/energy.h
@@ -779,7 +779,7 @@ namespace Faunus {
 
           NonbondedCutg2g(Tmjson &j, const string &sec="nonbonded") : base(j,sec) {
             noPairPotentialCutoff=false;
-            rcut2 = pow( j["energy"][sec]["cutoff_g2g"] | pc::infty, 2);
+            rcut2 = pow( j["energy"][sec].value("cutoff_g2g", pc::infty), 2);
             base::name += " (g2g cut=" + std::to_string(sqrt(rcut2))
               + textio::_angstrom + ")";
           }
@@ -1221,7 +1221,7 @@ namespace Faunus {
 
           ExternalPressure( Tmjson &j, string sec="isobaric" ) {
             this->name="External Pressure";
-            P = ( j["moves"][sec]["pressure"] | 0.0 ) * 1.0_mM;
+            P = ( j["moves"][sec].value("pressure", 0.0) ) * 1.0_mM;
             if (P < 0)
               throw std::runtime_error( "Negative pressure forbidden." );
           }
@@ -1656,7 +1656,7 @@ namespace Faunus {
               _min = j["min"].get<Tvec>();
               _max = j["max"].get<Tvec>();
               _scale = j["scale"].get<Tvec>();
-              _nstep = j["nstep"] | 1000;
+              _nstep = j.value("nstep", 1000);
               assert( _min.size() >= 1);
               assert( _min.size() == _max.size());
               assert( _min.size() == _scale.size());
@@ -2296,7 +2296,7 @@ namespace Faunus {
             base::name = "SASA Energy";
             auto _j = j["energy"][dir];
             probe = _j["proberadius"] | 1.4; // angstrom
-            conc = _j["conc"] | 0.0;         // co-solute concentratil (mol/l);
+            conc = _j.value("conc", 0.0);         // co-solute concentratil (mol/l));
           }
 
           auto tuple() -> decltype(std::make_tuple(this)) {

--- a/include/faunus/externalpotential.h
+++ b/include/faunus/externalpotential.h
@@ -140,13 +140,13 @@ namespace Faunus {
         if ( std::abs(phi0) > 1e-6 )
           rho = sqrt(2*c0/(pc::pi*lB))*sinh(.5*phi0); //Evans&Wennerstrom,Colloidal Domain p 138-140
         else {
-          rho = 1 / (js["qarea"] | 0.0);
+          rho = 1 / (js.value("qarea", 0.0));
           if (rho>1e9)
-            rho = js["rho"] | 0.0;
+            rho = js.value("rho", 0.0);
           phi0 = 2.*asinh(rho * sqrt(0.5*lB*pc::pi/c0 ));//[Evans..]
         }
         gamma0 = tanh(phi0/4); // assuming z=1  [Evans..]
-        offset = js["offset"] | 0.0;
+        offset = js.value("offset", 0.0);
       }
 
     /**

--- a/include/faunus/inputfile.h
+++ b/include/faunus/inputfile.h
@@ -187,8 +187,8 @@ namespace Faunus {
   inline UnitTest::UnitTest(Tmjson &j) {
     cnt=0;
     auto _j = j["system"]["unittest"];
-    file    = _j["testfile"] | string();
-    stable  = _j["stable"] | true;
+    file = _j.value("testfile", string());
+    stable = _j.value("stable", true);
     include( file );
   }
 

--- a/include/faunus/molecule.h
+++ b/include/faunus/molecule.h
@@ -259,12 +259,12 @@ namespace Faunus {
           name = molecule.key();
           auto _js = molecule.value();
 
-          _isAtomic   = _js["atomic"] | false;
-          Ninit       = _js["Ninit"] | 0;
-          capacitance = _js["Cavg"] | 0.0;
-          meancharge  = _js["Zavg"] | 0.0;
-          bool keeppos= _js["keeppos"] | false;
-          activity    = _js["activity"] | 0.0;
+          _isAtomic   = _js.value("atomic", false);
+          Ninit       = _js.value("Ninit", 0);
+          capacitance = _js.value("Cavg", 0.0);
+          meancharge  = _js.value("Zavg", 0.0);
+          bool keeppos= _js.value("keeppos", false);
+          activity    = _js.value("activity", 0.0);
           chemPot     = log( activity * 1.0_molar );
 
           // create bond list
@@ -279,7 +279,7 @@ namespace Faunus {
 
           // read conformation from disk
           {
-            string structure = _js["structure"] | string();
+            string structure = _js.value("structure", string());
             if ( !structure.empty() ) {
               Tpvec v;
               if (structure.substr(structure.find_last_of(".") + 1) == "aam")
@@ -300,7 +300,7 @@ namespace Faunus {
           }
 
           // construct flexible peptide from fasta sequence
-          string fasta = _js["fasta"] | string();
+          string fasta = _js.value("fasta", string());
           if ( !fasta.empty() ) {
             assert( atoms.empty() );
             atoms = FastaToAtoms( fasta ); // -> atomid
@@ -329,7 +329,7 @@ namespace Faunus {
           }
 
           // read tracjectory w. conformations from disk
-          string traj = _js["traj"] | string();
+          string traj = _js.value("traj", string());
           if ( !traj.empty() ) {
             conformations.clear();
             FormatPQR::load( traj, conformations );
@@ -345,7 +345,7 @@ namespace Faunus {
               confDist = std::discrete_distribution<>(w.begin(), w.end());
 
               // look for weight file
-              string weightfile = _js["trajweight"] | string();
+              string weightfile = _js.value("trajweight", string());
               if (!weightfile.empty()) {
                 std::ifstream f(weightfile.c_str());
                 if (f) {
@@ -367,7 +367,7 @@ namespace Faunus {
 
           // add atoms to atom list
           if ( atoms.empty() ) {
-            string atomlist = _js["atoms"] | string();
+            string atomlist = _js.value("atoms", string());
             for ( auto &a : textio::words2vec<string>(atomlist) )
               if ( atom[a].id > 0 )
                 atoms.push_back( atom[a].id );

--- a/include/faunus/move.h
+++ b/include/faunus/move.h
@@ -195,8 +195,8 @@ namespace Faunus {
           template<class Tspace>
             PolarizeMove(Energy::Energybase<Tspace> &e, Tspace &s, Tmjson &j) :
               Tmove(e,s,j) {
-                threshold = j["pol_threshold"] | 0.001;
-                max_iter  = j["max_iterations"] | 40;
+                threshold = j.value("pol_threshold", 0.001);
+                max_iter  = j.value("max_iterations", 40);
               }
 
           PolarizeMove(const Tmove &m) : max_iter(40), threshold(0.001), Tmove(m) {};
@@ -282,10 +282,10 @@ namespace Faunus {
 
             MolListData( Tmjson &j ) {
               *this = MolListData();
-              prob = j["prob"] | 1.0;
-              perMol = j["permol"] | false;
-              perAtom = j["peratom"] | false;
-              dir << ( j["dir"] | std::string("1 1 1") );
+              prob = j.value("prob", 1.0);
+              perMol = j.value("permol", false);
+              perAtom = j.value("peratom", false);
+              dir << ( j.value("dir", std::string("1 1 1") ));
             }
           };
 
@@ -1664,9 +1664,9 @@ namespace Faunus {
         base::cite        = "doi:10/fthw8k";
         base::jsondir     = "moves/"+pfx; // just for unittesting (to be changed)
         base::useAlternativeReturnEnergy =true;
-        base::runfraction = _j["prob"] | 1.0;
-        skipEnergyUpdate  = _j["skipenergy"] | false;
-        dp                = _j["dp"] | 0.0;
+        base::runfraction = _j.value("prob", 1.0);
+        skipEnergyUpdate  = _j.value("skipenergy", false);
+        dp                = _j.value("dp", 0.0);
         if (dp<1e-6)
           base::runfraction=0;
         g=spc->groupList(); // currently ALL groups in the system will be moved!

--- a/include/faunus/potentials.h
+++ b/include/faunus/potentials.h
@@ -1418,7 +1418,7 @@ namespace Faunus {
 
           FromDisk( Tmjson &j, const string &sec="fromdisk") {
             PairPotentialBase::name = "fromdisk";
-            string filename = j[sec] | string();
+            string filename = j.value(sec, string());
             if (!t.load(filename))
               throw std::runtime_error("Couldn't load tabulated potential.");
           }

--- a/include/faunus/species.h
+++ b/include/faunus/species.h
@@ -250,28 +250,28 @@ namespace Faunus {
         if ( ! atom.key().empty() )
           name = atom.key();
 
-        activity     =  _js["activity"] | 0.0;
+        activity     =  _js.value("activity", 0.0);
         chemPot      =  log( activity * 1.0_molar );
-        alpha        << (_js["alpha"] | string());
+        alpha        << (_js.value("alpha", string()));
         alpha        /= pc::lB(1.0);
-        theta        << (_js["theta"] | string());
+        theta        << (_js.value("theta", string()));
         theta        *= 1.0_Debye;
-        dp           =  _js["dp"] | 0.0;
+        dp           =  _js.value("dp", 0.0);
         dprot        =  ( _js["dprot"] | 0.0 ) * 1._deg; // deg->rads
         eps          =  ( _js["eps"] | 0.0 ) * 1.0_kJmol;
-        hydrophobic  =  _js["hydrophobic"] | false;
-        mu           << ( _js["mu"] | string("0 0 0") );
+        hydrophobic  =  _js.value("hydrophobic", false);
+        mu           << ( _js.value("mu", string("0 0 0") ));
         muscalar     =  mu.len()* 1.0_Debye;
         if ( mu.len() > 1e-6 )
           mu = mu/mu.len();
 
-        mw           = _js["mw"] | 1.0;
-        Ninit        = _js["Ninit"] | 0.0;
-        charge       = _js["q"] | 0.0;
+        mw           = _js.value("mw", 1.0);
+        Ninit        = _js.value("Ninit", 0.0);
+        charge       = _js.value("q", 0.0);
         radius       = ( _js["r"] | 0.0 ) * 1.0_angstrom;
         sigma        = ( _js["sigma"] | 2*radius ) * 1.0_angstrom;
         radius       = 0.5 * sigma;
-        tfe          = _js["tfe"] | 0.0;
+        tfe          = _js.value("tfe", 0.0);
         alphax       = (_js["alphax"] | 0.0)*std::pow(radius,3);
         string unit  = _js["alphax_unit"] | string("unitless");
           if ( unit == "angstrom^3" )
@@ -279,16 +279,16 @@ namespace Faunus {
 
         // spherocylindrical properties
         half_len     = 0.5 * ( _js["len"] | 0.0 );
-        patchtype    = _js["patchtype"] | 0.0;
-        pswitch      = _js["patchswitch"] | 0.0;
-        pdis         = _js["patchdistance"] | 0.0;
+        patchtype    = _js.value("patchtype", 0.0);
+        pswitch      = _js.value("patchswitch", 0.0);
+        pdis         = _js.value("patchdistance", 0.0);
         pangl        = ( _js["patchangle"] | 0.0 ) * 1._deg;
         panglsw      = ( _js["patchangleswitch"] | 0.0 ) * 1._deg;
         chiral_angle = ( _js["patchchiralangle"] | 0.0 ) * 1._deg;
 
-        betaC = _js["betaC"] | pc::infty;
-        betaD = _js["betaD"] | pc::infty;
-        betaQ = _js["betaQ"] | pc::infty;
+        betaC = _js.value("betaC", pc::infty);
+        betaD = _js.value("betaD", pc::infty);
+        betaQ = _js.value("betaQ", pc::infty);
       }
   };
 

--- a/include/faunus/tabulate.h
+++ b/include/faunus/tabulate.h
@@ -1266,14 +1266,14 @@ namespace Faunus {
 
             auto j = in[sec]["spline"];
 
-            rmin = j["rmin"] | 1.0;
-            rmax = j["rmax"] | 100.0;
+            rmin = j.value("rmin", 1.0);
+            rmax = j.value("rmax", 100.0);
             tab.setRange( rmin, rmax );
             tab.setTolerance(
                 j["utol"] | 0.01, 
                 j["ftol"] | -1, 
                 j["umaxtol"] | -1, 
-                j["fmaxtol"] |-1 );
+                j.value("fmaxtol", -1 ));
 
             verbose = in[sec]["verbose"] | false;
 

--- a/src/potentials.cpp
+++ b/src/potentials.cpp
@@ -429,7 +429,7 @@ namespace Faunus {
 
     Harmonic::Harmonic( Tmjson &j, const string &sec) : PairPotentialBase(sec) {
       name="Harmonic";
-      k   = j[sec]["k"]   | 0.0;
+      k   = j[sec].value("k", 0.0);;
       req = j[sec]["req"] | 0.0;
     }
 


### PR DESCRIPTION
I only replaced the ones that were easy to automatically fix. There are many more.

I guess this replacement is only _necessary_ if:
- the value provided by the config _could_ be falsey (`0`, `nullptr`, `false` or `""`)
- the default value is truthy (ie not falsey)

I didn't check the necessary cases, just the easy ones.