### PR TITLE
functionparser compiles to a stand-alone object file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,6 +197,7 @@ include_directories(SYSTEM ${eigen_SOURCE_DIR} ${doctest_SOURCE_DIR} ${modernjso
 
 # faunus cpp files
 set(objs
+    ${CMAKE_SOURCE_DIR}/src/functionparser.cpp
     ${CMAKE_SOURCE_DIR}/src/random.cpp
     ${CMAKE_SOURCE_DIR}/src/mpi.cpp
     ${CMAKE_SOURCE_DIR}/src/core.cpp
@@ -221,6 +222,7 @@ set(hdrs
     ${CMAKE_SOURCE_DIR}/src/auxiliary.h
     ${CMAKE_SOURCE_DIR}/src/core.h
     ${CMAKE_SOURCE_DIR}/src/energy.h
+    ${CMAKE_SOURCE_DIR}/src/functionparser.h
     ${CMAKE_SOURCE_DIR}/src/geometry.h
     ${CMAKE_SOURCE_DIR}/src/group.h
     ${CMAKE_SOURCE_DIR}/src/io.h

--- a/src/functionparser.cpp
+++ b/src/functionparser.cpp
@@ -1,0 +1,31 @@
+#include "functionparser.h"
+
+template<typename T>
+void ExprFunction<T>::set(const std::string &exprstr, const Tvarvec &vars, const Tconstvec &consts) {
+    if (not parser)
+        parser = std::make_shared<exprtk::parser<T>>();
+    symbols.clear();
+    for (auto &v : vars)
+        symbols.add_variable(v.first,*v.second);
+    for (auto &v : consts)
+        symbols.add_constant(v.first,v.second);
+    symbols.add_constants();
+    expression.register_symbol_table(symbols);
+    if (not parser->compile( exprstr, expression ))
+        throw std::runtime_error("error passing function/expression");
+}
+
+template<typename T>
+void ExprFunction<T>::set(const nlohmann::json &j, const Tvarvec &vars) {
+    Tconstvec consts;
+    auto it = j.find("constants");
+    if (it!=j.end())
+        for (auto i=it->begin(); i!=it->end(); ++i)
+            consts.push_back( {i.key(), i.value()} );
+    set(j.at("function"), vars, consts);
+}
+
+template<typename T>
+T ExprFunction<T>::operator()() const { return expression.value(); }
+
+template class ExprFunction<double>;

--- a/src/functionparser.cpp
+++ b/src/functionparser.cpp
@@ -6,12 +6,12 @@ void ExprFunction<T>::set(const std::string &exprstr, const Tvarvec &vars, const
         parser = std::make_shared<exprtk::parser<T>>();
     symbols.clear();
     for (auto &v : vars)
-        symbols.add_variable(v.first,*v.second);
+        symbols.add_variable(v.first, *v.second);
     for (auto &v : consts)
-        symbols.add_constant(v.first,v.second);
+        symbols.add_constant(v.first, v.second);
     symbols.add_constants();
     expression.register_symbol_table(symbols);
-    if (not parser->compile( exprstr, expression ))
+    if (! parser->compile(exprstr, expression))
         throw std::runtime_error("error passing function/expression");
 }
 
@@ -19,13 +19,15 @@ template<typename T>
 void ExprFunction<T>::set(const nlohmann::json &j, const Tvarvec &vars) {
     Tconstvec consts;
     auto it = j.find("constants");
-    if (it!=j.end())
-        for (auto i=it->begin(); i!=it->end(); ++i)
-            consts.push_back( {i.key(), i.value()} );
+    if (it != j.end())
+        for (auto i = it->begin(); i != it->end(); ++i)
+            consts.push_back({i.key(), i.value()});
     set(j.at("function"), vars, consts);
 }
 
 template<typename T>
-T ExprFunction<T>::operator()() const { return expression.value(); }
+T ExprFunction<T>::operator()() const {
+    return expression.value();
+}
 
 template class ExprFunction<double>;

--- a/src/functionparser.h
+++ b/src/functionparser.h
@@ -1,4 +1,5 @@
 #pragma once
+
 #include <string>
 #include <exprtk.hpp> // https://github.com/ArashPartow/exprtk
 #include <nlohmann/json.hpp>
@@ -8,28 +9,29 @@
  * with a shared pointer, allowing `ExprFunction`
  * to be directly assigned to `std::function`.
  */
-template <typename T=double> class ExprFunction {
-    private:
-        std::shared_ptr<exprtk::parser<T>> parser;
-        exprtk::expression<T> expression;
-        exprtk::symbol_table<T> symbols;
-        typedef std::vector<std::pair<std::string,T*>> Tvarvec;
-        typedef std::vector<std::pair<std::string,T>> Tconstvec;
-    public:
-        void set(const std::string &exprstr, const Tvarvec &vars={}, const Tconstvec &consts={});
-        void set(const nlohmann::json &j, const Tvarvec &vars={});
-        T operator()() const;
+template<typename T=double>
+class ExprFunction {
+    std::shared_ptr<exprtk::parser<T>> parser;
+    exprtk::expression <T> expression;
+    exprtk::symbol_table <T> symbols;
+    typedef std::vector<std::pair<std::string, T*>> Tvarvec;
+    typedef std::vector<std::pair<std::string, T>> Tconstvec;
+
+  public:
+    void set(const std::string &exprstr, const Tvarvec &vars = {}, const Tconstvec &consts = {});
+    void set(const nlohmann::json &j, const Tvarvec &vars = {});
+    T operator()() const;
 };
 
 
 #ifdef DOCTEST_LIBRARY_INCLUDED
 TEST_CASE("[Faunus] ExprFunction") {
-    double x=0, y=0;
+    double x = 0, y = 0;
     ExprFunction<double> expr;
-    nlohmann::json j = R"( { "function":"x*x+kappa", "constants":{ "kappa":0.4, "f":2 } })"_json;
-    expr.set(j, {{"x",&x}, {"y",&y}} );
+    nlohmann::json j = R"({ "function": "x*x+kappa", "constants": {"kappa": 0.4, "f": 2} })"_json;
+    expr.set(j, {{"x", &x}, {"y", &y}});
     std::function<double()> f = expr;
-    x=4;
-    CHECK(f() == doctest::Approx(4*4+0.4));
+    x = 4;
+    CHECK( f() == doctest::Approx(4*4+0.4) );
 }
 #endif

--- a/src/functionparser.h
+++ b/src/functionparser.h
@@ -1,7 +1,5 @@
 #pragma once
 #include <string>
-#include <functional>
-#include <iostream>
 #include <exprtk.hpp> // https://github.com/ArashPartow/exprtk
 #include <nlohmann/json.hpp>
 
@@ -18,31 +16,11 @@ template <typename T=double> class ExprFunction {
         typedef std::vector<std::pair<std::string,T*>> Tvarvec;
         typedef std::vector<std::pair<std::string,T>> Tconstvec;
     public:
-        void set(const std::string &exprstr, const Tvarvec &vars={}, const Tconstvec &consts={}) {
-            if (not parser)
-                parser = std::make_shared<exprtk::parser<T>>();
-            symbols.clear();
-            for (auto &v : vars)
-                symbols.add_variable(v.first,*v.second);
-            for (auto &v : consts)
-                symbols.add_constant(v.first,v.second);
-            symbols.add_constants();
-            expression.register_symbol_table(symbols);
-            if (not parser->compile( exprstr, expression ))
-                throw std::runtime_error("error passing function/expression");
-        }
-
-        void set(const nlohmann::json &j, const Tvarvec &vars={}) {
-            Tconstvec consts;
-            auto it = j.find("constants");
-            if (it!=j.end())
-                for (auto i=it->begin(); i!=it->end(); ++i)
-                    consts.push_back( {i.key(), i.value()} );
-            set(j.at("function"), vars, consts);
-        }
-
-        T operator()() const { return expression.value(); }
+        void set(const std::string &exprstr, const Tvarvec &vars={}, const Tconstvec &consts={});
+        void set(const nlohmann::json &j, const Tvarvec &vars={});
+        T operator()() const;
 };
+
 
 #ifdef DOCTEST_LIBRARY_INCLUDED
 TEST_CASE("[Faunus] ExprFunction") {

--- a/src/potentials.h
+++ b/src/potentials.h
@@ -702,6 +702,8 @@ namespace Faunus {
          */
         class CustomPairPotential : public PairPotentialBase {
             private:
+                // Only ExprFunction<double> is explicitly instantiated in functionparser.cpp. Other types as well as
+                // the implicit template instantiation is disabled to save reasources during the compilation/build.
                 ExprFunction<double> expr;
                 struct Data {
                     double r=0, q1=0, q2=0, s1=0, s2=0;

--- a/src/unittests.cpp
+++ b/src/unittests.cpp
@@ -17,4 +17,4 @@
 #include "move.h"
 #include "penalty.h"
 #include "celllist.h"
-
+#include "functionparser.h"


### PR DESCRIPTION
Exprtk is a resources-hungry library during compilation, considerably
prolonging the compilation time and increasing the memory usage. Its
isolation to a standalone object file hugely improves compilation
characteristics, especially when  when the potentials are changed and
recompiled.

make -j2 faunus
touch src/potentials.h
time make -j2 faunus

before: system 182% cpu 2:27,81; peak memory usage approx 4.8 GB
after:  system 168% cpu 1:13,53; peak memory usage approx 2.5 GB
gcc 8.2.0; i5-4310U @ 2.00GHz
