### PR TITLE
Allow a dot in ruamel.yaml (sub)module name

### DIFF
--- a/docs/_docs/energy.md
+++ b/docs/_docs/energy.md
@@ -422,16 +422,16 @@ In addition to user-defined constants, the following symbols are defined:
 `symbol`   | Description
 ---------- | ---------------------------------------------
 `e0`       | Vacuum permittivity [C^2/J/m]
-`inf`      | infinity
-`kB`       | Boltzmann's constant [J/K]
-`kT`       | Boltzmann's constant x temperature [J]
-`Nav`      | Avogadro's number [1/mol]
+`inf`      | Infinity
+`kB`       | Boltzmann constant [J/K]
+`kT`       | Boltzmann constant × temperature [J]
+`Nav`      | Avogadro constant [1/mol]
 `pi`       | Pi
-`q1`,`q2`  | particle charges [e]
-`r`        | particle-particle separation [angstrom]
+`q1`,`q2`  | Particle charges [e]
+`r`        | Particle-particle separation [angstrom]
 `Rc`       | Spherical cut-off [angstrom]
-`s1`,`s2`  | particle sigma [angstrom]
-`T`        | temperature [K]
+`s1`,`s2`  | Particle sigma [angstrom]
+`T`        | Temperature [K]
 
 ## Custom External Potential
 
@@ -451,15 +451,15 @@ In addition to user-defined `constants`, the following symbols are available:
 `symbol`   | Description
 ---------- | ---------------------------------------
 `e0`       | Vacuum permittivity [C^2/J/m]
-`inf`      | infinity
-`kB`       | Boltzmann's constant [J/K]
-`kT`       | Boltzmann's constant x temperature [J]
-`Nav`      | Avogadro's number [1/mol]
+`inf`      | Infinity
+`kB`       | Boltzmann constant [J/K]
+`kT`       | Boltzmann constant × temperature [J]
+`Nav`      | Avogadro constant [1/mol]
 `pi`       | Pi
-`q`        | particle charge [e]
-`s`        | particle sigma [angstrom]
-`x`,`y`,`z`| particle positions [angstrom]
-`T`        | temperature [K]
+`q`        | Particle charge [e]
+`s`        | Particle sigma [angstrom]
+`x`,`y`,`z`| Particle positions [angstrom]
+`T`        | Temperature [K]
 
 If `com=true`, charge refers to the molecular net-charge, and `x,y,z` the mass-center coordinates.
 The following illustrates how to confine molecules in a spherical shell of radius, _r_, and

--- a/docs/_docs/energy.md
+++ b/docs/_docs/energy.md
@@ -306,7 +306,7 @@ The potentials below are often used to keep particles apart and/or to introduce 
 The atomic interaction parameters, e.g., $\sigma_i$ and $\epsilon\_i$, are taken from the
 topology.
 
-type             | atomic parameters | $u(r)$ (non-zero part)
+Type             | Atomic parameters | $u(r)$ (non-zero part)
 ---------------- | ----------------- | --------------------------------------------------------
 `hardsphere`     | `sigma`           | $\infty$ for $r < \sigma\_{ij}$
 `hertz`          | `sigma`, `eps`    | $\epsilon\_{ij} \left ( 1-r / \sigma\_{ij}\right )^{5/2}$ for $r<\sigma\_{ij}$
@@ -326,7 +326,7 @@ If not described otherwise, the same rule is applied to all atomic parameters us
 No meaningful defaults are defined yet, hence always specify the mixing rule explicitly, e.g.,
 `arithmetic` for `hardsphere`.
 
-rule                  | description        | formula
+Rule                  | Description        | Formula
 --------------------- | ------------------ | ------------------------------------------------------
 `arithmetic`          | arithmetic mean    | $a\_{ij} = \frac 12 \left( a\_{ii} + a_{jj} \right)$
 `geometric`           | geometric mean     | $a\_{ij} = \sqrt{a\_{ii} a_{jj}}$

--- a/docs/_docs/topology.md
+++ b/docs/_docs/topology.md
@@ -19,9 +19,9 @@ temperature: 298.15  # system temperature (K)
 geometry:
   type: cuboid       # Cuboidal simulation container
   length: [40,40,40] # cuboid dimensions (array or number)
