### PR TITLE
Enable muVT ensemble with cluster move

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -28,7 +28,7 @@ if (PANDOC)
         grep -v ".notice--" |
         grep -v "Github-Improve_this_page" |
         sed 's.\\\\_._.g' | # this allows us to use \_ in markdown math
-        ${PANDOC} --self-contained --highlight-style=tango --template ../pandoc.tex
+        ${PANDOC} --self-contained --highlight-style=pygments --template ../pandoc.tex
         -V date:${GIT_LATEST_TAG}""
         -N --toc ${TEX_ENGINE_OPTION}=${TEX_ENGINE} -o ${CMAKE_BINARY_DIR}/manual.pdf
         )

--- a/docs/_docs/moves.md
+++ b/docs/_docs/moves.md
@@ -88,22 +88,22 @@ Atomic _rotation_ affects only anisotropic particles such as dipoles, spherocyli
 `cluster`       | Description
 --------------- | --------------------------------------------
 `molecules`     | Array of molecule names; `[*]` selects all
-`threshold`     | Mass-center threshold for forming a cluster
+`threshold`     | Mass-center threshold for forming a cluster (number or object)
 `dir=[1,1,1]`   | Directions to translate
-`dirrot=[0,0,0]`| Predefined axis of rotation
+`dirrot=[0,0,0]`| Predefined axis of rotation. If zero, a random unit vector is generated for each move event
 `dprot`         | Rotational displacement (radians)
 `dp`            | Translational displacement (Å)
-`spread`        | If false, stops cluster-growth after one layer around centered molecule (experimental)
+`spread=true`   | If `false`, stops cluster-growth after one layer around centered molecule (experimental)
 `satellites`    | Subset of `molecules` that cannot be cluster centers
 
 This will attempt to rotate and translate clusters of molecular `molecules` defined by a distance `threshold`
 between mass centers.
 The `threshold` can be specified as a single number or as a complete list of combinations.
-For simulations where small molecules cluster around a large macro-molecules it can be useful to use the `satellites`
+For simulations where small molecules cluster around large macro-molecules, it can be useful to use the `satellites`
 keyword which denotes a list of molecules that can be part of a cluster, but cannot be the cluster nucleus or
 starting point. All molecules listed in `satellites` must be part of `molecules`.
 A predefined axis of rotation can be specified as `dirrot`. For example, setting `dirrot` to [1,0,0], [0,1,0] or [0,0,1] 
