### PR TITLE
Fix unittest for random

### DIFF
--- a/src/random.h
+++ b/src/random.h
@@ -47,9 +47,11 @@ namespace Faunus {
 #ifdef DOCTEST_LIBRARY_INCLUDED
     TEST_CASE("[Faunus] Random")
     {
-        Random slump; // local instance
+        Random slump, slump2; // local instances
 
-        CHECK( slump() == random() );
+        CHECK( slump() == slump2() ); // deterministic initialization by default; the global random variable cannot
+                                      // be used for comparison as its state is not reset at the beginning of
+                                      // each test case
 
         int min=10, max=0, N=1e6;
         double x=0;


### PR DESCRIPTION
Global variables cannot be used directly in unit tests as they are
not reset at the beginning of each test case.