### PR TITLE
Minor changes in docs and in ConformationSwap

### DIFF
--- a/docs/_docs/analysis.md
+++ b/docs/_docs/analysis.md
@@ -204,7 +204,7 @@ where $\bf{t_i} = \bf{r_i} - \bf{cm}$, $\bf{r_i}$ is the coordinate of the $i$th
 position of the mass center of the whole group of atoms, $m_i$ is the molecular weight of the $i$th particle, 
 $\bf{I}$ is the identity matrix and $N$ is the number of atoms.
 
-`gyration`       | Description
+`atominertia`       | Description
 ---------------- | ----------------------------------------
 `nstep`          | Interval with which to sample
 `index`          | Particle id
@@ -225,7 +225,7 @@ where $\bf{t_i} = \bf{r_i} - \bf{cm}$, $\bf{r_i}$ is the coordinate of the $i$th
 position of the mass center of the whole group of atoms, $m_i$ is the molecular weight of the $i$th particle,
 $\bf{I}$ is the identity matrix and $N$ is the number of atoms.
 
-`atominertia`    | Description
+`inertia`    | Description
 ---------------- | ----------------------------------------
 `nstep`          | Interval with which to sample
 `indexes`        | Array defining a range of indexes within the molecule 

--- a/docs/_docs/energy.md
+++ b/docs/_docs/energy.md
@@ -827,7 +827,7 @@ follow the order of insertion specified in `insertmolecules`.
 General keywords  | Description 
 ----------------- | -------------------------------------------------------------------
 `index`           | Atom index, atom id or group index
-`indexes`         | Array of atomic indexes
+`indexes`         | Array of atomic indexes (`[a,b]` or `[a,b,c,d]`)
 `range`           | Array w. [min:max] value
 `resolution`      | Resolution along the coordinate (Å)
 `dir`             | Axes of the reaction coordinate, $e.g.$, `[1,1,0]` for the $xy$-plane  
@@ -856,7 +856,7 @@ General keywords  | Description
 `N`                         | Number of atoms in group
 `Q`                         | Monopole moment (net charge)
 `atomatom`                  | Distance along `dir` between 2 atoms specified by the `indexes` array
-`cmcm`                      | Absolute mass-center separation between groups `indexes[0:1]` or atomic `indexes[0:1]` and `indexes[2:3]`
+`cmcm`                      | Absolute mass-center separation between group indexes `a` and `b` or atomic indexes `a`–`b` and `c`–`d`
 `cmcm_z`                    | $z$-component of `cmcm`
 `mindist`                   | Minimum distance between particles of id `indexes[0]` and `indexes[1]`
 `L/R`                       | Ratio between height and radius of a cylindrical vesicle

--- a/docs/_docs/moves.md
+++ b/docs/_docs/moves.md
@@ -50,6 +50,7 @@ and if `dir=[0,0,1]` on a line (here $z$).
 ---------------- |  ---------------------------------
 `molecule`       |  Molecule name to operate on
 `dir=[1,1,1]`    |  Translational directions
+`dirrot=[0,0,0]` |  Predefined axis of rotation
 `dp`             |  Translational displacement parameter
 `dprot`          |  Rotational displacement parameter (radians)
 `repeat=N`       |  Number of repeats per MC sweep. `N` equals $N\_{molid}$ times.
