### PR TITLE
AtomData JSON output and cleanup

### DIFF
--- a/docs/_docs/energy.md
+++ b/docs/_docs/energy.md
@@ -408,20 +408,20 @@ as shown in the example bellow.
 - lennardjones:
     mixing: LB
     custom:
-      Na Cl: {eps: 0.2, sigma: 2}
-      K Cl: { ... }
+      - Na Cl: {eps: 0.2, sigma: 2}
+      - K Cl: { ... }
 
 - hertz:
     mixing: LB
     eps: eps_hz
     custom:
-      Na Cl: {eps_hz: 0.2, sigma: 2}
+      - Na Cl: {eps_hz: 0.2, sigma: 2}
 
 - hardsphere:
     mixing: arithmetic
     sigma: sigma_hs
     custom:
-      Na Cl: {sigma_hs: 2}
+      - Na Cl: {sigma_hs: 2}
 ~~~
 
 ### SASA (pair potential)

--- a/examples/fasta-titration.yml
+++ b/examples/fasta-titration.yml
@@ -94,13 +94,13 @@ energy:
                 # custom parameters to match bulk electrolyte
                 # activity coefficient measurements. Valid
                 # for LJ potential + Coulomb potential.
-                "na cl" :  {sigma: 4.6,  eps: 0.01}
-                "na GLU":  {sigma: 5.25, eps: 0.01}
-                "na ASP":  {sigma: 5.25, eps: 0.01}
-                "na CTR":  {sigma: 5.25, eps: 0.01}
-                "cl HNTR": {sigma: 4.7,  eps: 0.01}
-                "cl HLYS": {sigma: 4.7,  eps: 0.01}
-                "cl HARG": {sigma: 3.5,  eps: 0.01}
+                - "na cl" :  {sigma: 4.6,  eps: 0.01}
+                - "na GLU":  {sigma: 5.25, eps: 0.01}
+                - "na ASP":  {sigma: 5.25, eps: 0.01}
+                - "na CTR":  {sigma: 5.25, eps: 0.01}
+                - "cl HNTR": {sigma: 4.7,  eps: 0.01}
+                - "cl HLYS": {sigma: 4.7,  eps: 0.01}
+                - "cl HARG": {sigma: 3.5,  eps: 0.01}
         coulomb: {epsr: 80, type: yukawa, debyelength: {{ debyelength }}, cutoff: 30}
 moves:
     - rcmc:  {}

--- a/examples/membrane/membrane.yml
+++ b/examples/membrane/membrane.yml
@@ -32,18 +32,18 @@ energy:
             - wca:
                 mixing: LB
                 custom:
-                    TL TL: {sigma: 9, eps: 2.2525}
+                    - TL TL: {sigma: 9, eps: 2.2525}
             - cos2: {rc: 10.1021, eps: 2.2525, wc: 14.4}
         HD TL:
             - wca:
                 mixing: LB
                 custom:
-                    HD TL: {sigma: 9, eps: 2.2525}
+                    - HD TL: {sigma: 9, eps: 2.2525}
         HD HD:
             - wca:
                 mixing: LB
                 custom:
-                    HD HD: {sigma: 8.55, eps: 2.2525}
+                    - HD HD: {sigma: 8.55, eps: 2.2525}
 moves:
     - moltransrot: {molecule: lipid, dp: 1.0, dprot: 0.5, repeat: 100}
     - transrot: {molecule: lipid, repeat: 100}

