### PR TITLE
Use XeLaTeX to create PDF manual

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -2,6 +2,16 @@
 
 find_program(PANDOC pandoc)
 if (PANDOC)
+    if(NOT TEX_ENGINE)
+        set(TEX_ENGINE xelatex CACHE STRING "TeX engine for PDF manual: xelatex lualatex")
+    endif()
+    set(TEX_ENGINE_OPTION --pdf-engine)
+    execute_process(COMMAND ${PANDOC} ${TEX_ENGINE_OPTION}=${TEX_ENGINE}
+        INPUT_FILE /dev/null ERROR_QUIET RESULT_VARIABLE PANDOC_CMD_SYNTAX)
+    if(NOT PANDOC_CMD_SYNTAX EQUAL 0)
+        # fallback to pandoc version 1 syntax
+        set(TEX_ENGINE_OPTION --latex-engine)
+    endif()
     add_custom_target(
         manual
         COMMENT "Building PDF manual"
@@ -20,7 +30,7 @@ if (PANDOC)
         sed 's.\\\\_._.g' | # this allows us to use \_ in markdown math
         ${PANDOC} --self-contained --highlight-style=tango --template ../pandoc.tex
         -V date:${GIT_LATEST_TAG}""
-        -N --toc -o ${CMAKE_BINARY_DIR}/manual.pdf
+        -N --toc ${TEX_ENGINE_OPTION}=${TEX_ENGINE} -o ${CMAKE_BINARY_DIR}/manual.pdf
         )
     set_target_properties(manual PROPERTIES EXCLUDE_FROM_ALL TRUE)
 

--- a/docs/_docs/energy.md
+++ b/docs/_docs/energy.md
@@ -421,12 +421,12 @@ In addition to user-defined constants, the following symbols are defined:
 
 `symbol`   | Description
 ---------- | ---------------------------------------------
-`e0`       | Vacuum permittivity [C^2/J/m]
-`inf`      | Infinity
+`e0`       | Vacuum permittivity [C²/J/m]
+`inf`      | ∞ (infinity)
 `kB`       | Boltzmann constant [J/K]
 `kT`       | Boltzmann constant × temperature [J]
 `Nav`      | Avogadro constant [1/mol]
-`pi`       | Pi
+`pi`       | π (pi)
 `q1`,`q2`  | Particle charges [e]
 `r`        | Particle-particle separation [angstrom]
 `Rc`       | Spherical cut-off [angstrom]
@@ -450,12 +450,12 @@ In addition to user-defined `constants`, the following symbols are available:
 
 `symbol`   | Description
 ---------- | ---------------------------------------
-`e0`       | Vacuum permittivity [C^2/J/m]
-`inf`      | Infinity
+`e0`       | Vacuum permittivity [C²/J/m]
+`inf`      | ∞ (infinity)
 `kB`       | Boltzmann constant [J/K]
 `kT`       | Boltzmann constant × temperature [J]
 `Nav`      | Avogadro constant [1/mol]
-`pi`       | Pi
+`pi`       | π (pi)
 `q`        | Particle charge [e]
 `s`        | Particle sigma [angstrom]
 `x`,`y`,`z`| Particle positions [angstrom]

--- a/docs/_docs/header.md
+++ b/docs/_docs/header.md
@@ -1,5 +1,4 @@
 ---
-# https://tex.stackexchange.com/questions/3214/error-when-using-t1-fontenc-and-urw-garamond-from-mathdesign
 title: \emph{The Faunus User Manual}
 papersize: a4
 fontsize: 10pt
@@ -8,8 +7,19 @@ toccolor: Maroon
 linkcolor: Maroon
 citecolor: Maroon
 urlcolor: Maroon
