### PR TITLE
Geometry

### DIFF
--- a/src/geometry.cpp
+++ b/src/geometry.cpp
@@ -697,6 +697,9 @@ namespace Faunus {
                 case OCTAHEDRON:
                     geometry = std::make_unique<TruncatedOctahedron>();
                     break;
+                case HYPERSPHERE2D:
+                    geometry = std::make_unique<Hypersphere2d>();
+                    break;
                 default:
                     throw std::invalid_argument("unknown geometry");
             }

--- a/src/geometry.cpp
+++ b/src/geometry.cpp
@@ -655,6 +655,11 @@ namespace Faunus {
             makeGeometry(type);
         }
 
+        Chameleon::Chameleon(const GeometryImplementation &geo, const Variant type) :
+                geometry(geo.clone()), _type(type) {
+            _setLength(geometry->getLength());
+        }
+
         Point Chameleon::getLength() const {
             assert(geometry);
             return geometry->getLength();

--- a/src/geometry.cpp
+++ b/src/geometry.cpp
@@ -66,7 +66,7 @@ namespace Faunus {
         Cuboid::Cuboid(double x) : Cuboid(x, x, x) {
         }
 
-        inline Point Cuboid::getLength() const {
+        Point Cuboid::getLength() const {
             return box;
         }
 
@@ -76,7 +76,7 @@ namespace Faunus {
             box_inv = box.cwiseInverse();
         }
 
-        inline double Cuboid::getVolume(int) const {
+        double Cuboid::getVolume(int) const {
             return box.x() * box.y() * box.z();
         }
 
@@ -107,7 +107,7 @@ namespace Faunus {
             return box_scaling; // this will scale any point to new volume
         }
 
-        inline void Cuboid::boundary(Point &a) const {
+        void Cuboid::boundary(Point &a) const {
             if (boundary_conditions.direction.x() == PERIODIC) {
                 if (std::fabs(a.x()) > box_half.x())
                     a.x() -= box.x() * anint(a.x() * box_inv.x());
@@ -122,7 +122,7 @@ namespace Faunus {
             }
         }
 
-        inline Point Cuboid::vdist(const Point &a, const Point &b) const {
+        Point Cuboid::vdist(const Point &a, const Point &b) const {
             Point distance(a - b);
             if (boundary_conditions.direction.x() == PERIODIC) {
                 if (distance.x() > box_half.x())
@@ -145,13 +145,13 @@ namespace Faunus {
             return distance;
         }
 
-        inline void Cuboid::randompos(Point &m, Random &rand) const {
+        void Cuboid::randompos(Point &m, Random &rand) const {
             m.x() = (rand() - 0.5) * box.x();
             m.y() = (rand() - 0.5) * box.y();
             m.z() = (rand() - 0.5) * box.z();
         }
 
-        inline bool Cuboid::collision(const Point &a) const {
+        bool Cuboid::collision(const Point &a) const {
             bool collision =
                     std::fabs(a.x()) > box_half.x() ||
                     std::fabs(a.y()) > box_half.y() ||
@@ -205,7 +205,7 @@ namespace Faunus {
             return {2 * radius, 2 * radius, 2 * radius};
         }
 
-        inline double Sphere::getVolume(int dim) const {
+        double Sphere::getVolume(int dim) const {
             double result;
             switch (dim) {
                 case 3:
@@ -237,16 +237,16 @@ namespace Faunus {
             return box_scaling;
         }
 
-        inline void Sphere::boundary(Point &) const {
+        void Sphere::boundary(Point &) const {
             // no pbc
         }
 
-        inline bool Sphere::collision(const Point &a) const {
+        bool Sphere::collision(const Point &a) const {
             bool collision = a.squaredNorm() > radius * radius;
             return collision;
         }
 
-        inline Point Sphere::vdist(const Point &a, const Point &b) const {
+        Point Sphere::vdist(const Point &a, const Point &b) const {
             // no pbc; shall we check points coordinates?
             Point distance(a - b);
             return distance;
@@ -276,7 +276,7 @@ namespace Faunus {
             boundary_conditions = BoundaryCondition(NON3D);
         }
 
-        inline Point Hypersphere2d::vdist(const Point &a, const Point &b) const {
+        Point Hypersphere2d::vdist(const Point &a, const Point &b) const {
             // ugly but works, needs fixing though...
             Point distance3d(a - b);
             double angle = std::acos(a.dot(b) / radius / radius);
@@ -289,7 +289,7 @@ namespace Faunus {
             m = m / m.norm() * radius;
         }
 
-        inline bool Hypersphere2d::collision(const Point &a) const {
+        bool Hypersphere2d::collision(const Point &a) const {
             bool collision = std::fabs(a.norm() - radius) > 1e-6;
             return collision;
         }
@@ -310,7 +310,7 @@ namespace Faunus {
             set_box(side, height);
         }
 
-        inline Point HexagonalPrism::getLength() const {
+        Point HexagonalPrism::getLength() const {
             return box;
         }
 
@@ -349,13 +349,13 @@ namespace Faunus {
             return box_scaling;
         }
 
-        inline Point HexagonalPrism::vdist(const Point &a, const Point &b) const {
+        Point HexagonalPrism::vdist(const Point &a, const Point &b) const {
             Point distance(a - b);
             boundary(distance);
             return distance;
         }
 
-        inline bool HexagonalPrism::collision(const Point &a) const {
+        bool HexagonalPrism::collision(const Point &a) const {
             const double height = box.z();
             const double outer_radius = 0.5 * box.y();
 
@@ -367,7 +367,7 @@ namespace Faunus {
             return collision;
         }
 
-        inline void HexagonalPrism::boundary(Point &a) const {
+        void HexagonalPrism::boundary(Point &a) const {
             // TODO optimise and add documentation
             const double sqrtThreeByTwo = sqrt(3.0) / 2.0;
             const Point unitvX = {1.0, 0.0, 0.0};
@@ -426,11 +426,11 @@ namespace Faunus {
             boundary_conditions = BoundaryCondition(ORTHOGONAL, {FIXED, FIXED, PERIODIC});
         }
 
-        inline Point Cylinder::getLength() const {
+        Point Cylinder::getLength() const {
             return {2 * radius, 2 * radius, height};
         }
 
-        inline double Cylinder::getVolume(int) const {
+        double Cylinder::getVolume(int) const {
             return pc::pi * radius * radius * height;
         }
 
@@ -465,7 +465,7 @@ namespace Faunus {
             return box_scaling;
         }
 
-        inline void Cylinder::boundary(Point &a) const {
+        void Cylinder::boundary(Point &a) const {
             // z-pbc
             if (std::fabs(a.z()) > 0.5 * height)
                 a.z() -= height * anint(a.z() / height);
@@ -476,7 +476,7 @@ namespace Faunus {
             return collision;
         }
 
-        inline Point Cylinder::vdist(const Point &a, const Point &b) const {
+        Point Cylinder::vdist(const Point &a, const Point &b) const {
             Point distance(a - b);
             if (distance.z() > 0.5 * height)
                 distance.z() -= height;
@@ -513,7 +513,7 @@ namespace Faunus {
             boundary_conditions = BoundaryCondition(TRUNC_OCTAHEDRAL, {PERIODIC, PERIODIC, PERIODIC});
         }
 
-        inline Point TruncatedOctahedron::getLength() const {
+        Point TruncatedOctahedron::getLength() const {
             // todo check orientation in xyz
             return Point::Constant(2. * std::sqrt(2.) * side); // distance between opposite square faces
         }
@@ -537,13 +537,13 @@ namespace Faunus {
             return box_scaling;
         }
 
-        inline Point TruncatedOctahedron::vdist(const Point &a, const Point &b) const {
+        Point TruncatedOctahedron::vdist(const Point &a, const Point &b) const {
             Point distance(a - b);
             boundary(distance);
             return distance;
         }
 
-        inline bool TruncatedOctahedron::collision(const Point &a) const {
+        bool TruncatedOctahedron::collision(const Point &a) const {
             const double sqrtThreeI = 1.0 / std::sqrt(3.0);
             const double origin_to_square_face = std::sqrt(2.) * side;
             const double origin_to_hexagonal_face = std::sqrt(1.5) * side;
@@ -559,7 +559,7 @@ namespace Faunus {
             return false;
         }
 
-        inline void TruncatedOctahedron::boundary(Point &a) const {
+        void TruncatedOctahedron::boundary(Point &a) const {
             const double sqrtThreeI = 1.0 / std::sqrt(3.0);
             const double square_face_distance = std::sqrt(8.) * side;
             const double hexagonal_face_distance = std::sqrt(6.) * side;
@@ -651,18 +651,16 @@ namespace Faunus {
             g.to_json(j);
         }
 
-        inline Point Chameleon::getLength() const {
+        Chameleon::Chameleon(const Variant type) {
+            makeGeometry(type);
+        }
+
+        Point Chameleon::getLength() const {
             assert(geometry);
             return geometry->getLength();
         }
 
-        inline void Chameleon::_setLength(const Point &l) {
-            len = l;
-            len_half = l * 0.5;
-            len_inv = l.cwiseInverse();
-        }
-
-        inline void Chameleon::setLength(const Point &l) {
+        void Chameleon::setLength(const Point &l) {
             assert(geometry);
             _setLength(l);
             // ugly
@@ -672,27 +670,6 @@ namespace Faunus {
             } else {
                 throw std::runtime_error("setLength allowed only for the Cuboid geometry");
             }
-        }
-
-        inline double Chameleon::getVolume(int dim) const {
-            assert(geometry);
-            return geometry->getVolume(dim);
-        }
-
-        inline Point Chameleon::setVolume(double V, VolumeMethod method) {
-            auto scale = geometry->setVolume(V, method);
-            _setLength(geometry->getLength());
-            return scale;
-        }
-
-        inline void Chameleon::randompos(Point &m, Random &rand) const {
-            assert(geometry);
-            geometry->randompos(m, rand);
-        }
-
-        inline bool Chameleon::collision(const Point &a) const {
-            assert(geometry);
-            return geometry->collision(a);
         }
 
         void Chameleon::makeGeometry(const Variant type) {

--- a/src/geometry.h
+++ b/src/geometry.h
@@ -642,6 +642,7 @@ namespace Faunus {
             }
 
             Chameleon(const Variant type = CUBOID);
+            Chameleon(const GeometryImplementation &geo, const Variant type);
 
             //! Copy everything, but clone the geometry.
             Chameleon(const Chameleon &geo) : GeometryBase(geo),
@@ -750,155 +751,105 @@ namespace Faunus {
         void from_json(const json&, Chameleon&);
 
 #ifdef DOCTEST_LIBRARY_INCLUDED
-        TEST_CASE("[Faunus] Chameleon") {
+    TEST_CASE("[Faunus] Chameleon") {
 
-            using doctest::Approx;
-            Chameleon geo;
-            Random slump;
+        using doctest::Approx;
+        Random slump;
 
-            SUBCASE("cuboid") {
-                geo = R"( {"type": "cuboid", "length": [2,3,4]} )"_json;
-                CHECK( geo.getVolume() == doctest::Approx(2*3*4) );
-                Point a(1.1, 1.5, -2.001);
-                CHECK( geo.collision(a) == true);
-                geo.getBoundaryFunc()(a);
-                CHECK( geo.collision(a) == false);
-                CHECK( a.x() == Approx(-0.9) );
-                CHECK( a.y() == Approx(1.5) );
-                CHECK( a.z() == Approx(1.999) );
-                CHECK( geo.vdist({1,2,3}, a) == geo.getDistanceFunc()({1,2,3},a) );
-                Point b = a;
+        //! function compares if Chamelon's and Geometry's boundary methods produce the same result
+        //! using n random points
+        auto compare_boundary = [&slump](Chameleon &chameleon, GeometryImplementation &geo, Cuboid &box,
+                int n = 100) {
+            Point a, b;
+            for (int i = 0; i < n; i++) {
+                box.randompos(a, slump);
+                b = a;
+                chameleon.boundary(a);
                 geo.boundary(b);
-                CHECK( a == b );
-
-                // check that geometry is properly enscribed in a cuboid
-                Point L = geo.getLength();
-                CHECK( L.x() == Approx(2) );
-                CHECK( L.y() == Approx(3) );
-                CHECK( L.z() == Approx(4) );
-
-                // check random position
-                bool containerOverlap=false;
-                for (int i=0; i<1e4; i++) {
-                    geo.randompos(a, slump);
-                    if (geo.collision(a))
-                        containerOverlap=true;
-                }
-                CHECK( containerOverlap==false );
+                CHECK(a.x() == Approx(b.x()));
+                CHECK(a.y() == Approx(b.y()));
+                CHECK(a.z() == Approx(b.z()));
             }
+        };
 
-            SUBCASE("slit") {
-                geo = R"( {"type": "slit", "length": [2,3,4]} )"_json;
-                CHECK( geo.getVolume() == doctest::Approx(2*3*4) );
-                Point a(1.1, 1.5, -2.001);
-                CHECK( geo.collision(a) == true);
-                geo.getBoundaryFunc()(a);
-                CHECK( geo.collision(a) == true);
-                CHECK( a.x() == doctest::Approx(-0.9) );
-                CHECK( a.y() == doctest::Approx(1.5) );
-                CHECK( a.z() == doctest::Approx(-2.001) );
-
-                Point b = a;
-                b.z() = -b.z();
-                geo.boundary(b);
-                CHECK( b.z() == doctest::Approx(2.001) );
-                CHECK( geo.vdist(a,b).x()==0);
-                CHECK( geo.vdist(a,b).y()==0);
-                CHECK( geo.vdist(a,b).z()==-4.002);
-
-                // check that geometry is properly enscribed in a cuboid
-                Point L = geo.getLength();
-                CHECK( L.x() == Approx(2) );
-                CHECK( L.y() == Approx(3) );
-                CHECK( L.z() == Approx(4) );
-
-                // check random position
-                bool containerOverlap=false;
-                for (int i=0; i<1e4; i++) {
-                    geo.randompos(a, slump);
-                    if (geo.collision(a))
-                        containerOverlap=true;
-                }
-                CHECK( containerOverlap==false );
+        //! function compares if Chamelon's and Geometry's vdist methods produce the same result
+        //! using n random points
+        auto compare_vdist = [&slump](Chameleon &chameleon, GeometryImplementation &geo, Cuboid &box,
+                int n = 100) {
+            Point a, b, d_cham, d_geo;
+            for (int i = 0; i < n; i++) {
+                box.randompos(a, slump);
+                box.randompos(b, slump);
+                d_cham = chameleon.vdist(a, b);
+                d_geo = geo.vdist(a, b);
+                CHECK(d_cham.x() == Approx(d_geo.x()));
+                CHECK(d_cham.y() == Approx(d_geo.y()));
+                CHECK(d_cham.z() == Approx(d_geo.z()));
             }
+        };
 
-            SUBCASE("cylinder") {
-                json j = {  {"type","cylinder"}, {"radius",1.0}, {"length", 1/pc::pi} };
-                geo = j;
-                CHECK( geo.getVolume() == doctest::Approx( 1.0 ) );
-                CHECK( geo.collision({1.01,0,0}) == true);
-                CHECK( geo.collision({0.99,0,0}) == false);
-                CHECK( geo.collision({0.99,1/pc::pi+0.01,0}) == true);
-
-                // check that geometry is properly enscribed in a cuboid
-                Point L = geo.getLength();
-                CHECK( L.x() == Approx(2) );
-                CHECK( L.y() == Approx(2) );
-                CHECK( L.z() == Approx(1/pc::pi) );
-
-                // check random position
-                Point a;
-                bool containerOverlap=false;
-                for (int i=0; i<1e4; i++) {
-                    geo.randompos(a, slump);
-                    if (geo.collision(a))
-                        containerOverlap=true;
-                }
-                CHECK( containerOverlap==false );
-            }
-
-            SUBCASE("hexagonal") {
-                json j = {  {"type","hexagonal"}, {"radius",1.0}, {"length", 1.0/2.0/std::sqrt(3.0)} };
-                geo = j;
-                CHECK( geo.getVolume() == doctest::Approx( 1.0 ) );
-                CHECK( geo.collision({1.01,0,0}) == true);
-                CHECK( geo.collision({0.99,0,0}) == false);
-                CHECK( geo.collision({0.0,2.0/std::sqrt(3.0)+0.01,0}) == true);
-
-                // check that geometry is properly enscribed in a cuboid
-                Point L = geo.getLength();
-                //CHECK( L.x() == Approx(1.0) );
-                //CHECK( L.y() == Approx(1.0) );
-                CHECK( L.z() == Approx(1.0/2.0/std::sqrt(3.0)) );
-
-                // check random position
-                Point a;
-                bool containerOverlap=false;
-                for (int i=0; i<1e4; i++) {
-                    geo.randompos(a, slump);
-                    if (geo.collision(a))
-                        containerOverlap=true;
-                }
-                CHECK( containerOverlap==false );
-            }
-
-            SUBCASE("sphere") {
-                geo = R"( { "type": "sphere", "radius": 2 } )"_json;
-                CHECK( geo.getVolume() == doctest::Approx( 4*pc::pi*8/3.0 ) );
-                CHECK( geo.collision( { 2.01, 0, 0 } ) == true );
-                CHECK( geo.collision( { 1.99, 0, 0 } ) == false );
-                CHECK( geo.getLength().squaredNorm() == doctest::Approx(48) );
-
-                // check that geometry is properly enscribed in a cuboid
-                Point L = geo.getLength();
-                CHECK( L.x() == Approx(4) );
-                CHECK( L.y() == Approx(4) );
-                CHECK( L.z() == Approx(4) );
-
-                geo.setVolume(123.4);
-                CHECK( geo.getVolume() == doctest::Approx(123.4) );
-
-                // check random position
-                Point a;
-                bool containerOverlap=false;
-                for (int i=0; i<1e4; i++) {
-                    geo.randompos(a, slump);
-                    if (geo.collision(a))
-                        containerOverlap=true;
-                }
-                CHECK( containerOverlap==false );
-            }
+        SUBCASE("cuboid") {
+            double x = 2.0, y = 3.0, z = 4.0;
+            Point box_size = std::cbrt(2.0) * Point(x, y, z);
+            Cuboid box(box_size);
+            Cuboid geo(x, y, z);
+            Chameleon chameleon(geo, CUBOID);
+            compare_boundary(chameleon, geo, box);
+            compare_vdist(chameleon, geo, box);
         }
+
+        SUBCASE("slit") {
+            double x = 2.0, y = 3.0, z = 4.0;
+            Point box_size = std::cbrt(2.0) * Point(x, y, z);
+            Cuboid box(box_size);
+            Slit geo(x, y, z);
+            Chameleon chameleon(geo, SLIT);
+            compare_boundary(chameleon, geo, box);
+            compare_vdist(chameleon, geo, box);
+        }
+
+        SUBCASE("sphere") {
+            double radius = 10.0;
+            Point box_size;
+            box_size.setConstant(std::cbrt(2.0) * 2*radius);
+            Cuboid box(box_size);
+            Sphere geo(radius);
+            Chameleon chameleon(geo, SPHERE);
+            compare_boundary(chameleon, geo, box);
+            compare_vdist(chameleon, geo, box);
+        }
+
+        SUBCASE("cylinder") {
+            double radius = 2.0, height = 10.0;
+            Point box_size = std::cbrt(2.0) * Point(2*radius, 2*radius, height);
+            Cuboid box(box_size);
+            Cylinder geo(radius, height);
+            Chameleon chameleon(geo, CYLINDER);
+            compare_boundary(chameleon, geo, box);
+            compare_vdist(chameleon, geo, box);
+        }
+
+        SUBCASE("hexagonal prism") {
+            double edge = 5.0, height = 20.0;
+            Point box_size = std::cbrt(2.0) * Point(2*edge, 2*edge, height); // a bit larger in x-direction
+            Cuboid box(box_size);
+            HexagonalPrism geo(edge);
+            Chameleon chameleon(geo, HEXAGONAL);
+            compare_boundary(chameleon, geo, box);
+            compare_vdist(chameleon, geo, box);
+        }
+
+        SUBCASE("truncated octahedron") {
+            double edge = 5.0;
+            Point box_size;
+            box_size.setConstant(std::cbrt(2.0) * edge * std::sqrt(5.0/2.0)); // enlarged circumradius
+            Cuboid box(box_size);
+            TruncatedOctahedron geo(edge);
+            Chameleon chameleon(geo, OCTAHEDRON);
+            compare_boundary(chameleon, geo, box);
+            compare_vdist(chameleon, geo, box);
+        }
+    }
 #endif
 
         /*

--- a/src/geometry.h
+++ b/src/geometry.h
@@ -180,8 +180,8 @@ namespace Faunus {
             void boundary(Point &a) const override;
             bool collision(const Point &a) const override;
             void randompos(Point &m, Random &rand) const override;
-            void from_json(const json &j);
-            void to_json(json &j) const;
+            void from_json(const json &j) override;
+            void to_json(json &j) const override;
             Cuboid(const Point &p);
             Cuboid(double x, double y, double z);
             Cuboid(double x = 0.0);
@@ -225,8 +225,8 @@ namespace Faunus {
             void boundary(Point &a) const override;
             bool collision(const Point &a) const override;
             void randompos(Point &m, Random &rand) const override;
-            void from_json(const json &j);
-            void to_json(json &j) const;
+            void from_json(const json &j) override;
+            void to_json(json &j) const override;
             Sphere(double radius = 0.0);
 
             std::unique_ptr<GeometryImplementation> clone() const override {
@@ -264,8 +264,8 @@ namespace Faunus {
             void boundary(Point &a) const override;
             bool collision(const Point &a) const override;
             void randompos(Point &m, Random &rand) const override;
-            void from_json(const json &j);
-            void to_json(json &j) const;
+            void from_json(const json &j) override;
+            void to_json(json &j) const override;
             Cylinder(double radius = 0.0, double height = 0.0);
 
             std::unique_ptr<GeometryImplementation> clone() const override {
@@ -300,8 +300,8 @@ namespace Faunus {
             void boundary(Point &a) const override;
             bool collision(const Point &a) const override;
             void randompos(Point &m, Random &rand) const override;
-            void from_json(const json &j);
-            void to_json(json &j) const;
+            void from_json(const json &j) override;
+            void to_json(json &j) const override;
             HexagonalPrism(double side = 0.0, double height = 0.0);
 
             std::unique_ptr<GeometryImplementation> clone() const override {
@@ -324,8 +324,8 @@ namespace Faunus {
             void boundary(Point &a) const override;
             bool collision(const Point &a) const override;
             void randompos(Point &m, Random &rand) const override;
-            void from_json(const json &j);
-            void to_json(json &j) const;
+            void from_json(const json &j) override;
+            void to_json(json &j) const override;
             TruncatedOctahedron(double side = 0.0);
 
             std::unique_ptr<GeometryImplementation> clone() const override {

--- a/src/geometry.h
+++ b/src/geometry.h
@@ -289,7 +289,6 @@ namespace Faunus {
             static const Eigen::Matrix3d cartesian2rhombic;
 
             Point box; //!< x = inscribed circle diameter, y = circumscribed circle diameter, z = height
-            double volume; //!< volume of the prism
             void set_box(double side, double height);
 
         public:


### PR DESCRIPTION
A quick fix of linker's errors when using clang (forgotten inline keywords in cpp file). Override keyword used explicitly for overridden methods (clang warnings). As a bonus, unit tests of Chameleon verifying agreement between its own inline methods (vdist, boundary) and the underlying geometry implementations.