--- a/src/atomdata_test.h
+++ b/src/atomdata_test.h
@@ -22,11 +22,11 @@ TEST_CASE("[Faunus] AtomData") {
     CHECK_EQ(v.size(), 2);
     CHECK_EQ(v.front().id(), 0);
     CHECK_EQ(v.front().name, "A");                             // alphabetic order in std::map
-    CHECK(v.front().getProperty("sigma") == Approx(2.5));      // raw number, no units
-    CHECK(v.front().getProperty("eps_custom") == Approx(0.1)); // raw number, no units
+    CHECK(v.front().interaction.get("sigma") == Approx(2.5));      // raw number, no units
+    CHECK(v.front().interaction.get("eps_custom") == Approx(0.1)); // raw number, no units
 
-    CHECK_EQ(std::isnan(v.front().getProperty("eps_unknown")), true);
-    // CHECK_THROWS_AS_MESSAGE(v.front().getProperty("eps_unknown"), std::runtime_error, "unknown atom property");
+    CHECK_EQ(std::isnan(v.front().interaction.get("eps_unknown")), true);
+    // CHECK_THROWS_AS_MESSAGE(v.front().interaction.get("eps_unknown"), std::runtime_error, "unknown atom property");
     CHECK(v.front().sigma == Approx(2.5e-10_m));
     CHECK(v.front().activity == Approx(0.01_molar));
     CHECK(v.back().tfe == Approx(0.98_kJmol / (1.0_angstrom * 1.0_angstrom * 1.0_molar)));
@@ -36,8 +36,8 @@ TEST_CASE("[Faunus] AtomData") {
     CHECK_EQ(a.name, "B");
     CHECK_EQ(a.id(), 1);
     CHECK(a.activity == Approx(0.2_molar));
-    CHECK(a.getProperty("sigma") == Approx(2.2)); // raw number, no units
-    CHECK(a.getProperty("eps") == Approx(0.05));  // raw number, no units
+    CHECK(a.interaction.get("sigma") == Approx(2.2)); // raw number, no units
+    CHECK(a.interaction.get("eps") == Approx(0.05));  // raw number, no units
     CHECK(a.dp == Approx(9.8));
     CHECK(a.dprot == Approx(3.14));
     CHECK(a.mw == Approx(1.1));

--- a/src/geometry.cpp
+++ b/src/geometry.cpp
@@ -581,7 +581,10 @@ void from_json(const json &j, Chameleon &g) {
 
 void to_json(json &j, const Chameleon &g) { g.to_json(j); }
 
-Chameleon::Chameleon(const Variant type) { makeGeometry(type); }
+Chameleon::Chameleon(const Variant type) {
+    makeGeometry(type);
+    _setLength(geometry->getLength());
+}
 
 Chameleon::Chameleon(const GeometryImplementation &geo, const Variant type) : geometry(geo.clone()), _type(type) {
     _setLength(geometry->getLength());

--- a/src/geometry.h
+++ b/src/geometry.h
@@ -397,10 +397,6 @@ inline Point Chameleon::vdist(const Point &a, const Point &b) const {
             else if (distance.z() < -len_half.z())
                 distance.z() += len.z();
         }
-    } else if (boundary_conditions.coordinates == ORTHOHEXAGONAL ||
-               boundary_conditions.coordinates == TRUNC_OCTAHEDRAL) {
-        distance = a - b;
-        boundary(distance);
     } else {
         distance = geometry->vdist(a, b);
     }

--- a/src/molecule.cpp
+++ b/src/molecule.cpp
@@ -581,22 +581,23 @@ void RandomInserter::to_json(json &j) const {
 }
 
 bool Conformation::empty() const {
-    if (positions.empty())
-        if (charges.empty())
-            return true;
-    return false;
+    return positions.empty() && charges.empty();
 }
 
 ParticleVector &Conformation::toParticleVector(ParticleVector &p) const {
     assert(not p.empty() and not empty());
     // copy positions
-    if (positions.size() == p.size())
-        for (int i = 0; i < p.size(); i++)
+    if (positions.size() == p.size()) {
+        for (size_t i = 0; i < p.size(); ++i) {
             p[i].pos = positions[i];
+        }
+    }
     // copy charges
-    if (charges.size() == p.size())
-        for (int i = 0; i < p.size(); i++)
+    if (charges.size() == p.size()) {
+        for (size_t i = 0; i < p.size(); ++i) {
             p[i].charge = charges[i];
+        }
+    }
     return p;
 }
 
@@ -616,12 +617,11 @@ std::vector<int> ReactionData::participatingMolecules() const {
         v.push_back(i.first);
     return v;
 }
+
 bool ReactionData::containsMolecule(int molid) const {
-    if (_reagid_m.count(molid) == 0)
-        if (_prodid_m.count(molid) == 0)
-            return false;
-    return true;
+    return _reagid_m.count(molid) > 0 || _prodid_m.count(molid) > 0;
 }
+
 const ReactionData::Tmap &ReactionData::Molecules2Add(bool forward) const { return (forward) ? _prodid_m : _reagid_m; }
 const ReactionData::Tmap &ReactionData::Atoms2Add(bool forward) const { return (forward) ? _prodid_a : _reagid_a; }
 
@@ -633,7 +633,7 @@ void from_json(const json &j, ReactionData &a) {
     for (auto &m : Faunus::molecules)
         for (auto &a : Faunus::atoms)
             if (m.name == a.name)
-                throw std::runtime_error("Molecules and atoms nust have different names");
+                throw std::runtime_error("Molecules and atoms must have different names");
 
     for (auto it = j.begin(); it != j.end(); ++it) {
         a.name = it.key();

--- a/src/pyfaunus.cpp
+++ b/src/pyfaunus.cpp
@@ -173,10 +173,10 @@ PYBIND11_MODULE(pyfaunus, m)
     // AtomData
     py::class_<AtomData>(m, "AtomData")
         .def(py::init<>())
-        .def_property("eps", [](const AtomData &a) { return a.getProperty("eps"); },
-                      [](AtomData &a, double val) { a.getProperty("eps") = val; })
-        .def_property("sigma", [](const AtomData &a) { return a.getProperty("sigma"); },
-                      [](AtomData &a, double val) { a.getProperty("sigma") = val; })
+        .def_property("eps", [](const AtomData &a) { return a.interaction.get("eps"); },
+                      [](AtomData &a, double val) { a.interaction.get("eps") = val; })
+        .def_property("sigma", [](const AtomData &a) { return a.interaction.get("sigma"); },
+                      [](AtomData &a, double val) { a.interaction.get("sigma") = val; })
         .def_readwrite("name", &AtomData::name)
         .def_readwrite("activity", &AtomData::activity, "Activity = chemical potential in log scale (mol/l)")
         .def("id", (const int& (AtomData::*)() const) &AtomData::id); // explicit signature due to overload in c++


### PR DESCRIPTION
# Description

- Separate atom interaction parameters into a container to allow a clean JSON export (fix #159). Canonical form of the custom parameters list is an array, however a plain object is also accepted.
- Speed-up `Chameleon::vdist()` by decreasing its size to allow inlining; an unnecessary call of another inlined function is removed.
- Random cleanup in `molecule.cpp`.
