### PR TITLE
Add nonbonded interaction exclusions

### DIFF
--- a/docs/_docs/topology.md
+++ b/docs/_docs/topology.md
@@ -99,6 +99,8 @@ Properties of molecules and their default values:
 `atoms=[]`              | Array of atom names; required if `atomic=true`
 `bondlist`              | List of _internal_ bonds (harmonic, dihedrals etc.)
 `compressible=false`    | If true, molecular internal coordinates are scaled upon volume moves
+`excluded_neighbours=0` | Generate an `exclusionlist` from the bonded interaction: Add all atom pairs which are `excluded_neighbours` or less bonds apart
+`exclusionlist`         | List of _internal_ atom pairs which nonbonded interactions are excluded
 `implicit=false`        | If this species is implicit in GCMC schemes
 `insdir=[1,1,1]`        | Insert directions are scaled by this
 `insoffset=[0,0,0]`     | Shifts mass center after insertion
@@ -121,6 +123,17 @@ moleculelist:
       bondlist:
         - harmonic: {index: [0,1], k: 100, req: 1.5}
         - ...
+  - carbon_dioxide:
+      structure:
+        - O: [-1.162,0,0]
+        - C: [0,0,0]
+        - O: [1.162,0,0]
+      bondlist:
+        - harmonic: {index: [1,0], k: 8443, req: 1.162}
+        - harmonic: {index: [1,2], k: 8443, req: 1.162}
+        - harmonic_torsion: {index: [0,1,2], k: 451.9, aeq: 180}
+      excluded_neighbours: 2 # generates an exclusionlist as shown below
+      exclusionlist: [ [0,1], [1,2], [0,2] ] # redundant in this topology
   - ...
 ~~~
 
@@ -142,6 +155,21 @@ When giving structures using the `structure` keyword, the following policies app
   Use `keepcharges=False` to override.
 - A warning is issued if radii/charges differ in files and `atomlist`.
 - Box dimensions in files are ignored.
+
+### Nonbonded Interaction Exclusion
+
+Some nonbonded interactions between atoms within a molecule may be excluded in the topology.
+Force fields almost always exclude nonbonded interactions between directly bonded atoms. However
+other nonbonded interactions may be excluded as well; refer to your force field parametrization.
+If a molecule contains overlapping hard spheres, e.g., if the bond length is shorter than
+the spheresʼ diameter, it is necessary to exclude corresponding nonbonded interactions to avoid
+infinite energies.
+
+The excluded nonbonded interactions can be given as an explicit list of atom pairs `excludelist`,
+or they can be deduced from the moleculeʼs topology using the `excluded_neighbours=n` option:
+If the atoms are `n` or less bonds apart from each other in the molecule, the nonbonded interactions
+between them are excluded. Both options `excluded_neighbours` and `exclusionlist` can be used together
+making a union.
 
 ## Initial Configuration
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -75,6 +75,7 @@ set(tsts
     ${CMAKE_SOURCE_DIR}/src/core_test.h
     ${CMAKE_SOURCE_DIR}/src/energy_test.h
     ${CMAKE_SOURCE_DIR}/src/group_test.h
+    ${CMAKE_SOURCE_DIR}/src/molecule_test.h
     ${CMAKE_SOURCE_DIR}/src/potentials_test.h
     ${CMAKE_SOURCE_DIR}/src/space_test.h
     ${CMAKE_SOURCE_DIR}/src/tensor_test.h

--- a/src/core.h
+++ b/src/core.h
@@ -184,4 +184,10 @@ auto filter(iter begin, iter end, std::function<bool(T&)> unarypredicate) {
                   const Point &dir = {1, 1, 1}); //!< Random unit vector using Neuman's method ("sphere picking")
     Point ranunit_polar(Random &);               //!< Random unit vector using polar coordinates ("sphere picking")
 
-}//end of faunus namespace
+    /** Exception to be thrown when parsing json configuration */
+    struct ConfigurationError : public std::runtime_error {
+        explicit ConfigurationError(const std::string &what_arg) : std::runtime_error(what_arg){};
+        explicit ConfigurationError(const char *what_arg) : std::runtime_error(what_arg){};
+    };
+
+    }//end of faunus namespace

