### PR TITLE
Add output file for Virtual Volume Move

### DIFF
--- a/src/analysis.cpp
+++ b/src/analysis.cpp
@@ -289,7 +289,7 @@ void VirtualVolume::_sample() {
 #endif
             // write excess pressure to output file
             if (f)
-                f << cnt << " " << -std::log(x) / (dV * 1.0_mM) << "\n";
+                f << cnt << " " << dV << " " << du << " " << x  << "\n";
         }
     }
 }
@@ -301,6 +301,8 @@ void VirtualVolume::_from_json(const json &j) {
         if (f)
             f.close();
         f.open(file);
+        f << "# steps dV/"+ u8::angstrom + u8::cubed + " du/kT exp(-du/kT)" << "\n";
+        f.precision(14);
         if (!f)
             throw std::runtime_error(name + ": cannot open output file " + file);
     }


### PR DESCRIPTION
# Description

Please edit this text to include a summary of the change and which issue is fixed.

## Checklist

- [x] `make test` passes with no errors
- [x] the source code is well documented
- [ ] new functionality includes unittests
- [X] the user-manual has been updated to reflect the changes
- [ ] I have installed the provided commit hook to auto-format commits (requires `clang-format`):

  ``` bash
  ./scripts/git-pre-commit-format install
  ```

- [ ] code naming scheme follows the convention:

  Style        | Elements
  ------------ | ---------------------
  `PascalCase` | classes, namespaces
  `camelCase`  | functions
  `snake_case` | variables