-results in rotations about the $x-$, $y-$, and $z-$axis, respectively.
+results in rotations about the $x-$, $y-$, or $z-$axis, respectively.
 
 The move is associated with [bias](http://dx.doi.org/10/cj9gnn), such that
 the cluster size and composition remain unaltered.
@@ -122,10 +122,6 @@ cluster:
    dp: 3
    dprot: 1
 ```
-
-**Restrictions:**
-Currently, the number of `molecules` must be constant throughout simulation, _i.e._
-grand canonical schemes are unsupported.
 
 ## Internal Degrees of Freedom
 

--- a/docs/_docs/running.md
+++ b/docs/_docs/running.md
@@ -41,6 +41,26 @@ atomlist:
     - Na+: { q: 1.0, mw: 22.99 }
 ~~~
 
+Generating several input files for a parameter scan, it can be helpful to use
+an input _template file_,
+
+~~~ yaml
+# template.yml
+geometry: {type: cylinder, length: {{length}}, radius: {{radius}}}
+~~~
+
+which can be populated using python:
+
+~~~ python
+from jinja2 import Template
+with open('template.yml') as f:
+    output = Template(f.read()).render(
+            length = 200,
+            radius = 50 )
+    print(output)
+~~~
+
+
 ### Post-Processing
 
 JSON formatted output can conveniently be converted to

--- a/src/analysis.cpp
+++ b/src/analysis.cpp
@@ -116,6 +116,7 @@ void SystemEnergy::_from_json(const json &j) {
     for (auto &n : names)
         f << sep << n;
     f << "\n";
+    f.precision(16);
 }
 SystemEnergy::SystemEnergy(const json &j, Energy::Hamiltonian &pot) {
     for (auto i : pot.vec)

--- a/src/clustermove.h
+++ b/src/clustermove.h
@@ -7,8 +7,6 @@ namespace Faunus {
 namespace Move {
 /**
  * @brief Molecular cluster move
- *
- * @todo fix so that it works w. GC molecules (index are calculating before simulation)
  */
 class Cluster : public Movebase {
   private:
@@ -22,12 +20,14 @@ class Cluster : public Movebase {
     bool spread; // true if cluster should spread outside of the first layer of surrounding molecules
     Point dir = {1, 1, 1}, dp;
     Point dirrot = {0, 0, 0}; // predefined axis of rotation
-    std::vector<std::string> names; // names of molecules to be considered
-    std::vector<int> ids;           // molecule id's of molecules to be considered
-    std::set<int> satellites;       // subset of molecules to cluster, but NOT act as nuclei (cluster centers)
-    std::vector<size_t> index;      // index of all possible molecules to be considered
+    std::vector<std::string> molecule_names; // names of molecules to be considered
+    std::vector<int> molids;                 // molecule id's of molecules to be considered
+    std::set<int> satellites;           // subset of molecule id's to cluster, but NOT act as nuclei (cluster centers)
+    std::vector<size_t> molecule_index; // index of all possible molecules to be considered
     std::map<size_t, size_t> clusterSizeDistribution; // distribution of cluster sizes
-    PairMatrix<double, true> thresholdsq;
+    PairMatrix<double, true> group_thresholds;
+
+    void updateMoleculeIndex(); //!< update `molecule_index`
 
     virtual double clusterProbability(const Tgroup &g1, const Tgroup &g2) const;
 

--- a/src/montecarlo.cpp
+++ b/src/montecarlo.cpp
@@ -157,63 +157,66 @@ void MCSimulation::State::sync(MCSimulation::State &other, Change &change) {
 
 void to_json(json &j, MCSimulation &mc) { mc.to_json(j); }
 
+/**
+ * Entropic, contribution to the change associated with a density fluctuation.
+ * This far tested with particle fluctuations, only.
+ */
 double IdealTerm(Space &spc_n, Space &spc_o, const Change &change) {
-    using Tpvec = typename Space::Tpvec;
     double NoverO = 0;
-    if (change.dN) { // Has the number of any molecules changed?
-        for (auto &m : change.groups) {
-            int N_o = 0;
-            int N_n = 0;
-            if (m.dNswap) {
-                assert(m.atoms.size() == 1);
-                auto &g_n = spc_n.groups.at(m.index);
-                int id1 = (g_n.begin() + m.atoms.front())->id;
-                auto &g_o = spc_o.groups.at(m.index);
-                int id2 = (g_o.begin() + m.atoms.front())->id;
-                for (int id : {id1, id2}) {
-                    auto atomlist_n = spc_n.findAtoms(id);
-                    auto atomlist_o = spc_o.findAtoms(id);
-                    N_n = rng_size(atomlist_n);
-                    N_o = rng_size(atomlist_o);
-                    int dN = N_n - N_o;
-                    double V_n = spc_n.geo.getVolume();
-                    double V_o = spc_o.geo.getVolume();
-                    if (dN > 0)
-                        for (int n = 0; n < dN; n++)
-                            NoverO += std::log((N_o + 1 + n) / (V_n * 1.0_molar));
-                    else
-                        for (int n = 0; n < (-dN); n++)
-                            NoverO -= std::log((N_o - n) / (V_o * 1.0_molar));
-                }
-            } else {
-                if (m.dNatomic) {
-                    auto mollist_n = spc_n.findMolecules(spc_n.groups[m.index].id, Space::ALL);
-                    auto mollist_o = spc_o.findMolecules(spc_o.groups[m.index].id, Space::ALL);
-                    if (rng_size(mollist_n) > 1 || rng_size(mollist_o) > 1)
-                        throw std::runtime_error("Bad definition: One group per atomic molecule!");
-                    if (not molecules[spc_n.groups[m.index].id].atomic)
-                        throw std::runtime_error("Only atomic molecules!");
-
-                    // Below is safe due to the catches above
-                    // add consistency criteria with m.atoms.size() == N
-                    N_n = mollist_n.begin()->size();
-                    N_o = mollist_o.begin()->size();
-                } else {
-                    auto mollist_n = spc_n.findMolecules(spc_n.groups[m.index].id, Space::ACTIVE);
-                    auto mollist_o = spc_o.findMolecules(spc_o.groups[m.index].id, Space::ACTIVE);
-                    N_n = rng_size(mollist_n);
-                    N_o = rng_size(mollist_o);
-                }
+    if (not change.dN)
+        return NoverO;
+    for (const Change::data &m : change.groups) { // loop over each change group
+        int N_o = 0;                              // number of molecules/atoms before change
+        int N_n = 0;                              // number of molecules/atoms after change
+        if (m.dNswap) {                           // the number of atoms has changed as a result of a swap move
+            assert(m.atoms.size() == 1);
+            auto &g_n = spc_n.groups.at(m.index);
+            auto &g_o = spc_o.groups.at(m.index);
+            int id1 = (g_n.begin() + m.atoms.front())->id;
+            int id2 = (g_o.begin() + m.atoms.front())->id;
+            for (int atom_id : {id1, id2}) {
+                auto mollist_n = spc_n.findAtoms(atom_id);
+                auto mollist_o = spc_o.findAtoms(atom_id);
+                N_n = rng_size(mollist_n);
+                N_o = rng_size(mollist_o);
                 int dN = N_n - N_o;
-                if (dN != 0) {
-                    double V = spc_n.geo.getVolume() * 1.0_molar;
-                    if (dN > 0)
-                        for (int n = 0; n < dN; n++)
-                            NoverO += std::log( (N_o + 1 + n) / V );
-                    else
-                        for (int n = 0; n < (-dN); n++)
-                            NoverO -= std::log( (N_o - n) / V );
-                }
+                double V_n = spc_n.geo.getVolume();
+                double V_o = spc_o.geo.getVolume();
+                if (dN > 0)
+                    for (int n = 0; n < dN; n++)
+                        NoverO += std::log((N_o + 1 + n) / (V_n * 1.0_molar));
+                else
+                    for (int n = 0; n < (-dN); n++)
+                        NoverO -= std::log((N_o - n) / (V_o * 1.0_molar));
+            }
+        } else {              // it is not a swap move
+            if (m.dNatomic) { // the number of atomic molecules has changed
+                auto mollist_n = spc_n.findMolecules(spc_n.groups[m.index].id, Space::ALL); // why not "ACTIVE"?
+                auto mollist_o = spc_o.findMolecules(spc_o.groups[m.index].id, Space::ALL);
+                if (rng_size(mollist_n) > 1 || rng_size(mollist_o) > 1)
+                    throw std::runtime_error("Bad definition: One group per atomic molecule!");
+                if (not molecules[spc_n.groups[m.index].id].atomic)
+                    throw std::runtime_error("Only atomic molecules!");
+
+                // Below is safe due to the catches above
+                // add consistency criteria with m.atoms.size() == N
+                N_n = mollist_n.begin()->size();
+                N_o = mollist_o.begin()->size();
+            } else {
+                auto mollist_n = spc_n.findMolecules(spc_n.groups[m.index].id, Space::ACTIVE);
+                auto mollist_o = spc_o.findMolecules(spc_o.groups[m.index].id, Space::ACTIVE);
+                N_n = rng_size(mollist_n);
+                N_o = rng_size(mollist_o);
+            }
+            int dN = N_n - N_o;
+            if (dN != 0) {
+                double V = spc_n.geo.getVolume() * 1.0_molar;
+                if (dN > 0)
+                    for (int n = 0; n < dN; n++)
+                        NoverO += std::log((N_o + 1 + n) / V);
+                else
+                    for (int n = 0; n < (-dN); n++)
+                        NoverO -= std::log((N_o - n) / V);
             }
         }
     }

--- a/src/space.h
+++ b/src/space.h
@@ -169,11 +169,11 @@ struct Space {
         return p | ranges::cpp20::views::filter([&, atomid](const Particle &i) {
                    if (i.id == atomid)
                        for (const auto &g : groups)
-                           if (g.contains(i))
+                           if (g.contains(i, false))
                                return true;
                    return false;
                });
-    } //!< Range with all atoms of type `atomid` (complexity: order N)
+    } //!< Range with all active atoms of type `atomid` (complexity: order N)
 
     auto findGroupContaining(const Particle &i) {
         return std::find_if(groups.begin(), groups.end(), [&i](auto &g) { return g.contains(i); });

--- a/src/speciation.h
+++ b/src/speciation.h
@@ -30,7 +30,7 @@ class SpeciationMove : public Movebase {
     void _to_json(json &) const override;
     void _from_json(const json &) override;
 
-    bool insertProducts(std::vector<ReactionData>::iterator);
+    bool checkInsertProducts(std::vector<ReactionData>::iterator);
     bool swapReaction(Change &, std::vector<ReactionData>::iterator);
 
     void activateProducts(Change &, std::vector<Faunus::ReactionData>::iterator);

--- a/src/units.h
+++ b/src/units.h
@@ -10,15 +10,16 @@ namespace Faunus {
     namespace PhysicalConstants {
         typedef double T; //!< Float size
         constexpr T infty = std::numeric_limits<T>::infinity(), //!< Numerical infinity
-                  epsilon_dbl = std::numeric_limits<T>::epsilon(), //!< Numerical precision
-                  max_exp_argument = 709.8, //!< Largest value exp() can take before overflow (hard-coded for double)
-                  pi = 3.141592653589793, //!< Pi
-                  e0 = 8.85419e-12,  //!< Permittivity of vacuum [C^2/(J*m)]
-                  e = 1.602177e-19,  //!< Absolute electronic unit charge [C]
-                  kB = 1.380658e-23, //!< Boltzmann's constant [J/K]
-                  Nav = 6.022137e23, //!< Avogadro's number [1/mol]
-                  c = 299792458.0,   //!< Speed of light [m/s]
-                  R = kB * Nav;      //!< Molar gas constant [J/(K*mol)]
+            epsilon_dbl = std::numeric_limits<T>::epsilon(),    //!< Numerical precision
+            max_exp_argument =
+                709.782712893384,    //!< Largest value exp() can take before overflow (hard-coded for double)
+            pi = 3.141592653589793,  //!< Pi
+            e0 = 8.85419e-12,        //!< Permittivity of vacuum [C^2/(J*m)]
+            e = 1.602177e-19,        //!< Absolute electronic unit charge [C]
+            kB = 1.380658e-23,       //!< Boltzmann's constant [J/K]
+            Nav = 6.022137e23,       //!< Avogadro's number [1/mol]
+            c = 299792458.0,         //!< Speed of light [m/s]
+            R = kB * Nav;            //!< Molar gas constant [J/(K*mol)]
         extern T temperature;        //!< Temperature (Kelvin)
         static inline T kT() { return temperature*kB; } //!< Thermal energy (Joule)
         static inline T lB( T epsilon_r ) {


### PR DESCRIPTION
Enable muVT ensemble with cluster move

Additional changes:

- Cluster move has been refactored for readability
- Increases file output precision for `SystemEnergy`
- Refactor Speciation and IdealTerm variables to increase readability
- Change code block style in pdf manual