### PR TITLE
Extend unit tests of MixerPairPotentials

### DIFF
--- a/src/potentials.cpp
+++ b/src/potentials.cpp
@@ -41,7 +41,12 @@ TPairMatrixPtr PairMixer::createPairMatrix(const std::vector<AtomData> &atoms) {
     TPairMatrixPtr matrix = std::make_shared<TPairMatrix>(n, n);
     for (auto &i : atoms) {
         for (auto &j : atoms) {
-            (*matrix)(i.id(), j.id()) = modifier(combinator(extractor(i), extractor(j)));
+            if(i.id() == j.id()) {
+                // if the combinator is "undefined" the homogeneous interaction is still well defined
+                (*matrix)(i.id(), j.id()) = modifier(extractor(i));
+            } else {
+                (*matrix)(i.id(), j.id()) = modifier(combinator(extractor(i), extractor(j)));
+            }
         }
     }
     return matrix;

--- a/src/potentials.h
+++ b/src/potentials.h
@@ -327,7 +327,7 @@ class HardSphere : public MixerPairPotentialBase {
         : MixerPairPotentialBase(name, std::string(), COMB_ARITHMETIC) {};
 
     inline double operator()(const Particle &a, const Particle &b, const Point &r) const override {
-        return r.squaredNorm() < (*sigma_squared)(a.id, b.id) ? pc::infty : 0;
+        return r.squaredNorm() < (*sigma_squared)(a.id, b.id) ? pc::infty : 0.0;
     }
 };
 
@@ -390,9 +390,7 @@ class SquareWell : public MixerPairPotentialBase {
     SquareWell(const std::string &name = "squarewell")
         : MixerPairPotentialBase(name) {};
     inline double operator()(const Particle &a, const Particle &b, const Point &r) const override {
-        if (r.squaredNorm() < (*diameter_sw_squared)(a.id, b.id))
-            return -(*depth_sw)(a.id, b.id);
-        return 0.0;
+        return (r.squaredNorm() < (*diameter_sw_squared)(a.id, b.id)) ? -(*depth_sw)(a.id, b.id) : 0.0;
     }
 };
 


### PR DESCRIPTION
Unit tests now cover PairMixer and MixerPairPotentialBase descendants except WCA and Hertz. I have discovered that when the interaction coefficient is NaN the behaviour of potentials is not well defined. An  arbitrary value is returned based on the if-condition construction.