### PR TITLE
Corrections in docs and mol_cm key in MultipoleMoments

### DIFF
--- a/docs/_docs/analysis.md
+++ b/docs/_docs/analysis.md
@@ -191,7 +191,7 @@ where $\bf{t_i} = \bf{r_i} - \bf{cm}$, $\bf{r_i}$ is the coordinate of the $i$th
 position of the mass center of the whole group of atoms, $m_i$ is the molecular weight of the $i$th particle,
 $\bf{I}$ is the identity matrix and $N$ is the number of atoms.
 
-`gyration`       | Description
+`atominertia`    | Description
 ---------------- | ----------------------------------------
 `nstep`          | Interval with which to sample
 `indexes`        | Array defining a range of indexes within the molecule 
@@ -236,11 +236,12 @@ position of the mass center of the whole group of atoms, $q_i$ is the charge of 
 $\bf{I}$ is the identity matrix and $N$ is the number of atoms.
 
 
-`gyration`       | Description
----------------- | ----------------------------------------
-`nstep`          | Interval with which to sample
-`indexes`        | Array defining a range of indexes within the molecule 
-`index`          | Index of the molecular group
+`multipolemoments`  | Description
+------------------- | -------------------------------------
+`nstep`             | Interval with which to sample
+`indexes`           | Array defining a range of indexes within the molecule 
+`index`             | Index of the molecular group
+`mol_cm=true`       | Moments w.r.t. the mass center of the whole molecule (instead of the subgroup)
 
 ### Electric Multipole Distribution
 

--- a/docs/_docs/energy.md
+++ b/docs/_docs/energy.md
@@ -866,9 +866,9 @@ $\bf{r}$ is the position vector
 - `L/R` can be used to calculate the bending modulus of a cylindrical lipid vesicle
 - `Rg` is calculated as the square-root of the sum of the eigenvalues of the gyration tensor, $S$. 
 $$
-S = \frac{1}{N} \sum_{i=1}^{N} \bf{t_i} \bf{t_i^T}
+S = \frac{1}{\sum_{i=1}^{N} m_{i}} \sum_{i=1}^{N} m_{i} \bf{t_i} \bf{t_i^T}
 $$
-where $\bf{t_i} = \bf{r_i} - \bf{cm}$, $\bf{r_i}$ is the coordinate of the $i$th atom, $\bf{cm}$ is the
+where $\bf{t_i} = \bf{r_i} - \bf{cm}$, $\bf{r_i}$ is the coordinate of the $i$th atom, $m_i$ is the mass of the $i$th atom, $\bf{cm}$ is the
 mass center of the group and $N$ is the number of atoms in the molecule.
 
 #### System Properties

--- a/src/analysis.cpp
+++ b/src/analysis.cpp
@@ -974,6 +974,8 @@ void MultipoleMoments::_to_json(json &j) const {
 MultipoleMoments::Data MultipoleMoments::compute() {
     Space::Tgroup g(spc.groups[index].begin()+indexes[0], spc.groups[index].begin()+indexes[1]+1);
     auto cm = spc.groups[index].cm;
+    if (not mol_cm)
+        cm = Geometry::massCenter(g.begin(), g.end(), spc.geo.getBoundaryFunc());
     MultipoleMoments::Data d;
     Tensor S; // quadrupole tensor
     S.setZero();
@@ -990,12 +992,13 @@ MultipoleMoments::Data MultipoleMoments::compute() {
     std::ptrdiff_t i_eival;
     d.eivals.minCoeff(&i_eival);
     d.eivec = esf.eigenvectors().col(i_eival).real(); // eigenvector corresponding to the smallest eigenvalue
+    d.center = cm;
     return d;
 }
 void MultipoleMoments::_sample() {
     MultipoleMoments::Data d = compute();
     if (file) 
-        file << cnt * steps << " " << d.q << " " << d.mu.transpose() << " " 
+        file << cnt * steps << " " << d.q << " " << d.mu.transpose() << " " << d.center.transpose() << " "
              << d.eivals.transpose() << " " << d.eivec.transpose() << "\n";
 }
 MultipoleMoments::MultipoleMoments(const json &j, Space &spc) : spc(spc) {
@@ -1005,6 +1008,7 @@ MultipoleMoments::MultipoleMoments(const json &j, Space &spc) : spc(spc) {
     file.open(filename); // output file
     index = j.at("index").get<size_t>(); // group index
     indexes = j.value("indexes", std::vector<size_t>({0, spc.groups[index].size()-1})); // whole molecule by default
+    mol_cm = j.value("mol_cm", true); // use the mass center of the whole molecule
 }
 
 // =============== PolymerShape ===============

--- a/src/analysis.h
+++ b/src/analysis.h
@@ -448,11 +448,12 @@ class MultipoleMoments : public Analysisbase {
     std::string filename;
     std::vector<size_t> indexes; // range of indexes within the group
     size_t index; // group index
+    bool mol_cm;
     std::ofstream file;
     struct Data {
         int q = 0; // total charge
         Point mu {0,0,0}; // dipole vector
-        Point eivals, eivec; // quadrupole eigenvalues and major axis
+        Point eivals, eivec, center; // quadrupole eigenvalues and major axis
     };
 
     Data compute();


### PR DESCRIPTION
# Description

Corrections in MultipoleMoments & Reaction coordinate docs.
Added mol_cm key in MultipoleMoments to control whether to calculate the dipole moment and quadrupole tensor w.r.t. the center of mass of the subgroup (mol_cm=false) or of the whole molecule (mol_cm=true).

## Checklist

- [x] `make test` passes with no errors
- [x] the source code is well documented
- [ ] new functionality includes unittests
- [x] the user-manual has been updated to reflect the changes
- [ ] I have installed the provided commit hook to auto-format commits (requires `clang-format`):

  ``` bash
  ./scripts/git-pre-commit-format install
  ```

- [x] code naming scheme follows the convention:

  Style        | Elements
  ------------ | ---------------------
  `PascalCase` | classes, namespaces
  `camelCase`  | functions
  `snake_case` | variables