--- a/src/molecule_test.h
+++ b/src/molecule_test.h
@@ -1,0 +1,152 @@
+#include "molecule.h"
+
+namespace Faunus {
+
+using doctest::Approx;
+
+TEST_SUITE_BEGIN("Molecule");
+
+TEST_CASE("[Faunus] Structure") {
+    MoleculeStructureReader sf;
+    ParticleVector particles;
+
+    SUBCASE("[Faunus] Structure JSON") {
+        atoms = R"([{"Na": {}}, {"Cl": {}}, {"M": {}}])"_json.get<decltype(atoms)>();
+        auto j = R"([ {"Na": [0,0,0]}, {"Cl": [1,0,0]}, {"M": [0,4.2,0]} ])"_json;
+        particles.clear();
+        sf.readJson(particles, j);
+        CHECK_EQ(particles.size(), 3);
+        CHECK_EQ(particles.front().id, 0);
+        CHECK_EQ(particles.back().pos, Point {0, 4.2, 0});
+    }
+
+    SUBCASE("[Faunus] Structure FASTA") {
+        atoms = R"([{"ALA": {}}, {"GLY": {}}, {"NTR": {}}, {"CTR": {}}])"_json.get<decltype(atoms)>();
+        auto j = R"({"fasta": "nAAAAGGc", "k": 3, "req": 7})"_json;
+        particles.clear();
+        sf.readJson(particles, j);
+        CHECK_EQ(particles.size(), 8);
+        CHECK_EQ(particles[4].id, 0);
+        CHECK_EQ(particles[5].id, 1);
+    }
+}
+
+TEST_CASE("[Faunus] ExclusionsVicinity") {
+    std::vector<std::pair<int, int>> pairs{{0,1}, {1,2}, {1,3}, {6,7}};
+    auto exclusions = ExclusionsVicinity::create(10, pairs);
+
+    CHECK(exclusions.isExcluded(1,3));
+    CHECK(exclusions.isExcluded(6,7));
+    CHECK_FALSE(exclusions.isExcluded(2,3));
+    CHECK_FALSE(exclusions.isExcluded(4,5));
+    CHECK_FALSE(exclusions.isExcluded(8,9));
+}
+
+TEST_CASE("[Faunus] MoleculeData") {
+//    json j = R"(
+//            { "moleculelist": [
+//                { "B": {"activity":0.2, "atomic":true, "insdir": [0.5,0,0], "insoffset": [-1.1, 0.5, 10], "atoms":["a"] } },
+//                { "A": { "atomic":false, "structure": [{"a": [0.1, 0.1, 0.1]}] } }
+//            ]})"_json;
+    json j = R"([
+                { "B": {"activity": 0.2, "atomic": true, "atoms": ["a"] } },
+                { "A": { "atomic": false, "structure": [{"a": [0.1, 0.1, 0.1]}] } }
+            ])"_json;
+
+    SUBCASE("Unknown atom") {
+        atoms.clear();
+        CHECK_THROWS_AS_MESSAGE(j.get<decltype(molecules)>(), std::runtime_error,
+                                "JSON->molecule B: unknown atom in atomic molecule");
+    }
+    SUBCASE("Construction") {
+        json ja = R"([{"a": {}}])"_json;
+        atoms = ja.get<decltype(atoms)>();
+        molecules = j.get<decltype(molecules)>(); // fill global instance
+
+        CHECK_EQ(molecules.size(), 2);
+        CHECK_EQ(molecules.front().id(), 0);
+        CHECK_EQ(molecules.front().name, "B"); // alphabetic order in std::map
+        CHECK_EQ(molecules.front().atomic, true);
+        CHECK_EQ(molecules.back().id(), 1);
+        CHECK_EQ(molecules.back().name, "A"); // alphabetic order in std::map
+        CHECK_EQ(molecules.back().atomic, false);
+
+        MoleculeData m = json(molecules.front()); // moldata --> json --> moldata
+
+        CHECK_EQ(m.name, "B");
+        CHECK_EQ(m.id(), 0);
+        CHECK_EQ(m.activity, Approx(0.2_molar));
+        CHECK_EQ(m.atomic, true);
+        //CHECK(m.insdir == Point(0.5, 0, 0));
+        //CHECK(m.insoffset == Point(-1.1, 0.5, 10));
+    }
+}
+
+TEST_CASE("[Faunus] MoleculeBuilder") {
+    atoms = R"([{"ALA": {}}, {"GLY": {}}, {"NTR": {}}, {"CTR": {}}])"_json.get<decltype(atoms)>();
+    auto j = R"(
+        {"peptide": { "excluded_neighbours": 2,
+        "structure": {"fasta": "nAAAAGGc", "k": 3, "req": 7},
+        "exclusionlist": [[3,6]],
+        "bondlist": [{"harmonic": {"index": [0, 7], "k": 3, "req": 7}}] }}
+    )"_json;
+
+    auto molecule = j.get<MoleculeData>();
+
+    REQUIRE_EQ(molecule.atoms.size(), 8);
+    REQUIRE_EQ(molecule.bonds.size(), 7 + 1);
+    CHECK(molecule.isPairExcluded(0, 1));
+    CHECK(molecule.isPairExcluded(0, 2));
+    CHECK_FALSE(molecule.isPairExcluded(0, 3));
+    CHECK(molecule.isPairExcluded(7, 5));
+    CHECK_FALSE(molecule.isPairExcluded(7, 4));
+    CHECK(molecule.isPairExcluded(3, 6));
+    CHECK(molecule.isPairExcluded(6, 3));
+    CHECK_FALSE(molecule.isPairExcluded(3, 7));
+    CHECK(molecule.isPairExcluded(7, 1));
+}
+
+TEST_CASE("[Faunus] Conformation") {
+    ParticleVector p(1);
+    Conformation c;
+    CHECK(c.empty());
+
+    c.positions.push_back({1, 2, 3});
+    c.charges.push_back(0.5);
+    CHECK(not c.empty());
+
+    c.toParticleVector(p);
+
+    CHECK(p[0].pos == Point(1, 2, 3));
+    CHECK(p[0].charge == 0.5);
+}
+
+TEST_CASE("[Faunus] ReactionData") {
+    using doctest::Approx;
+
+    json j = R"(
+            {
+                "atomlist" :
+                    [ {"a": { "r":1.1 } } ],
+                "moleculelist": [
+                    { "A": { "atomic":false, "activity":0.2 } },
+                    { "B": { "atomic":true, "atoms":["a"] } }
+                ],
+                "reactionlist": [
+                    {"A = B": {"lnK":-10.051, "canonic":true, "N":100 } }
+                ]
+            } )"_json;
+
+    Faunus::atoms = j["atomlist"].get<decltype(atoms)>();
+    molecules = j["moleculelist"].get<decltype(molecules)>(); // fill global instance
+
+    auto &r = reactions; // reference to global reaction list
+    r = j["reactionlist"].get<decltype(reactions)>();
+
+    CHECK(r.size() == 1);
+    CHECK(r.front().name == "A = B");
+    CHECK(r.front().lnK == Approx(-10.051 - std::log(0.2)));
+}
+
+TEST_SUITE_END();
+} // namespace Faunus

--- a/src/unittests.cpp
+++ b/src/unittests.cpp
@@ -18,6 +18,7 @@
 #include "bonds_test.h"
 #include "energy_test.h"
 #include "group_test.h"
+#include "molecule_test.h"
 #include "potentials_test.h"
 #include "space_test.h"
 #include "tensor_test.h"


### PR DESCRIPTION
# Description

- Two implementations are provided so far: ExclusionsSimple for testing and memory-optimized ExclusionsVicinity
- Introduce MoleculeBuilder to construct MoleculeData from JSON
- Change MoleculeInserter in MoleculeData from a function pointer to a class instance fully supporting JSON.
- Add NeighboursGenerator for excluded_neighbours option
- Add documentation for nonbonded interaction exclusions

Shall not be included in 2.3 release. Branched from #210, hence that pull request shall be merged first.
