### PR TITLE
Use composition over inheritance for Move::Propagator 

### DIFF
--- a/src/analysis.cpp
+++ b/src/analysis.cpp
@@ -350,43 +350,43 @@ CombinedAnalysis::CombinedAnalysis(const json &j, Space &spc, Energy::Hamiltonia
                     try {
                         size_t oldsize = this->vec.size();
                         if (it.key() == "atomprofile")
-                            push_back<AtomProfile>(it.value(), spc);
+                            emplace_back<AtomProfile>(it.value(), spc);
                         else if (it.key() == "atomrdf")
-                            push_back<AtomRDF>(it.value(), spc);
+                            emplace_back<AtomRDF>(it.value(), spc);
                         else if (it.key() == "atomdipdipcorr")
-                            push_back<AtomDipDipCorr>(it.value(), spc);
+                            emplace_back<AtomDipDipCorr>(it.value(), spc);
                         else if (it.key() == "density")
-                            push_back<Density>(it.value(), spc);
+                            emplace_back<Density>(it.value(), spc);
                         else if (it.key() == "chargefluctuations")
-                            push_back<ChargeFluctuations>(it.value(), spc);
+                            emplace_back<ChargeFluctuations>(it.value(), spc);
                         else if (it.key() == "molrdf")
-                            push_back<MoleculeRDF>(it.value(), spc);
+                            emplace_back<MoleculeRDF>(it.value(), spc);
                         else if (it.key() == "multipole")
-                            push_back<Multipole>(it.value(), spc);
+                            emplace_back<Multipole>(it.value(), spc);
                         else if (it.key() == "multipoledist")
-                            push_back<MultipoleDistribution>(it.value(), spc);
+                            emplace_back<MultipoleDistribution>(it.value(), spc);
                         else if (it.key() == "polymershape")
-                            push_back<PolymerShape>(it.value(), spc);
+                            emplace_back<PolymerShape>(it.value(), spc);
                         else if (it.key() == "qrfile")
-                            push_back<QRtraj>(it.value(), spc);
+                            emplace_back<QRtraj>(it.value(), spc);
                         else if (it.key() == "reactioncoordinate")
-                            push_back<FileReactionCoordinate>(it.value(), spc);
+                            emplace_back<FileReactionCoordinate>(it.value(), spc);
                         else if (it.key() == "sanity")
-                            push_back<SanityCheck>(it.value(), spc);
+                            emplace_back<SanityCheck>(it.value(), spc);
                         else if (it.key() == "savestate")
-                            push_back<SaveState>(it.value(), spc);
+                            emplace_back<SaveState>(it.value(), spc);
                         else if (it.key() == "scatter")
-                            push_back<ScatteringFunction>(it.value(), spc);
+                            emplace_back<ScatteringFunction>(it.value(), spc);
                         else if (it.key() == "sliceddensity")
-                            push_back<SlicedDensity>(it.value(), spc);
+                            emplace_back<SlicedDensity>(it.value(), spc);
                         else if (it.key() == "systemenergy")
-                            push_back<SystemEnergy>(it.value(), pot);
+                            emplace_back<SystemEnergy>(it.value(), pot);
                         else if (it.key() == "virtualvolume")
-                            push_back<VirtualVolume>(it.value(), spc, pot);
+                            emplace_back<VirtualVolume>(it.value(), spc, pot);
                         else if (it.key() == "widom")
-                            push_back<WidomInsertion>(it.value(), spc, pot);
+                            emplace_back<WidomInsertion>(it.value(), spc, pot);
                         else if (it.key() == "xtcfile")
-                            push_back<XTCtraj>(it.value(), spc);
+                            emplace_back<XTCtraj>(it.value(), spc);
                         // additional analysis go here...
 
                         if (this->vec.size() == oldsize)

--- a/src/auxiliary.h
+++ b/src/auxiliary.h
@@ -2162,14 +2162,20 @@ namespace Faunus
             auto end() const noexcept { return vec.end(); }
             auto empty() const noexcept { return vec.empty(); }
             auto size() const noexcept { return vec.size(); }
+            auto back() const noexcept { return vec.back(); }
 
-            template<typename Tderived, class... Args, class = std::enable_if_t<std::is_base_of<T,Tderived>::value>>
-                void push_back(Args&... args) {
-                    vec.push_back( std::make_shared<Tderived>(args...) );
-                } //!< Add (derived) pointer to vector
+            template <typename Tderived, class... Args, class = std::enable_if_t<std::is_base_of<T, Tderived>::value>>
+            void emplace_back(Args &... args) {
+                vec.push_back(std::make_shared<Tderived>(args...));
+            } //!< Create an (derived) instance and append a pointer to it to the vector
+
+            template<typename Tderived, class Arg, class = std::enable_if_t<std::is_base_of<T,Tderived>::value>>
+            void push_back(std::shared_ptr<Arg> arg) {
+                vec.push_back( arg );
+            } //!< Append a pointer to a (derived) instance to the vector
 
             template<typename Tderived, class = std::enable_if_t<std::is_base_of<T,Tderived>::value>>
-                auto find() {
+                auto find() const {
                     std::vector<std::shared_ptr<Tderived>> _v;
                     for (auto base : vec) {
                         auto derived = std::dynamic_pointer_cast<Tderived>(base);
@@ -2179,7 +2185,9 @@ namespace Faunus
                     return _v;
                 } //!< Pointer list to all matching type
 
-        }; //!< Helper class for storing vectors of base pointers
+                template<typename U>
+                friend void to_json(json&, const BasePointerVector<U>&); //!< Allow serialization to JSON
+                }; //!< Helper class for storing vectors of base pointers
 
     template<typename T>
         void to_json(json &j, const BasePointerVector<T> &b) {

--- a/src/auxiliary.h
+++ b/src/auxiliary.h
@@ -2152,50 +2152,48 @@ namespace Faunus
     }
 #endif
 
-    template<typename T>
-        struct BasePointerVector {
-            std::vector<std::shared_ptr<T>> vec; //!< Vector of shared pointers to base class
+    template <typename T> struct BasePointerVector {
+        std::vector<std::shared_ptr<T>> vec; //!< Vector of shared pointers to base class
 
-            auto begin() noexcept { return vec.begin(); }
-            auto begin() const noexcept { return vec.begin(); }
-            auto end() noexcept { return vec.end(); }
-            auto end() const noexcept { return vec.end(); }
-            auto empty() const noexcept { return vec.empty(); }
-            auto size() const noexcept { return vec.size(); }
-            auto back() const noexcept { return vec.back(); }
+        auto begin() noexcept { return vec.begin(); }
+        auto begin() const noexcept { return vec.begin(); }
+        auto end() noexcept { return vec.end(); }
+        auto end() const noexcept { return vec.end(); }
+        auto empty() const noexcept { return vec.empty(); }
+        auto size() const noexcept { return vec.size(); }
+        auto back() const noexcept { return vec.back(); }
 
-            template <typename Tderived, class... Args, class = std::enable_if_t<std::is_base_of<T, Tderived>::value>>
-            void emplace_back(Args &... args) {
-                vec.push_back(std::make_shared<Tderived>(args...));
-            } //!< Create an (derived) instance and append a pointer to it to the vector
+        template <typename Tderived, class... Args, class = std::enable_if_t<std::is_base_of<T, Tderived>::value>>
+        void emplace_back(Args &... args) {
+            vec.push_back(std::make_shared<Tderived>(args...));
+        } //!< Create an (derived) instance and append a pointer to it to the vector
 
-            template<typename Tderived, class Arg, class = std::enable_if_t<std::is_base_of<T,Tderived>::value>>
-            void push_back(std::shared_ptr<Arg> arg) {
-                vec.push_back( arg );
-            } //!< Append a pointer to a (derived) instance to the vector
+        template <typename Tderived, class Arg, class = std::enable_if_t<std::is_base_of<T, Tderived>::value>>
+        void push_back(std::shared_ptr<Arg> arg) {
+            vec.push_back(arg);
+        } //!< Append a pointer to a (derived) instance to the vector
 
-            template<typename Tderived, class = std::enable_if_t<std::is_base_of<T,Tderived>::value>>
-                auto find() const {
-                    std::vector<std::shared_ptr<Tderived>> _v;
-                    for (auto base : vec) {
-                        auto derived = std::dynamic_pointer_cast<Tderived>(base);
-                        if (derived)
-                            _v.push_back(derived);
-                    }
-                    return _v;
-                } //!< Pointer list to all matching type
-
-                template<typename U>
-                friend void to_json(json&, const BasePointerVector<U>&); //!< Allow serialization to JSON
-                }; //!< Helper class for storing vectors of base pointers
-
-    template<typename T>
-        void to_json(json &j, const BasePointerVector<T> &b) {
-            try {
-                for (auto i : b.vec)
-                    j.push_back(*i);
-            } catch (const std::exception& e) {
-                throw std::runtime_error("error converting to json: "s + e.what());
+        template <typename Tderived, class = std::enable_if_t<std::is_base_of<T, Tderived>::value>>
+        auto find() const {
+            std::vector<std::shared_ptr<Tderived>> _v;
+            for (auto base : vec) {
+                auto derived = std::dynamic_pointer_cast<Tderived>(base);
+                if (derived)
+                    _v.push_back(derived);
             }
+            return _v;
+        } //!< Pointer list to all matching type
+
+        template <typename U>
+        friend void to_json(json &, const BasePointerVector<U> &); //!< Allow serialization to JSON
+    }; //!< Helper class for storing vectors of base pointers
+
+    template <typename T> void to_json(json &j, const BasePointerVector<T> &b) {
+        try {
+            for (auto i : b.vec)
+                j.push_back(*i);
+        } catch (const std::exception &e) {
+            throw std::runtime_error("error converting to json: "s + e.what());
         }
+    }
 }//namespace

--- a/src/energy.cpp
+++ b/src/energy.cpp
@@ -377,7 +377,7 @@ void Hamiltonian::addEwald(const json &j, Space &spc) {
 
     if (_j.count("type"))
         if (_j.at("type") == "ewald")
-            push_back<Energy::Ewald<>>(j["coulomb"], spc);
+            emplace_back<Energy::Ewald<>>(j["coulomb"], spc);
 }
 
 Hamiltonian::Hamiltonian(Space &spc, const json &j) {
@@ -397,38 +397,38 @@ Hamiltonian::Hamiltonian(Space &spc, const json &j) {
 
     // add container overlap energy for non-cuboidal geometries
     if (spc.geo.type not_eq Geometry::CUBOID)
-        push_back<Energy::ContainerOverlap>(spc);
+        emplace_back<Energy::ContainerOverlap>(spc);
 
     for (auto &m : j) { // loop over move list
         size_t oldsize = vec.size();
         for (auto it : m.items()) {
             try {
                 if (it.key() == "nonbonded_coulomblj")
-                    push_back<Energy::Nonbonded<CoulombLJ>>(it.value(), spc, *this);
+                    emplace_back<Energy::Nonbonded<CoulombLJ>>(it.value(), spc, *this);
 
                 else if (it.key() == "nonbonded_newcoulomblj")
-                    push_back<Energy::Nonbonded<NewCoulombLJ>>(it.value(), spc, *this);
+                    emplace_back<Energy::Nonbonded<NewCoulombLJ>>(it.value(), spc, *this);
 
                 else if (it.key() == "nonbonded_coulomblj_EM")
-                    push_back<Energy::NonbondedCached<CoulombLJ>>(it.value(), spc, *this);
+                    emplace_back<Energy::NonbondedCached<CoulombLJ>>(it.value(), spc, *this);
 
                 else if (it.key() == "nonbonded_splined")
-                    push_back<Energy::Nonbonded<TabulatedPotential>>(it.value(), spc, *this);
+                    emplace_back<Energy::Nonbonded<TabulatedPotential>>(it.value(), spc, *this);
 
                 else if (it.key() == "nonbonded" or it.key() == "nonbonded_exact")
-                    push_back<Energy::Nonbonded<FunctorPotential>>(it.value(), spc, *this);
+                    emplace_back<Energy::Nonbonded<FunctorPotential>>(it.value(), spc, *this);
 
                 else if (it.key() == "nonbonded_cached")
-                    push_back<Energy::NonbondedCached<TabulatedPotential>>(it.value(), spc, *this);
+                    emplace_back<Energy::NonbondedCached<TabulatedPotential>>(it.value(), spc, *this);
 
                 else if (it.key() == "nonbonded_coulombwca")
-                    push_back<Energy::Nonbonded<CoulombWCA>>(it.value(), spc, *this);
+                    emplace_back<Energy::Nonbonded<CoulombWCA>>(it.value(), spc, *this);
 
                 else if (it.key() == "nonbonded_pm" or it.key() == "nonbonded_coulombhs")
-                    push_back<Energy::Nonbonded<PrimitiveModel>>(it.value(), spc, *this);
+                    emplace_back<Energy::Nonbonded<PrimitiveModel>>(it.value(), spc, *this);
 
                 else if (it.key() == "nonbonded_pmwca")
-                    push_back<Energy::Nonbonded<PrimitiveModelWCA>>(it.value(), spc, *this);
+                    emplace_back<Energy::Nonbonded<PrimitiveModelWCA>>(it.value(), spc, *this);
 
                 // this should be moved into `Nonbonded` and added when appropriate
                 // Nonbonded now has access to Hamiltonian (*this) and can therefore
@@ -436,35 +436,35 @@ Hamiltonian::Hamiltonian(Space &spc, const json &j) {
                 addEwald(it.value(), spc); // add reciprocal Ewald terms if appropriate
 
                 if (it.key() == "bonded")
-                    push_back<Energy::Bonded>(it.value(), spc);
+                    emplace_back<Energy::Bonded>(it.value(), spc);
 
                 else if (it.key() == "customexternal")
-                    push_back<Energy::CustomExternal>(it.value(), spc);
+                    emplace_back<Energy::CustomExternal>(it.value(), spc);
 
                 else if (it.key() == "akesson")
-                    push_back<Energy::ExternalAkesson>(it.value(), spc);
+                    emplace_back<Energy::ExternalAkesson>(it.value(), spc);
 
                 else if (it.key() == "confine")
-                    push_back<Energy::Confine>(it.value(), spc);
+                    emplace_back<Energy::Confine>(it.value(), spc);
 
                 else if (it.key() == "constrain")
-                    push_back<Energy::Constrain>(it.value(), spc);
+                    emplace_back<Energy::Constrain>(it.value(), spc);
 
                 else if (it.key() == "example2d")
-                    push_back<Energy::Example2D>(it.value(), spc);
+                    emplace_back<Energy::Example2D>(it.value(), spc);
 
                 else if (it.key() == "isobaric")
-                    push_back<Energy::Isobaric>(it.value(), spc);
+                    emplace_back<Energy::Isobaric>(it.value(), spc);
 
                 else if (it.key() == "penalty")
 #ifdef ENABLE_MPI
-                    push_back<Energy::PenaltyMPI>(it.value(), spc);
+                    emplace_back<Energy::PenaltyMPI>(it.value(), spc);
 #else
-                    push_back<Energy::Penalty>(it.value(), spc);
+                    emplace_back<Energy::Penalty>(it.value(), spc);
 #endif
 #if defined ENABLE_FREESASA
                 else if (it.key() == "sasa")
-                    push_back<Energy::SASAEnergy>(it.value(), spc);
+                    emplace_back<Energy::SASAEnergy>(it.value(), spc);
 #endif
                 // additional energies go here...
 

--- a/src/energy.h
+++ b/src/energy.h
@@ -544,7 +544,7 @@ template <typename Tpairpot> class Nonbonded : public Energybase {
     // add self energy term to Hamiltonian if appropriate
     void addPairPotentialSelfEnergy() {
         if (pairpot.selfEnergy) // only add if self energy is defined
-            pot.push_back<Energy::ParticleSelfEnergy>(spc, pairpot.selfEnergy);
+            pot.emplace_back<Energy::ParticleSelfEnergy>(spc, pairpot.selfEnergy);
     }
 
     void configureOpenMP(const json &j) {

--- a/src/montecarlo.cpp
+++ b/src/montecarlo.cpp
@@ -40,10 +40,8 @@ void MCSimulation::init() {
 
     // inject reference to state1 in SpeciationMove (needed to calc. *differences*
     // in ideal excess chem. potentials)
-    for (auto base : moves.vec) {
-        auto derived = std::dynamic_pointer_cast<Move::SpeciationMove>(base);
-        if (derived)
-            derived->setOther(state1.spc);
+    for (auto speciation_move : moves.moves().find<Move::SpeciationMove>()) {
+        speciation_move->setOther(state1.spc);
     }
 }
 


### PR DESCRIPTION
# Description

`Move::Propagator` is not a vector itself but contains vector(s).

Furthermore, the `BasePointerVector` class is changed to follow closer the `std::vector` interface. The original `push_back` method is renamed to `emplace_back` and a new implementation of `push_back` is added, hence already constructed instances can be appended.
