### PR TITLE
Bondvector

### DIFF
--- a/src/bonds.cpp
+++ b/src/bonds.cpp
@@ -3,11 +3,16 @@
 
 namespace Faunus {
 namespace Potential {
-void to_json(Faunus::json &j, const std::shared_ptr<BondData> &b) {
+
+void to_json(Faunus::json &j, const std::shared_ptr<const BondData> &b) {
+    to_json(j, *b);
+}
+
+void to_json(Faunus::json &j, const BondData &b) {
     json val;
-    b->to_json(val);
-    val["index"] = b->index;
-    j = {{b->name(), val}};
+    b.to_json(val);
+    val["index"] = b.index;
+    j = {{b.name(), val}};
 }
 
 void from_json(const Faunus::json &j, std::shared_ptr<BondData> &b) {

--- a/src/bonds.h
+++ b/src/bonds.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "core.h"
+#include "auxiliary.h"
 #include "particle.h"
 
 namespace Faunus {
@@ -154,13 +155,15 @@ struct PeriodicDihedral : public BondData {
  * Serialize to/from json
  */
 
-void to_json(json &j, const std::shared_ptr<BondData> &b);
 void from_json(const json &j, std::shared_ptr<BondData> &b);
+void to_json(json &j, const std::shared_ptr<const BondData> &b);
+void to_json(Faunus::json &j, const BondData &b);
 
 void setBondEnergyFunction(std::shared_ptr<BondData> &b,
                            const ParticleVector &p); //!< Set the bond energy function of `BondData` which
                                                      //!< require a reference to the particle vector
 
+[[deprecated("Use bonds.find<TClass>() method instead.")]]
 inline auto filterBonds(const std::vector<std::shared_ptr<BondData>> &bonds, BondData::Variant bondtype) {
     std::vector<std::shared_ptr<BondData>> filt;
     filt.reserve(bonds.size());

--- a/src/bonds.h
+++ b/src/bonds.h
@@ -21,8 +21,6 @@ namespace Potential {
 struct BondData {
     enum Variant { HARMONIC = 0, FENE, FENEWCA, HARMONIC_TORSION, GROMOS_TORSION, PERIODIC_DIHEDRAL, NONE };
     std::vector<int> index;
-    bool exclude = false;           //!< True if exclusion of non-bonded interaction should be attempted
-    bool keepelectrostatics = true; //!< If `exclude==true`, try to keep electrostatic interactions
     std::function<double(Geometry::DistanceFunction)> energy = nullptr; //!< potential energy (kT)
 
     virtual void from_json(const json &) = 0;
@@ -38,12 +36,25 @@ struct BondData {
     virtual ~BondData() = default;
 };
 
+struct StretchData : public BondData {
+    int numindex() const override { return 2; }
+    StretchData() = default;
+    StretchData(const std::vector<int> &index) : BondData(index) {};
+};
+
+struct TorsionData : public BondData {
+    int numindex() const override { return 3; }
+    TorsionData() = default;
+    TorsionData(const std::vector<int> &index) : BondData(index) {};
+};
+
 /**
  * @brief Harmonic Bond
+ *
+ * U(r) = k/2 * (r - r_eq)^2
  */
-struct HarmonicBond : public BondData {
+struct HarmonicBond : public StretchData {
     double k_half = 0, req = 0;
-    int numindex() const override;
     Variant type() const override;
     std::shared_ptr<BondData> clone() const override;
     void from_json(const json &j) override;
@@ -56,35 +67,44 @@ struct HarmonicBond : public BondData {
 
 /**
  * @brief FENE bond
+ *
+ * U(r) = -k/2 * r_max^2 * ln(1 - r^2 / r_max^2) if r < r_max, ∞ otherwise
  */
-struct FENEBond : public BondData {
-    std::array<double, 4> k = {{0, 0, 0, 0}};
-    int numindex() const override;
+struct FENEBond : public StretchData {
+    double k_half = 0, rmax_squared = 0;
     Variant type() const override;
     std::shared_ptr<BondData> clone() const override;
     void from_json(const json &j) override;
     void to_json(json &j) const override;
     std::string name() const override;
     void setEnergyFunction(const ParticleVector &p);
-}; // end of FENE
+    FENEBond() = default;
+    FENEBond(double k, double rmax, const std::vector<int> &index);
+};
 
 /**
  * @brief FENE+WCA bond
  */
-struct FENEWCABond : public BondData {
+struct FENEWCABond : public StretchData {
+    double k_half = 0, rmax_squared = 0, epsilon = 0, sigma_squared = 0;
     std::array<double, 4> k = {{0, 0, 0, 0}};
-    int numindex() const override;
     Variant type() const override;
     std::shared_ptr<BondData> clone() const override;
     void from_json(const json &j) override;
     void to_json(json &j) const override;
     std::string name() const override;
     void setEnergyFunction(const ParticleVector &p);
-}; // end of FENE+WCA
+    FENEWCABond() = default;
+    FENEWCABond(double k, double rmax, double epsilon, double sigma, const std::vector<int> &index);
+};
 
-struct HarmonicTorsion : public BondData {
+/**
+ * @brief Harmonic torsion
+ *
+ * U(a) = k/2 * (a - a_eq)^2
+ */
+struct HarmonicTorsion : public TorsionData {
     double k_half = 0, aeq = 0;
-    int numindex() const override;
     std::shared_ptr<BondData> clone() const override;
     void from_json(const json &j) override;
     void to_json(json &j) const override;
@@ -93,11 +113,15 @@ struct HarmonicTorsion : public BondData {
     void setEnergyFunction(const ParticleVector &p);
     HarmonicTorsion() = default;
     HarmonicTorsion(double k, double aeq, const std::vector<int> &index);
-}; // end of HarmonicTorsion
+};
 
-struct GromosTorsion : public BondData {
+/**
+ * @brief Gromos torsion
+ *
+ * U(a) = k/2 * (cos(a) - cos(a_eq))^2
+ */
+struct GromosTorsion : public TorsionData {
     double k_half = 0, cos_aeq = 0;
-    int numindex() const override;
     std::shared_ptr<BondData> clone() const override;
     void from_json(const json &j) override;
     void to_json(json &j) const override;
@@ -106,8 +130,13 @@ struct GromosTorsion : public BondData {
     void setEnergyFunction(const ParticleVector &p);
     GromosTorsion() = default;
     GromosTorsion(double k, double cos_aeq, const std::vector<int> &index);
-}; // end of GromosTorsion
+};
 
+/**
+ * @brief Periodic dihedral
+ *
+ * U(a) = k * (1 + cos(n * a - phi))
+ */
 struct PeriodicDihedral : public BondData {
     double k = 0, phi = 0, n = 1;
     int numindex() const override;
@@ -119,7 +148,7 @@ struct PeriodicDihedral : public BondData {
     void setEnergyFunction(const ParticleVector &p);
     PeriodicDihedral() = default;
     PeriodicDihedral(double k, double phi, double n, const std::vector<int> &index);
-}; // end of PeriodicDihedral
+};
 
 /*
  * Serialize to/from json

--- a/src/bonds_test.h
+++ b/src/bonds_test.h
@@ -178,15 +178,14 @@ TEST_CASE("[Faunus] BondData") {
         }
     }
 
-    // test bond filter
-    SUBCASE("filterBonds()") {
-        std::vector<std::shared_ptr<BondData>> bonds = {
-            R"({"fene":      {"index":[2,3], "k":1, "rmax":2.1, "eps":2.48}} )"_json,
-            R"({"harmonic" : {"index":[2,3], "k":0.5, "req":2.1} } )"_json};
-        auto filt = filterBonds(bonds, BondData::HARMONIC);
-        CHECK(filt.size() == 1);
-        CHECK(filt[0]->type() == BondData::HARMONIC);
-        CHECK(filt[0] == bonds[1]); // filt should contain references to bonds
+    SUBCASE("Find") {
+        BasePointerVector<BondData> bonds;
+        bonds.emplace_back<FENEBond>(1.0, 2.1, std::vector<int>{2, 3});
+        bonds.emplace_back<HarmonicBond>(1.0, 2.1, std::vector<int>{2, 3});
+        auto harmonic_bonds = bonds.find<HarmonicBond>();
+        CHECK(harmonic_bonds.size() == 1);
+        CHECK(harmonic_bonds.front()->type() == BondData::HARMONIC);
+        CHECK(harmonic_bonds.front() == bonds.back()); // harmonic_bonds should contain references to bonds
     }
 }
 TEST_SUITE_END();

--- a/src/bonds_test.h
+++ b/src/bonds_test.h
@@ -33,41 +33,68 @@ TEST_CASE("[Faunus] BondData") {
             CHECK_EQ(bond.energy(distance), Approx(50));
         }
         SUBCASE("HarmonicBond JSON") {
-            json j = R"({ "harmonic": {"index":[1,2], "k":10.0, "req":2.0}} )"_json;
+            json j = R"({"harmonic": {"index":[1,2], "k":10.0, "req":2.0}})"_json;
             bond_ptr = j;
             CHECK_EQ(json(bond_ptr), j);
             std::dynamic_pointer_cast<HarmonicBond>(bond_ptr)->setEnergyFunction(p_60deg_4a);
             CHECK_EQ(bond_ptr->energy(distance), Approx(10.0_kJmol / 2 * 4));
         }
         SUBCASE("HarmonicBond JSON Invalid") {
-            CHECK_NOTHROW((R"({"harmonic": {"index":[0,9], "k":0.5, "req":2.1}} )"_json).get<BondDataPtr>());
-            CHECK_THROWS((R"({"harmoNIC": {"index":[2,3], "k":0.5, "req":2.1}} )"_json).get<BondDataPtr>()); // exact match required
-            CHECK_THROWS((R"({"harmonic": {"index":[2], "k":0.5, "req":2.1}} )"_json).get<BondDataPtr>());   // 2 atom indices
-            CHECK_THROWS((R"({"harmonic": {"index":[2,3], "req":2.1}} )"_json).get<BondDataPtr>()); // k missing
-            CHECK_THROWS((R"({"harmonic": {"index":[2,3], "k":2.1}} )"_json).get<BondDataPtr>());   // req missing
+            CHECK_NOTHROW((R"({"harmonic": {"index":[0,9], "k":0.5, "req":2.1}})"_json).get<BondDataPtr>());
+            CHECK_THROWS((R"({"harmoNIC": {"index":[2,3], "k":0.5, "req":2.1}})"_json).get<BondDataPtr>()); // exact match required
+            CHECK_THROWS((R"({"harmonic": {"index":[2], "k":0.5, "req":2.1}})"_json).get<BondDataPtr>());   // 2 atom indices
+            CHECK_THROWS((R"({"harmonic": {"index":[2,3], "req":2.1}})"_json).get<BondDataPtr>()); // k missing
+            CHECK_THROWS((R"({"harmonic": {"index":[2,3], "k":2.1}})"_json).get<BondDataPtr>());   // req missing
         }
     }
 
-    // test fene
     SUBCASE("FENEBond") {
-        json j = R"({"fene": { "index":[2,3], "k":1, "rmax":2.1 }} )"_json;
-        bond_ptr = j;
-        CHECK(j == json(bond_ptr));
-        CHECK_THROWS(bond_ptr = R"({"fene": { "index":[2,3,4], "k":1, "rmax":2.1}} )"_json);
-        CHECK_THROWS(bond_ptr = R"({"fene": { "index":[2,3], "rmax":2.1}} )"_json);
-        CHECK_THROWS(bond_ptr = R"({"fene": { "index":[2,3], "k":1}} )"_json);
+        SUBCASE("FENEBond Energy") {
+            FENEBond bond(100.0, 5.0, {0, 1});
+            bond.setEnergyFunction(p_4a);
+            CHECK_EQ(bond.energy(distance_5a), pc::infty);
+            CHECK_EQ(bond.energy(distance_3a), Approx(557.86));
+            CHECK_EQ(bond.energy(distance), Approx(1277.06));
+        }
+        SUBCASE("FENEBond JSON") {
+            json j = R"({"fene": {"index":[1,2], "k":8, "rmax":6.0 }})"_json;
+            bond_ptr = j;
+            CHECK_EQ(json(bond_ptr), j);
+            std::dynamic_pointer_cast<FENEBond>(bond_ptr)->setEnergyFunction(p_60deg_4a);
+            CHECK_EQ(bond_ptr->energy(distance), Approx(84.641_kJmol));
+        }
+        SUBCASE("FENEBond JSON Invalid") {
+            CHECK_NOTHROW((R"({"fene": {"index":[0,9], "k":0.5, "rmax":2.1}})"_json).get<BondDataPtr>());
+            CHECK_THROWS((R"({"FENE": {"index":[0,9], "k":0.5, "rmax":2.1}})"_json).get<BondDataPtr>());
+            CHECK_THROWS((R"({"fene": {"index":[2,3,4], "k":1, "rmax":2.1}})"_json).get<BondDataPtr>());
+            CHECK_THROWS((R"({"fene": {"index":[2,3], "rmax":2.1}})"_json).get<BondDataPtr>());
+            CHECK_THROWS((R"({"fene": {"index":[2,3], "k":1}})"_json).get<BondDataPtr>());
+        }
     }
 
-    // test fene+wca
     SUBCASE("FENEWCABond") {
-        json j = R"({"fene+wca": { "index":[2,3], "k":1, "rmax":2.1, "eps":2.48, "sigma":2}} )"_json;
-        bond_ptr = j;
-        CHECK(j == json(bond_ptr));
-        CHECK_THROWS(bond_ptr = R"({"fene+wca": { "index":[2,3,4], "k":1, "rmax":2.1, "eps":2.48, "sigma":2}} )"_json);
-        CHECK_THROWS(bond_ptr = R"({"fene+wca": { "index":[2,3], "rmax":2.1, "eps":2.48, "sigma":2}} )"_json);
-        CHECK_THROWS(bond_ptr = R"({"fene+wca": { "index":[2,3], "k":1, "eps":2.48, "sigma":2}} )"_json);
-        CHECK_THROWS(bond_ptr = R"({"fene+wca": { "index":[2,3], "k":1, "rmax":2.1, "eps":2.48}} )"_json);
-        CHECK_THROWS(bond_ptr = R"({"fene+wca": { "index":[2,3], "k":1, "rmax":2.1, "sigma":2}} )"_json);
+        SUBCASE("FENEWCABond Energy") {
+            FENEWCABond bond(100.0, 5.0, 20.0, 3.2, {0, 1});
+            bond.setEnergyFunction(p_4a);
+            CHECK_EQ(bond.energy(distance_5a), pc::infty);
+            CHECK_EQ(bond.energy(distance_3a), Approx(557.86 + 18.931));
+            CHECK_EQ(bond.energy(distance), Approx(1277.06));
+        }
+        SUBCASE("FENEWCABond JSON") {
+            json j = R"({"fene+wca": {"index":[1,2], "k":8, "rmax":6.0, "eps":3.5, "sigma":4.5}})"_json;
+            bond_ptr = j;
+            CHECK_EQ(json(bond_ptr), j);
+            std::dynamic_pointer_cast<FENEWCABond>(bond_ptr)->setEnergyFunction(p_60deg_4a);
+            CHECK_EQ(bond_ptr->energy(distance), Approx(92.805_kJmol));
+        }
+        SUBCASE("FENEWCABond JSON Invalid") {
+            CHECK_NOTHROW((R"({"fene+wca": {"index":[0,9], "k":1, "rmax":2.1, "eps":2.48, "sigma":2}})"_json).get<BondDataPtr>());
+            CHECK_THROWS((R"({"fene+wca": {"index":[2,3,4], "k":1, "rmax":2.1, "eps":2.48, "sigma":2}})"_json).get<BondDataPtr>());
+            CHECK_THROWS((R"({"fene+wca": {"index":[2,3], "rmax":2.1, "eps":2.48, "sigma":2}})"_json).get<BondDataPtr>());
+            CHECK_THROWS((R"({"fene+wca": {"index":[2,3], "k":1, "eps":2.48, "sigma":2}})"_json).get<BondDataPtr>());
+            CHECK_THROWS((R"({"fene+wca": {"index":[2,3], "k":1, "rmax":2.1, "eps":2.48}})"_json).get<BondDataPtr>());
+            CHECK_THROWS((R"({"fene+wca": {"index":[2,3], "k":1, "rmax":2.1, "sigma":2}})"_json).get<BondDataPtr>());
+        }
     }
 
     SUBCASE("HarmonicTorsion") {
@@ -77,17 +104,17 @@ TEST_CASE("[Faunus] BondData") {
             CHECK_EQ(bond.energy(distance), Approx(100.0 / 2 * std::pow(15.0_deg, 2)));
         }
         SUBCASE("HarmonicTorsion JSON") {
-            json j = R"({ "harmonic_torsion": {"index":[0,1,2], "k":0.5, "aeq":65}} )"_json;
+            json j = R"({"harmonic_torsion": {"index":[0,1,2], "k":0.5, "aeq":65}})"_json;
             bond_ptr = j;
             CHECK_EQ(json(bond_ptr), j);
             std::dynamic_pointer_cast<HarmonicTorsion>(bond_ptr)->setEnergyFunction(p_60deg_4a);
             CHECK_EQ(bond_ptr->energy(distance), Approx(0.5_kJmol / 2 * std::pow(5.0_deg, 2)));
         }
         SUBCASE("HarmonicTorsion JSON Invalid") {
-            CHECK_NOTHROW((R"({"harmonic_torsion": { "index":[0,1,9], "k":0.5, "aeq":30.5}} )"_json).get<BondDataPtr>());
-            CHECK_THROWS((R"({"harmonic_torsion": { "index":[2], "k":0.5, "aeq":30.5}} )"_json).get<BondDataPtr>());
-            CHECK_THROWS((R"({"harmonic_torsion": { "index":[0,1,2], "aeq":30.5}} )"_json).get<BondDataPtr>());
-            CHECK_THROWS((R"({"harmonic_torsion": { "index":[0,1,3], "k":0.5}} )"_json).get<BondDataPtr>());
+            CHECK_NOTHROW((R"({"harmonic_torsion": {"index":[0,1,9], "k":0.5, "aeq":30.5}})"_json).get<BondDataPtr>());
+            CHECK_THROWS((R"({"harmonic_torsion": {"index":[2], "k":0.5, "aeq":30.5}})"_json).get<BondDataPtr>());
+            CHECK_THROWS((R"({"harmonic_torsion": {"index":[0,1,2], "aeq":30.5}})"_json).get<BondDataPtr>());
+            CHECK_THROWS((R"({"harmonic_torsion": {"index":[0,1,3], "k":0.5}})"_json).get<BondDataPtr>());
         }
     }
 
@@ -98,17 +125,17 @@ TEST_CASE("[Faunus] BondData") {
             CHECK_EQ(bond.energy(distance), Approx(100.0 / 2 * std::pow(cos(60.0_deg) - cos(45.0_deg), 2)));
         }
         SUBCASE("GromosTorsion JSON") {
-            json j = R"({ "gromos_torsion": {"index":[0,1,2], "k":0.5, "aeq":65}} )"_json;
+            json j = R"({"gromos_torsion": {"index":[0,1,2], "k":0.5, "aeq":65}})"_json;
             bond_ptr = j;
             CHECK_EQ(json(bond_ptr), j);
             std::dynamic_pointer_cast<GromosTorsion>(bond_ptr)->setEnergyFunction(p_60deg_4a);
             CHECK_EQ(bond_ptr->energy(distance), Approx(0.5_kJmol / 2 * std::pow(cos(60.0_deg) - cos(65.0_deg), 2)));
         }
         SUBCASE("GromosTorsion JSON Invalid") {
-            CHECK_NOTHROW((R"({"gromos_torsion": { "index":[0,1,9], "k":0.5, "aeq":30.5}} )"_json).get<BondDataPtr>());
-            CHECK_THROWS((R"({"gromos_torsion": { "index":[2], "k":0.5, "aeq":30.5}} )"_json).get<BondDataPtr>());
-            CHECK_THROWS((R"({"gromos_torsion": { "index":[0,1,2], "aeq":30.5}} )"_json).get<BondDataPtr>());
-            CHECK_THROWS((R"({"gromos_torsion": { "index":[0,1,3], "k":0.5}} )"_json).get<BondDataPtr>());
+            CHECK_NOTHROW((R"({"gromos_torsion": {"index":[0,1,9], "k":0.5, "aeq":30.5}})"_json).get<BondDataPtr>());
+            CHECK_THROWS((R"({"gromos_torsion": {"index":[2], "k":0.5, "aeq":30.5}})"_json).get<BondDataPtr>());
+            CHECK_THROWS((R"({"gromos_torsion": {"index":[0,1,2], "aeq":30.5}})"_json).get<BondDataPtr>());
+            CHECK_THROWS((R"({"gromos_torsion": {"index":[0,1,3], "k":0.5}})"_json).get<BondDataPtr>());
         }
     }
 
@@ -136,18 +163,18 @@ TEST_CASE("[Faunus] BondData") {
             CHECK_EQ(bond.energy(distance), Approx(100.0));
         }
         SUBCASE("PeriodicDihedral JSON") {
-            json j = R"({"periodic_dihedral": { "index":[0,1,2,3], "k":10, "phi":0.0, "n": 3}} )"_json;
+            json j = R"({"periodic_dihedral": {"index":[0,1,2,3], "k":10, "phi":0.0, "n": 3}})"_json;
             bond_ptr = j;
             CHECK_EQ(json(bond_ptr), j);
             std::dynamic_pointer_cast<PeriodicDihedral>(bond_ptr)->setEnergyFunction(p_90deg);
             CHECK_EQ(bond_ptr->energy(distance), Approx(10.0_kJmol));
         }
         SUBCASE("PeriodicDihedral JSON Invalid") {
-            CHECK_NOTHROW((R"({"periodic_dihedral": { "index":[0,1,2,9], "k":0.5, "phi":2.1, "n": 2}} )"_json).get<BondDataPtr>());
-            CHECK_THROWS((R"({"periodic_dihedral": { "index":[0,1,2], "k":0.5, "phi":2.1, "n": 2}} )"_json).get<BondDataPtr>());
-            CHECK_THROWS((R"({"periodic_dihedral": { "index":[0,1,2,3], "phi":2.1, "n": 2}} )"_json).get<BondDataPtr>());
-            CHECK_THROWS((R"({"periodic_dihedral": { "index":[0,1,2,3], "k":0.5, "n": 2}} )"_json).get<BondDataPtr>());
-            CHECK_THROWS((R"({"periodic_dihedral": { "index":[0,1,2,3], "k":0.5, "phi":2.1}} )"_json).get<BondDataPtr>());
+            CHECK_NOTHROW((R"({"periodic_dihedral": {"index":[0,1,2,9], "k":0.5, "phi":2.1, "n": 2}})"_json).get<BondDataPtr>());
+            CHECK_THROWS((R"({"periodic_dihedral": {"index":[0,1,2], "k":0.5, "phi":2.1, "n": 2}})"_json).get<BondDataPtr>());
+            CHECK_THROWS((R"({"periodic_dihedral": {"index":[0,1,2,3], "phi":2.1, "n": 2}})"_json).get<BondDataPtr>());
+            CHECK_THROWS((R"({"periodic_dihedral": {"index":[0,1,2,3], "k":0.5, "n": 2}})"_json).get<BondDataPtr>());
+            CHECK_THROWS((R"({"periodic_dihedral": {"index":[0,1,2,3], "k":0.5, "phi":2.1}})"_json).get<BondDataPtr>());
         }
     }
 

--- a/src/chainmove.cpp
+++ b/src/chainmove.cpp
@@ -146,7 +146,7 @@ size_t CrankshaftMove::select_segment() {
 PivotMove::PivotMove(Space &spc) : ChainRotationMove(spc) { this->name = "pivot"; }
 void PivotMove::_from_json(const json &j) {
     Tbase::_from_json(j);
-    bonds = Potential::filterBonds(molecules[this->molid].bonds, Potential::BondData::HARMONIC);
+    bonds = molecules[this->molid].bonds.find<Potential::HarmonicBond>();
 
     if (this->repeat < 0) {
         // set the number of repetitions to the length of the chain (minus 2) times the number of the chains

--- a/src/chainmove.h
+++ b/src/chainmove.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "move.h"
+#include "bonds.h"
 
 namespace Faunus {
 namespace Move {
@@ -111,7 +112,7 @@ class PivotMove : public ChainRotationMove {
     using Tbase = ChainRotationMove;
 
   private:
-    std::vector<std::shared_ptr<Potential::BondData>> bonds;
+    BasePointerVector<Potential::HarmonicBond> bonds;
 
   public:
     explicit PivotMove(Space &spc);

--- a/src/energy.cpp
+++ b/src/energy.cpp
@@ -277,7 +277,7 @@ void Bonded::update_intra() {
     for (size_t i = 0; i < spc.groups.size(); i++) {
         auto &group = spc.groups.at(i);
         for (auto &bond : molecules.at(group.id).bonds) {
-            intra[i].push_back(bond->clone()); // deep copy BondData from MoleculeData
+            intra[i].push_back<BondData>(bond->clone()); // deep copy BondData from MoleculeData
             intra[i].back()->shift(std::distance(spc.p.begin(), group.begin()));
             Potential::setBondEnergyFunction(intra[i].back(), spc.p);
         }

--- a/src/energy.h
+++ b/src/energy.h
@@ -352,7 +352,7 @@ class Constrain : public Energybase {
 class Bonded : public Energybase {
   private:
     Space &spc;
-    typedef std::vector<std::shared_ptr<Potential::BondData>> BondVector;
+    typedef BasePointerVector<Potential::BondData> BondVector;
     BondVector inter;                // inter-molecular bonds
     std::map<int, BondVector> intra; // intra-molecular bonds
 

--- a/src/molecule.h
+++ b/src/molecule.h
@@ -2,6 +2,7 @@
 
 #include <set>
 #include "core.h"
+#include "auxiliary.h"
 #include "particle.h"
 #include "random.h"
 #include "spdlog/spdlog.h"
@@ -192,12 +193,12 @@ class MoleculeData {
     double activity = 0.0;       //!< Chemical activity (mol/l)
 
     std::vector<int> atoms;                    //!< Sequence of atoms in molecule (atom id's)
-    std::vector<std::shared_ptr<Potential::BondData>> bonds;
+    BasePointerVector<Potential::BondData> bonds;
     WeightedDistribution<ParticleVector> conformations; //!< Conformations of molecule
 
     MoleculeData();
     MoleculeData(const std::string &name, ParticleVector particles,
-                 const std::vector<std::shared_ptr<Potential::BondData>> &bonds);
+                 const BasePointerVector<Potential::BondData> &bonds);
 
     bool isPairExcluded(int i, int j);
 
@@ -281,18 +282,19 @@ class MoleculeStructureReader {
 };
 
 /**
- * @brief Generate all possible atom pairs within a given bond distance. Only harmonic bonds are considered.
+ * @brief Generate all possible atom pairs within a given bond distance. Only 1-2 bonds (e.g., harmonic or FENE)
+ * are considered.
  *
  * @internal Used by MoleculeBuilder only to generate exclusions from excluded neighbours count.
  */
 class NeighboursGenerator {
-    //! a path created from harmonic bonds as an ordered list of atoms involved;
+    //! a path created from 1-2 bonds (e.g., harmonic or FENE) as an ordered list of atoms involved;
     //! atoms are addressed by intramolecular indices
     typedef std::vector<int> AtomList;
-    //! atom → list of directly bonded atoms with a harmonic bond; addressing by indices
+    //! atom → list of directly bonded atoms with a 1-2 bond; addressing by indices
     std::map<int, AtomList> bond_map;
     //! paths indexed by a path length (starting with a zero distance for a single atom)
-    //! a path is a sequence (without loops) of atoms connected by a harmonic bond,
+    //! a path is a sequence (without loops) of atoms connected by a 1-2 bond,
     std::vector<std::set<AtomList>> paths;
 
     typedef decltype(MoleculeData::bonds) BondVector;
@@ -307,7 +309,7 @@ class NeighboursGenerator {
     /**
      * Append all atom pairs within a given bond distance to the pair list.
      * @param pairs atom pair list
-     * @param bond_distance maximal number of harmonic bonds between atoms to consider
+     * @param bond_distance maximal number of 1-2 bonds between atoms to consider
      */
     void generatePairs(AtomPairList &pairs, int bond_distance);
 };


### PR DESCRIPTION
# Description
Refactor `BondData` vector to use `BasePointerVector`

- The excluded_neighbour generator now takes into account any 1-2 bond, not only harmonic ones.
- Add unit tests for FENE and FENEWCA bonds.

Includes also PR #211 to allow subsequent merging.