### PR TITLE
Map loaded structure to a sphere

### DIFF
--- a/docs/_docs/topology.md
+++ b/docs/_docs/topology.md
@@ -99,6 +99,7 @@ Properties of molecules and their default values:
 `atoms=[]`              | Array of atom names; required if `atomic=true`
 `bondlist`              | List of _internal_ bonds (harmonic, dihedrals etc.)
 `compressible=false`    | If true, molecular internal coordinates are scaled upon volume moves
+`ensphere=false`        | Radial rescale of positions to sphere w. radius of average radial distance from COM
 `excluded_neighbours=0` | Generate an `exclusionlist` from the bonded interaction: Add all atom pairs which are `excluded_neighbours` or less bonds apart
 `exclusionlist`         | List of _internal_ atom pairs which nonbonded interactions are excluded
 `implicit=false`        | If this species is implicit in GCMC schemes

--- a/src/geometry.cpp
+++ b/src/geometry.cpp
@@ -599,8 +599,9 @@ ParticleVector mapParticlesOnSphere(const ParticleVector &particles) {
         i.pos = i.pos * radius.avg() + COM;
 
     // rmsd, skipping the first particle
-    double _rmsd = rootMeanSquareDeviation(dst.begin() + 1, dst.end(), particles.begin() + 1,
-                                           [](const Particle &a, const Particle &b) { return (a.pos - b.pos).norm(); });
+    double _rmsd =
+        rootMeanSquareDeviation(dst.begin() + 1, dst.end(), particles.begin() + 1,
+                                [](const Particle &a, const Particle &b) { return (a.pos - b.pos).squaredNorm(); });
 
     faunus_logger->info("{} particles mapped on sphere of radius {} with RMSD {} {}", dst.size(), radius.avg(), _rmsd,
                         u8::angstrom);

--- a/src/geometry.h
+++ b/src/geometry.h
@@ -558,11 +558,11 @@ Tensor inertia(iter begin, iter end, const Point origin = {0,0,0},
  * in the two sets, for example `[](int a, int b){return a-b;}`.
  */
 template <typename InputIt1, typename InputIt2, typename BinaryOperation>
-double rootMeanSquareDeviation(InputIt1 begin, InputIt1 end, InputIt2 d_begin, BinaryOperation difffunc) {
+double rootMeanSquareDeviation(InputIt1 begin, InputIt1 end, InputIt2 d_begin, BinaryOperation diff_squared_func) {
     assert(std::distance(begin, end) > 0);
     double sq_sum = 0;
     for (InputIt1 i = begin; i != end; ++i) {
-        sq_sum += std::pow(difffunc(*i, *d_begin), 2);
+        sq_sum += diff_squared_func(*i, *d_begin);
         ++d_begin;
     }
     return std::sqrt(sq_sum / std::distance(begin, end));
@@ -573,11 +573,13 @@ double rootMeanSquareDeviation(InputIt1 begin, InputIt1 end, InputIt2 d_begin, B
  * @param particles Vector of particles
  *
  * The sphere radius is taken as the average radial distance
- * of all particles with respect to the geometric center.
- * The _first_ particle of the given particles are excluded
+ * of all particles with respect to the mass center.
+ * The _first_ particle of the given particles is excluded
  * from the COM calculation and re-positioned at the center
  * of the sphere. Therefore, make sure to add a dummy particle
- * to the beginning of the particle vector.
+ * to the beginning of the particle vector; it's positions is
+ * not used and will be overwritten.
+ * Similar to routine described in doi:10.1021/jp010360o
  */
 ParticleVector mapParticlesOnSphere(const ParticleVector &);
 

--- a/src/geometry.h
+++ b/src/geometry.h
@@ -551,5 +551,18 @@ Tensor inertia(iter begin, iter end, const Point origin = {0,0,0},
     return I;
 }
 
+/**
+ * @brief Scale particles to the surface of a sphere
+ * @param particles Vector of particles
+ *
+ * The sphere radius is taken as the average radial distance
+ * of all particles with respect to the geometric center.
+ * The _first_ particle of the given particles are excluded
+ * from the COM calculation and re-positions to the center
+ * of the sphere. Therefore, make sure to add a dummy particle
+ * to the beginning of the particle vector.
+ */
+ParticleVector mapParticlesOnSphere(ParticleVector particles);
+
 } // namespace Geometry
 } // namespace Faunus

--- a/src/geometry.h
+++ b/src/geometry.h
@@ -552,17 +552,34 @@ Tensor inertia(iter begin, iter end, const Point origin = {0,0,0},
 }
 
 /**
+ * @brief Root-mean-square deviation of two data sets represented by iterators
+ *
+ * A binary function must be given that returns the difference between data points
+ * in the two sets, for example `[](int a, int b){return a-b;}`.
+ */
+template <typename InputIt1, typename InputIt2, typename BinaryOperation>
+double rootMeanSquareDeviation(InputIt1 begin, InputIt1 end, InputIt2 d_begin, BinaryOperation difffunc) {
+    assert(std::distance(begin, end) > 0);
+    double sq_sum = 0;
+    for (InputIt1 i = begin; i != end; ++i) {
+        sq_sum += std::pow(difffunc(*i, *d_begin), 2);
+        ++d_begin;
+    }
+    return std::sqrt(sq_sum / std::distance(begin, end));
+}
+
+/**
  * @brief Scale particles to the surface of a sphere
  * @param particles Vector of particles
  *
  * The sphere radius is taken as the average radial distance
  * of all particles with respect to the geometric center.
  * The _first_ particle of the given particles are excluded
- * from the COM calculation and re-positions to the center
+ * from the COM calculation and re-positioned at the center
  * of the sphere. Therefore, make sure to add a dummy particle
  * to the beginning of the particle vector.
  */
-ParticleVector mapParticlesOnSphere(ParticleVector particles);
+ParticleVector mapParticlesOnSphere(const ParticleVector &);
 
 } // namespace Geometry
 } // namespace Faunus

--- a/src/geometry_test.h
+++ b/src/geometry_test.h
@@ -385,6 +385,14 @@ TEST_CASE("[Faunus] anyCenter") {
     CHECK(cm.z() == doctest::Approx(0));
 }
 
+TEST_CASE("[Faunus] rootMeanSquareDeviation") {
+    std::vector<double> v1 = {1.3, 4.4, -1.1};
+    std::vector<double> v2 = {1.1, 4.6, -1.0};
+    auto f = [](double a, double b) { return std::pow(a - b, 2); };
+    double rmsd = Geometry::rootMeanSquareDeviation(v1.begin(), v1.end(), v2.begin(), f);
+    CHECK(rmsd == doctest::Approx(0.17320508075688745));
+}
+
 } // namespace Geometry
 } // namespace Faunus
 

--- a/src/molecule.cpp
+++ b/src/molecule.cpp
@@ -276,6 +276,8 @@ void MoleculeBuilder::readParticles(const json &j_properties) {
         bool read_charges = j_properties.value("keepcharges", true);
         MoleculeStructureReader structure_reader(read_charges);
         structure_reader.readJson(particles, *j_structure_it);
+        if (j_properties.value("ensphere", false))
+            particles = Geometry::mapParticlesOnSphere(particles);
     } else {
         // allow virtual molecules :-/
         // shall we rather try to fallback on readAtomic()?


### PR DESCRIPTION
Add the keyword `ensphere` which will map a given protein structure to a sphere with radius set to the average radial distance in the original structure. This is similar to the CPPM work by Dzubiella etc. but using charge distributions from real proteins.