### PR TITLE
Update gyration tensor and radius of gyration

### DIFF
--- a/docs/_docs/analysis.md
+++ b/docs/_docs/analysis.md
@@ -157,17 +157,18 @@ form factor of unity.
 `dq`        | _q_ spacing (1/Å)
 `com=true`  | Treat molecular mass centers as single point scatterers
 
-### Atomic Gyration Eigenvalues
+### Atomic Inertia Eigenvalues
 
-This calculates the gyration eigenvalues for all particles having a given id.
-The gyration tensor is defined as
+This calculates the inertia eigenvalues for all particles having a given id.
+The inertia tensor is defined as
 
 $$
-S = \frac{1}{N} \sum_{i=1}^{N} ( \| \bf{t_i} \|^2 \mathrm{I} - \bf{t_i} \bf{t_i^T} )
+I = \sum_{i=1}^N m_i ( \| \bf{t_i} \|^2 \mathrm{I} - \bf{t_i} \bf{t_i}^T ) 
 $$
 
 where $\bf{t_i} = \bf{r_i} - \bf{cm}$, $\bf{r_i}$ is the coordinate of the $i$th particle, $\bf{cm}$ is the
-position of the mass center of the whole group of atoms, $\bf{I}$ is the identity matrix and $N$ is the number of atoms.
+position of the mass center of the whole group of atoms, $m_i$ is the molecular weight of the $i$th particle, 
+$\bf{I}$ is the identity matrix and $N$ is the number of atoms.
 
 `gyration`       | Description
 ---------------- | ----------------------------------------
@@ -187,7 +188,7 @@ I = \sum_{i=1}^N m_i ( \| \bf{t_i} \|^2 \mathrm{I} - \bf{t_i} \bf{t_i}^T )
 $$
 
 where $\bf{t_i} = \bf{r_i} - \bf{cm}$, $\bf{r_i}$ is the coordinate of the $i$th particle, $\bf{cm}$ is the
-position of the mass center of the whole group of atoms, $m_i$ is the molecular weight of the _i_th particle,
+position of the mass center of the whole group of atoms, $m_i$ is the molecular weight of the $i$th particle,
 $\bf{I}$ is the identity matrix and $N$ is the number of atoms.
 
 `gyration`       | Description
@@ -204,7 +205,7 @@ fluctuations for all groups defined in `molecules`.
 `polymershape`   | Description
 ---------------- | ----------------------------------------
 `nstep`          | Interval with which to sample
-`molecules`      | List of molecule names to sample (array); `[*]` selects all 
+`molecules`      | List of molecule names to sample (array); `[*]` selects all
 
 ## Charge Properties
 

--- a/docs/_docs/energy.md
+++ b/docs/_docs/energy.md
@@ -839,6 +839,12 @@ Notes:
 - `Rinner` can be used to calculate the inner radius of cylindrical or spherical vesicles. $d^2=\bf{r} \cdot$`dir` where
 $\bf{r}$ is the position vector
 - `L/R` can be used to calculate the bending modulus of a cylindrical lipid vesicle
+- `Rg` is calculated as the square-root of the sum of the eigenvalues of the gyration tensor, $S$. 
+$$
+S = \frac{1}{N} \sum_{i=1}^{N} \bf{t_i} \bf{t_i^T}
+$$
+where $\bf{t_i} = \bf{r_i} - \bf{cm}$, $\bf{r_i}$ is the coordinate of the $i$th atom, $\bf{cm}$ is the
+mass center of the group and $N$ is the number of atoms in the molecule.
 
 #### System Properties
 

--- a/src/analysis.h
+++ b/src/analysis.h
@@ -400,7 +400,7 @@ class ScatteringFunction : public Analysisbase {
 /*
  * @brief Sample and save gyration eigenvalues of all particles having the same id
  */
-class AtomGyration : public Analysisbase {
+class AtomInertia : public Analysisbase {
   private:
     Space &spc;
     std::string filename;
@@ -412,7 +412,7 @@ class AtomGyration : public Analysisbase {
     void _sample() override;
 
   public:
-    AtomGyration(const json &j, Space &spc);
+    AtomInertia(const json &j, Space &spc);
 };
 
 /*

--- a/src/geometry.h
+++ b/src/geometry.h
@@ -913,7 +913,7 @@ struct Random;
          * @brief Calculates the gyration tensor of a molecular group
          * The gyration tensor is computed from the atomic position
          * vectors with respect to a reference point, \f$ t_{i} = r_{i} - shift \f$:
-         * \f$ S = (1 / N) \sum_{i=1}^{N} t_{i} \cdot t_{i} I  - t_{i} t_{i}^{T} \f$
+         * \f$ S = (1 / N) \sum_{i=1}^{N} t_{i} t_{i}^{T} \f$
          */
         template<typename iter>
             Tensor gyration(iter begin, iter end, BoundaryFunction boundary=[](const Point&){}, const Point shift=Point(0,0,0) ) {
@@ -923,9 +923,9 @@ struct Random;
                     for (auto it=begin; it!=end; ++it) {
                         Point t = it->pos - shift;
                         boundary(t);
-                        S += t.squaredNorm() * Eigen::Matrix<double, 3, 3>::Identity() - t * t.transpose();
+                        S += t * t.transpose();
                     }
-                    return S*(1.0/n);
+                    return S * (1.0 / n);
                 }
                 return S;
             }

--- a/src/reactioncoordinate.cpp
+++ b/src/reactioncoordinate.cpp
@@ -195,9 +195,9 @@ MoleculeProperty::MoleculeProperty(const json &j, Space &spc) : ReactionCoordina
     else if (property == "Rg")
         f = [&spc, i = index]() {
             assert(spc.groups[i].size() > 1);
-            auto S = Geometry::gyration(spc.groups[i].begin(), spc.groups[i].end(), spc.geo.getBoundaryFunc(), -spc.groups[i].cm);
+            auto S = Geometry::gyration(spc.groups[i].begin(), spc.groups[i].end(), spc.geo.getBoundaryFunc(), spc.groups[i].cm);
             Eigen::SelfAdjointEigenSolver<Eigen::Matrix3d> esf(S);
-            return esf.eigenvalues().norm();
+            return std::sqrt(esf.eigenvalues().sum());
         };
 
     else if (property == "muangle") {


### PR DESCRIPTION
# Description

Corrections in the calculation of gyration tensor in `geometry.h` and of the reaction coordinate `Rg`. The radius of gyration is calculated as the square-root of the trace of the diagonalised gyration tensor.
The analysis AtomGyration has been renamed and updated to calculate the inertia tensor for a group of particles having the same id.

## Checklist

- [] `make test` passes with no errors
- [x] the source code is well documented
- [ ] new functionality includes unittests
- [x] the user-manual has been updated to reflect the changes
- [ ] I have installed the provided commit hook to auto-format commits (requires `clang-format`):

  ``` bash
  ./scripts/git-pre-commit-format install
  ```

- [x] code naming scheme follows the convention:

  Style      | Elements
  ---------- | -------------------
  PascalCase | classes, namespaces
  camelCase  | functions
  snake_case | variables