-fontfamily: mathdesign
-fontfamilyoptions: urw-garamond
+# https://tex.stackexchange.com/questions/3214/error-when-using-t1-fontenc-and-urw-garamond-from-mathdesign
+# fontfamily: mathdesign
+# fontfamilyoptions: urw-garamond
+mainfont: EB Garamond       # https://github.com/octaviopardo/EBGaramond12
+mathfont: Garamond-Math     # https://github.com/YuanshengZhao/Garamond-Math
+# sansfont: Gill Sans Nova
+monofont: Fira Code         # https://github.com/tonsky/FiraCode
+monofontoptions:
+- StylisticSet=4 # sans-serif like g
+- StylisticSet=5 # traditional shape of @
+# monofont: Inconsolata
+# monofont: Source Code Pro
+linestretch: 1.15
 links-as-notes: true
 header-includes: |
     \usepackage{fancyhdr}

--- a/docs/_docs/install.md
+++ b/docs/_docs/install.md
@@ -92,13 +92,15 @@ Pandoc is required to build the HTML manual:
 make manual_html
 ~~~
 
-In addition to pandoc, a TeX Live installation is required to build
-the PDF manual. Garamond fonts must be available:
+In addition to pandoc, a TeX Live installation containing XeLaTeX is required to build the PDF manual.
+The manual is supposed to be typeset with
+[EB Garamond](https://github.com/octaviopardo/EBGaramond12/tree/master/fonts/otf),
+[Garamond Math](https://github.com/YuanshengZhao/Garamond-Math/blob/master/Garamond-Math.otf) and
+[Fira Code](https://github.com/tonsky/FiraCode/releases/download/2/FiraCode_2.zip)
+fonts thus they have to be available in your system. Alternatively, you can tweak the font options
+in the `header.md` file.
 
 ~~~ bash
-wget https://tug.org/fonts/getnonfreefonts/install-getnonfreefonts
-sudo texlua install-getnonfreefonts
-sudo getnonfreefonts garamond --sys
 make manual
 ~~~
 

--- a/docs/pandoc.tex
+++ b/docs/pandoc.tex
@@ -11,8 +11,7 @@ $if(linestretch)$
 \usepackage{setspace}
 \setstretch{$linestretch$}
 $endif$
-%\usepackage{amssymb,amsmath}
-\usepackage{amsmath}
+\usepackage{amsmath,amsfonts}
 \usepackage{ifxetex,ifluatex}
 \usepackage{fixltx2e} % provides \textsubscript
 \ifnum 0\ifxetex 1\fi\ifluatex 1\fi=0 % if pdftex
@@ -27,6 +26,7 @@ $endif$
   \else
     \usepackage{fontspec}
   \fi
+  \usepackage{unicode-math}
   \defaultfontfeatures{Ligatures=TeX,Scale=MatchLowercase}
 $for(fontfamilies)$
   \newfontfamily{$fontfamilies.name$}[$fontfamilies.options$]{$fontfamilies.font$}
@@ -44,7 +44,7 @@ $if(monofont)$
     \setmonofont[Mapping=tex-ansi$if(monofontoptions)$,$for(monofontoptions)$$monofontoptions$$sep$,$endfor$$endif$]{$monofont$}
 $endif$
 $if(mathfont)$
-    \setmathfont(Digits,Latin,Greek)[$for(mathfontoptions)$$mathfontoptions$$sep$,$endfor$]{$mathfont$}
+    \setmathsfont(Digits,Latin,Greek)[$for(mathfontoptions)$$mathfontoptions$$sep$,$endfor$]{$mathfont$}
 $endif$
 $if(CJKmainfont)$
     \usepackage{xeCJK}


### PR DESCRIPTION
To generate the PDF manual, three fonts have to be installed in the system, as documented in the manual. Only plain markdown readability saves us here from Catch-22.
- [EB Garamond](https://github.com/octaviopardo/EBGaramond12/tree/master/fonts/otf)
- [Garamond Math](https://github.com/YuanshengZhao/Garamond-Math/blob/master/Garamond-Math.otf)
- [Fira Code](https://github.com/tonsky/FiraCode/releases/download/2/FiraCode_2.zip)

I suggest merging to let the newly created documentation benefit from full unicode support.  