@@ -64,8 +65,9 @@ where $\mbox{Rot}$ rotates `dprot`$\cdot \left (\zeta-\frac{1}{2} \right )$ radi
 emanating from the mass center,
 $\zeta$ is a random number in the interval $[0,1[$, and
 $\delta$ is a random unit vector scaled by a random number in the interval `[0,dp]`.
-Upon MC movement, the mean squared displacement
-will be tracked.
+A predefined axis of rotation can be specified as `dirrot`. For example, setting `dirrot` to [1,0,0], [0,1,0] or [0,0,1] 
+results in rotations about the $x-$, $y-$, and $z-$axis, respectively.
+Upon MC movement, the mean squared displacement will be tracked.
 
 
 ### Atomic
@@ -83,15 +85,16 @@ Atomic _rotation_ affects only anisotropic particles such as dipoles, spherocyli
 
 ### Cluster Move
 
-`cluster`      | Description
--------------- | -----------------------
-`molecules`    | Array of molecule names; `[*]` selects all
-`threshold`    | Mass-center threshold for forming a cluster
-`dir=[1,1,1]`  | Directions to translate
-`dprot`        | Rotational displacement (radians)
-`dp`           | Translational displacement (Å)
-`spread`       | If false, stops cluster-growth after one layer around centered molecule (experimental)
-`satellites`   | Subset of `molecules` that cannot be cluster centers
+`cluster`       | Description
+--------------– | -----------------------
+`molecules`     | Array of molecule names; `[*]` selects all
+`threshold`     | Mass-center threshold for forming a cluster
+`dir=[1,1,1]`   | Directions to translate
+`dirrot=[0,0,0]`| Predefined axis of rotation
+`dprot`         | Rotational displacement (radians)
+`dp`            | Translational displacement (Å)
+`spread`        | If false, stops cluster-growth after one layer around centered molecule (experimental)
+`satellites`    | Subset of `molecules` that cannot be cluster centers
 
 This will attempt to rotate and translate clusters of molecular `molecules` defined by a distance `threshold`
 between mass centers.
@@ -99,6 +102,8 @@ The `threshold` can be specified as a single number or as a complete list of com
 For simulations where small molecules cluster around a large macro-molecules it can be useful to use the `satellites`
 keyword which denotes a list of molecules that can be part of a cluster, but cannot be the cluster nucleus or
 starting point. All molecules listed in `satellites` must be part of `molecules`.
+A predefined axis of rotation can be specified as `dirrot`. For example, setting `dirrot` to [1,0,0], [0,1,0] or [0,0,1] 
+results in rotations about the $x-$, $y-$, and $z-$axis, respectively.
 
 The move is associated with [bias](http://dx.doi.org/10/cj9gnn), such that
 the cluster size and composition remain unaltered.

--- a/src/clustermove.h
+++ b/src/clustermove.h
@@ -21,6 +21,7 @@ class Cluster : public Movebase {
     bool rotate; // true if cluster should be rotated
     bool spread; // true if cluster should spread outside of the first layer of surrounding molecules
     Point dir = {1, 1, 1}, dp;
+    Point dirrot = {0, 0, 0}; // predefined axis of rotation
     std::vector<std::string> names; // names of molecules to be considered
     std::vector<int> ids;           // molecule id's of molecules to be considered
     std::set<int> satellites;       // subset of molecules to cluster, but NOT act as nuclei (cluster centers)

--- a/src/move.h
+++ b/src/move.h
@@ -159,6 +159,7 @@ class TranslateRotate : public Movebase {
     double dptrans = 0;
     double dprot = 0;
     Point dir = {1, 1, 1};
+    Point dirrot = {0, 0, 0}; // predefined axis of rotation
     double _sqd;          // squared displacement
     Average<double> msqd; // mean squared displacement
 
@@ -265,7 +266,6 @@ class ConformationSwap : public Movebase {
     Space &spc; // Space to operate on
     int molid = -1;
     int newconfid = -1;
-    bool keeppos = false;
 
     void _to_json(json &j) const override;
     void _from_json(const json &j) override; //!< Configure via json object


### PR DESCRIPTION
# Description

Minor corrections to the documentation.
The keeppos key in ConformationSwap is now correctly read from the input.
I added an option (`dirrot`) in Cluster move and TranslateRotate to rotate clusters or molecules about a given axis.

## Checklist

- [x] `make test` passes with no errors
- [x] the source code is well documented
- [ ] new functionality includes unittests
- [x] the user-manual has been updated to reflect the changes
- [ ] I have installed the provided commit hook to auto-format commits (requires `clang-format`):

  ``` bash
  ./scripts/git-pre-commit-format install
  ```

- [x] code naming scheme follows the convention:

  Style        | Elements
  ------------ | ---------------------
  `PascalCase` | classes, namespaces
  `camelCase`  | functions
  `snake_case` | variables