-mcloop:              # number of MC steps (macro x micro)
+mcloop:              # number of MC steps (macro × micro)
   macro: 5           # Number of outer MC steps
-  micro: 100         # Number of inner MC steps; total = 5 x 100 = 5000
+  micro: 100         # Number of inner MC steps; total = 5 × 100 = 500
 random:              # seed for pseudo random number generator
   seed: fixed        # "fixed" (default) or "hardware" (non-deterministic)
 ~~~

--- a/scripts/yason.py
+++ b/scripts/yason.py
@@ -15,10 +15,15 @@ except ImportError:
     warnings.warn("warning: missing jinja2 module")
     jinja2 = None
 
+
+# API compatibility between pyyaml and ruamel.yaml might break in the future
+# https://yaml.readthedocs.io/en/latest/api.html
 try:
-    # API compatibility between pyyaml and ruamel.yaml might break in the future
-    # https://yaml.readthedocs.io/en/latest/api.html
-    import ruamel_yaml as yaml
+    try:
+        import ruamel.yaml as yaml
+    except ImportError:
+        # anaconda packs it as a standalone module (underscore instead of dot)
+        import ruamel_yaml as yaml
 except ImportError:
     import yaml
 

--- a/src/energy.cpp
+++ b/src/energy.cpp
@@ -526,7 +526,7 @@ SASAEnergy::SASAEnergy(const json &j, Space &spc)
 
 void SASAEnergy::updatePositions([[gnu::unused]] const ParticleVector &p) {
     assert(p.size() == spc.positions().size());
-    positions.resize(0); // clear
+    positions.clear();
     for(auto pos: spc.positions()) {
         auto xyz = pos.data();
         positions.insert(positions.end(), xyz, xyz+3);
@@ -544,9 +544,11 @@ void SASAEnergy::updateSASA(const ParticleVector &p, const Change &) {
     updatePositions(p);
     auto result = freesasa_calc_coord(positions.data(), radii.data(), p.size(), &parameters);
     if(result) {
-        sasa.resize(0); // clear
-        sasa.insert(sasa.begin(), result->sasa, result->sasa + p.size()); // copy
+        assert(result->n_atoms == p.size());
+        sasa.clear();
+        sasa.insert(sasa.begin(), result->sasa, result->sasa + result->n_atoms); // copy
         assert(sasa.size() == p.size());
+        freesasa_result_free(result);
     } else {
         throw std::runtime_error("FreeSASA failed");
     }

--- a/src/potentials.cpp
+++ b/src/potentials.cpp
@@ -44,7 +44,10 @@ TPairMatrixPtr PairMixer::createPairMatrix(const std::vector<AtomData> &atoms) {
     TPairMatrixPtr matrix = std::make_shared<TPairMatrix>(n, n);
     for (auto &i : atoms) {
         for (auto &j : atoms) {
-            if (i.id() == j.id()) {
+            if(i.implicit || j.implicit) {
+                // implicit atoms are ignored as the missing properties, e.g., sigma and epsilon, might raise errors
+                (*matrix)(i.id(), j.id()) = combUndefined();
+            } else if (i.id() == j.id()) {
                 // if the combinator is "undefined" the homogeneous interaction is still well defined
                 (*matrix)(i.id(), j.id()) = modifier(extractor(i));
             } else {

--- a/src/potentials.h
+++ b/src/potentials.h
@@ -95,7 +95,7 @@ class PairMixer {
     static TCombinatorFunc getCombinator(CombinationRuleType combination_rule, CoefficientType coefficient = COEF_ANY);
 
     // when explicit custom pairs are the only option
-    inline static constexpr double combUndefined(double, double) {
+    inline static constexpr double combUndefined(double = 0.0, double = 0.0) {
         return std::numeric_limits<double>::signaling_NaN();
     };
     inline static double combArithmetic(double a, double b) { return 0.5 * (a + b); }


### PR DESCRIPTION
In the upstream, yaml is a submodule of ruamel. Hence the proper
import syntax includes a dot. However anaconda, unlike pip, packs
the submodule as a standalone module with an underscore instead of
the dot. Now we support both ways of importing the (sub)module,
with the pyyaml module option as a fallback.