### PR TITLE
Add Cereal serialization and compressed SpaceTrajectory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,6 @@ CTestTestfile.cmake
 *.slo
 *.lo
 *.o
-*.cereal
 
 *.dsym
 

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ CTestTestfile.cmake
 *.slo
 *.lo
 *.o
+*.cereal
 
 *.dsym
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,16 @@ if(NOT modernjson_POPULATED)
 endif()
 add_compile_definitions("NLOHMANN_JSON_HPP") # older versions used this macro. Now it's suffixed with "_"
 
+# CEREAL
+FetchContent_Declare(
+    cereal
+    URL "https://github.com/USCiLab/cereal/archive/v1.3.0.tar.gz"
+    URL_HASH MD5=4342e811f245403646c4175258f413f1)
+FetchContent_GetProperties(cereal)
+if(NOT cereal_POPULATED)
+    FetchContent_Populate(cereal)
+endif()
+
 # RANGE-V3
 FetchContent_Declare(
     rangev3
@@ -277,7 +287,7 @@ endif ()
 # to disable potential compiler warnings
 include_directories(SYSTEM ${eigen_SOURCE_DIR} ${doctest_SOURCE_DIR} ${modernjson_SOURCE_DIR}/include ${rangev3_SOURCE_DIR}/include
     ${Pybind11IncludeDir} ${DocoptIncludeDir} ${CppsidIncludeDir} ${XdrfileIncludeDir} ${SpdlogIncludeDir}
-    ${ProgressTrackerIncludeDir} ${exprtk_SOURCE_DIR})
+    ${ProgressTrackerIncludeDir} ${exprtk_SOURCE_DIR} ${cereal_SOURCE_DIR}/include)
 
 #  Compiler specific flags
 ## GCC

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ set(CMAKE_CXX_EXTENSIONS NO)
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(PythonInterp 3 REQUIRED)
 find_package(Threads REQUIRED)
+find_package(zlib REQUIRED)
 enable_testing()
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
@@ -123,6 +124,16 @@ FetchContent_Declare(
 FetchContent_GetProperties(cereal)
 if(NOT cereal_POPULATED)
     FetchContent_Populate(cereal)
+endif()
+
+# ZSTR
+FetchContent_Declare(
+    zstr
+    URL "https://github.com/mateidavid/zstr/archive/v1.0.1.tar.gz"
+    URL_HASH MD5=42de51b1c6adac0ec957a24088ef7523)
+FetchContent_GetProperties(zstr)
+if(NOT zstr_POPULATED)
+    FetchContent_Populate(zstr)
 endif()
 
 # RANGE-V3
@@ -287,7 +298,7 @@ endif ()
 # to disable potential compiler warnings
 include_directories(SYSTEM ${eigen_SOURCE_DIR} ${doctest_SOURCE_DIR} ${modernjson_SOURCE_DIR}/include ${rangev3_SOURCE_DIR}/include
     ${Pybind11IncludeDir} ${DocoptIncludeDir} ${CppsidIncludeDir} ${XdrfileIncludeDir} ${SpdlogIncludeDir}
-    ${ProgressTrackerIncludeDir} ${exprtk_SOURCE_DIR} ${cereal_SOURCE_DIR}/include)
+    ${ProgressTrackerIncludeDir} ${exprtk_SOURCE_DIR} ${cereal_SOURCE_DIR}/include ${zstr_SOURCE_DIR}/src)
 
 #  Compiler specific flags
 ## GCC

--- a/docs/_docs/analysis.md
+++ b/docs/_docs/analysis.md
@@ -493,7 +493,6 @@ generated. For use with rod-like particles on surfaces, the `absz`
 keyword may be used to ensure orientations on only one
 half-sphere.
 
-**Important:**
 Exactly _one inactive_ `molecule` must be added to the simulation using the `inactive`
 keyword when inserting the initial molecules in the [topology](topology).
 
@@ -525,6 +524,25 @@ with the following information:
 - particle and group properties incl. positions
 - geometry
 - state of random number generator (if `saverandom=true`)
+
+
+### Space Trajectory (experimental)
+
+Save all particle and group information to a compressed, binary trajectory format.
+The following properties are saved:
+
+ - all particle properties (id, position, charge, dipole etc.)
+ - all group properties (id, size, capacity etc.)
+ - todo: geometry, energy
+
+The file suffix must be either `.traj` (uncomressed) or `.ztraj` (compressed).
+For the latter, the file size is reduced by roughly a factor of two using zlib
+compression.
+
+`spacetraj`  | Description
+------------ | ---------------------------------------
+`file`       | Filename of output .traj/.ztraj file
+`nstep`      | Interval between samples.
 
 
 ### XTC trajectory

--- a/docs/schema.yml
+++ b/docs/schema.yml
@@ -736,6 +736,18 @@ properties:
                     required: [atoms, file, nstep]
                     additionalProperties: false
 
+                spacetraj:
+                    properties:
+                        file:
+                            type: string
+                            pattern: "(.*?)\\.(traj|ztraj)$"
+                            description: "Output filename (.traj/.ztraj)"
+                        nstep: {type: integer}
+                        nskip: {type: integer, default: 0, description: Initial steps to skip}
+                    required: [file, nstep]
+                    additionalProperties: false
+                    type: object
+
                 systemenergy:
                     properties:
                         file: {type: string}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,6 +36,7 @@ set_source_files_properties(${objs} PROPERTIES LANGUAGE CXX)
 
 # faunus header files
 set(hdrs
+    ${CMAKE_SOURCE_DIR}/src/aux/eigen_cerealisation.hpp
     ${CMAKE_SOURCE_DIR}/src/aux/eigensupport.h
     ${CMAKE_SOURCE_DIR}/src/aux/iteratorsupport.h
     ${CMAKE_SOURCE_DIR}/src/aux/multimatrix.h
@@ -95,7 +96,7 @@ set_target_properties(functionparser PROPERTIES
 # targer: libfaunus - main functionality of faunus
 add_library(libfaunus STATIC ${objs} ${hdrs})
 target_compile_definitions(libfaunus PRIVATE SPDLOG_COMPILED_LIB)
-target_link_libraries(libfaunus PRIVATE ${CMAKE_THREAD_LIBS_INIT} xdrfile spdlog functionparser)
+target_link_libraries(libfaunus PRIVATE ${CMAKE_THREAD_LIBS_INIT} xdrfile spdlog functionparser ZLIB::ZLIB)
 set_target_properties(libfaunus PROPERTIES
     POSITION_INDEPENDENT_CODE ON)
     #LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/src/analysis.h
+++ b/src/analysis.h
@@ -570,7 +570,7 @@ class SpaceTrajectory : public Analysisbase {
     void _sample() override;
     void _to_json(json &j) const override;
     void _to_disk() override;
-    bool useCompression() const; //!< decide from filename if zlib should be used
+    bool useCompression() const; //! decide from filename if zlib should be used
 
   public:
     SpaceTrajectory(const json &, Space::Tgvec &);

--- a/src/analysis.h
+++ b/src/analysis.h
@@ -570,7 +570,7 @@ class SpaceTrajectory : public Analysisbase {
     void _sample() override;
     void _to_json(json &j) const override;
     void _to_disk() override;
-    bool useCompression() const; //! decide from filename if zlib should be used
+    bool useCompression() const; //!< decide from filename if zlib should be used
 
   public:
     SpaceTrajectory(const json &, Space::Tgvec &);

--- a/src/analysis.h
+++ b/src/analysis.h
@@ -7,6 +7,10 @@
 #include "auxiliary.h"
 #include <set>
 
+namespace cereal {
+class BinaryOutputArchive;
+}
+
 namespace Faunus {
 
 namespace Energy {
@@ -542,6 +546,34 @@ class QRtraj : public Analysisbase {
 
   public:
     QRtraj(const json &j, Space &spc);
+};
+
+/**
+ * @brief Trajectory with full Space information
+ *
+ * The following are saved in (compressed) binary form:
+ *
+ * - all particle properties (id, position, charge, dipole etc.)
+ * - all group properties (id, size, capacity etc.)
+ *
+ * If zlib compression is enabled the file size
+ * is reduced by roughly a factor of two.
+ *
+ * @todo Geometry information
+ */
+class SpaceTrajectory : public Analysisbase {
+  private:
+    Space::Tgvec &groups; // reference to all groups
+    std::string filename;
+    std::unique_ptr<std::ostream> stream;
+    std::unique_ptr<cereal::BinaryOutputArchive> archive;
+    bool compression = true;
+    void _sample() override;
+    void _to_json(json &j) const override;
+    void _to_disk() override;
+
+  public:
+    SpaceTrajectory(const json &, Space::Tgvec &);
 };
 
 struct CombinedAnalysis : public BasePointerVector<Analysisbase> {

--- a/src/analysis.h
+++ b/src/analysis.h
@@ -567,10 +567,10 @@ class SpaceTrajectory : public Analysisbase {
     std::string filename;
     std::unique_ptr<std::ostream> stream;
     std::unique_ptr<cereal::BinaryOutputArchive> archive;
-    bool compression = true;
     void _sample() override;
     void _to_json(json &j) const override;
     void _to_disk() override;
+    bool useCompression() const; //!< decide from filename if zlib should be used
 
   public:
     SpaceTrajectory(const json &, Space::Tgvec &);

--- a/src/aux/eigen_cerealisation.hpp
+++ b/src/aux/eigen_cerealisation.hpp
@@ -1,0 +1,85 @@
+/*
+ * eos - A 3D Morphable Model fitting library written in modern C++11/14.
+ *
+ * File: include/eos/morphablemodel/io/eigen_cerealisation.hpp
+ *
+ * Copyright 2017 Patrik Huber
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#ifndef EIGENCEREALISATION_HPP_
+#define EIGENCEREALISATION_HPP_
+
+#include "cereal/cereal.hpp"
+
+#include "Eigen/Core"
+
+#include <cstdint>
+
+/**
+ * @brief Serialisation of Eigen matrices for the serialisation
+ * library cereal (http://uscilab.github.io/cereal/index.html).
+ *
+ * Contains serialisation for Eigen matrices to binary archives, i.e. matrices like
+ * \c Eigen::MatrixXf, \c Eigen::Matrix4d, or \c Eigen::Vector3f.
+ *
+ * Todo: Add serialisation to and from JSON. Need to find out how to combine the two
+ * variants of SFINAE that are used.
+ */
+namespace cereal {
+
+/**
+ * @brief Serialise an Eigen::Matrix using cereal.
+ *
+ * Note: Writes the binary data from Matrix::data(), so not sure what happens if a matrix ever has
+ * non-contiguous data (if that can ever happen with Eigen).
+ *
+ * @param[in] ar The archive to serialise to.
+ * @param[in] matrix The matrix to serialise.
+ */
+template <class Archive, class _Scalar, int _Rows, int _Cols, int _Options, int _MaxRows, int _MaxCols>
+inline typename std::enable_if<traits::is_output_serializable<BinaryData<_Scalar>, Archive>::value, void>::type
+save(Archive &ar, const Eigen::Matrix<_Scalar, _Rows, _Cols, _Options, _MaxRows, _MaxCols> &matrix) {
+    const std::int32_t rows = static_cast<std::int32_t>(matrix.rows());
+    const std::int32_t cols = static_cast<std::int32_t>(matrix.cols());
+    ar(rows);
+    ar(cols);
+    ar(binary_data(matrix.data(), rows * cols * sizeof(_Scalar)));
+}
+
+/**
+ * @brief De-serialise an Eigen::Matrix using cereal.
+ *
+ * Reads the block of binary data back from a cereal archive into the Eigen::Matrix.
+ *
+ * @param[in] ar The archive to deserialise from.
+ * @param[in] matrix The matrix to deserialise into.
+ */
+template <class Archive, class _Scalar, int _Rows, int _Cols, int _Options, int _MaxRows, int _MaxCols>
+inline typename std::enable_if<traits::is_input_serializable<BinaryData<_Scalar>, Archive>::value, void>::type
+load(Archive &ar, Eigen::Matrix<_Scalar, _Rows, _Cols, _Options, _MaxRows, _MaxCols> &matrix) {
+    std::int32_t rows;
+    std::int32_t cols;
+    ar(rows);
+    ar(cols);
+
+    matrix.resize(rows, cols);
+
+    ar(binary_data(matrix.data(), static_cast<std::size_t>(rows * cols * sizeof(_Scalar))));
+}
+
+} /* namespace cereal */
+
+#endif /* EIGENCEREALISATION_HPP_ */

--- a/src/aux/eigensupport.h
+++ b/src/aux/eigensupport.h
@@ -3,6 +3,8 @@
 #include <Eigen/Core>
 #include <nlohmann/json.hpp>
 
+#include "aux/eigen_cerealisation.hpp"
+
 // Eigen<->JSON (de)serialization
 namespace Eigen {
 

--- a/src/average.h
+++ b/src/average.h
@@ -15,6 +15,8 @@ namespace Faunus
       unsigned long long int cnt=0; //!< Number of values
       T sum=0;                      //!< Sum
 
+      template <class Archive> void serialize(Archive &archive) { archive(sum, sqsum, cnt); }
+
       double avg() const {
           return sum / static_cast<double>(cnt);
       } //!< Average

--- a/src/geometry.h
+++ b/src/geometry.h
@@ -55,7 +55,7 @@ struct BoundaryCondition {
 
     template <class Archive> void serialize(Archive &archive) {
         archive(coordinates, direction);
-    } //!< Cereal serialisation
+    } //! Cereal serialisation
 
     BoundaryCondition(Coordinates coordinates = ORTHOGONAL, BoundaryXYZ boundary = {FIXED, FIXED, FIXED})
         : coordinates(coordinates), direction(boundary){};
@@ -103,7 +103,7 @@ class GeometryImplementation : public GeometryBase {
     //!< A unique pointer to a copy of self. To be used in copy constructors.
     virtual std::unique_ptr<GeometryImplementation> clone() const = 0;
 
-    //!< Cereal serialisation
+    //! Cereal serialisation
     template <class Archive> void serialize(Archive &archive) { archive(boundary_conditions); }
 };
 
@@ -133,9 +133,9 @@ class Cuboid : public GeometryImplementation {
         return std::make_unique<Cuboid>(*this);
     }; //!< A unique pointer to a copy of self.
 
-    //!< Cereal serialisation
+    //! Cereal serialisation
     template <class Archive> void serialize(Archive &archive) {
-        archive(cereal::base_class<GeometryImplementation>(this), box, box_half, box_inv);
+        archive(cereal::base_class<GeometryImplementation>(this), box);
     }
 };
 
@@ -180,7 +180,7 @@ class Sphere : public GeometryImplementation {
         return std::make_unique<Sphere>(*this);
     }; //!< A unique pointer to a copy of self.
 
-    //!< Cereal serialisation
+    //! Cereal serialisation
     template <class Archive> void serialize(Archive &archive) {
         archive(cereal::base_class<GeometryImplementation>(this), radius);
     }
@@ -221,7 +221,7 @@ class Cylinder : public GeometryImplementation {
         return std::make_unique<Cylinder>(*this);
     }; //!< A unique pointer to a copy of self.
 
-    //!< Cereal serialisation
+    //! Cereal serialisation
     template <class Archive> void serialize(Archive &archive) {
         archive(cereal::base_class<GeometryImplementation>(this), radius, height);
     }
@@ -260,7 +260,7 @@ class HexagonalPrism : public GeometryImplementation {
         return std::make_unique<HexagonalPrism>(*this);
     }; //!< A unique pointer to a copy of self.
 
-    //!< Cereal serialisation
+    //! Cereal serialisation
     template <class Archive> void serialize(Archive &archive) {
         archive(cereal::base_class<GeometryImplementation>(this), box);
     }
@@ -288,7 +288,7 @@ class TruncatedOctahedron : public GeometryImplementation {
         return std::make_unique<TruncatedOctahedron>(*this);
     }; //!< A unique pointer to a copy of self.
 
-    //!< Cereal serialisation
+    //! Cereal serialisation
     template <class Archive> void serialize(Archive &archive) {
         archive(cereal::base_class<GeometryImplementation>(this), side);
     }

--- a/src/geometry.h
+++ b/src/geometry.h
@@ -262,7 +262,7 @@ class HexagonalPrism : public GeometryImplementation {
 
     //!< Cereal serialisation
     template <class Archive> void serialize(Archive &archive) {
-        archive(cereal::base_class<GeometryImplementation>(this), rhombic2cartesian, cartesian2rhombic, box);
+        archive(cereal::base_class<GeometryImplementation>(this), box);
     }
 };
 

--- a/src/geometry.h
+++ b/src/geometry.h
@@ -6,6 +6,7 @@
 #include "tensor.h"
 #include <Eigen/Geometry>
 #include <iostream>
+#include <cereal/types/base_class.hpp>
 
 /** @brief Faunus main namespace */
 namespace Faunus {
@@ -52,6 +53,10 @@ struct BoundaryCondition {
     Coordinates coordinates;
     BoundaryXYZ direction;
 
+    template <class Archive> void serialize(Archive &archive) {
+        archive(coordinates, direction);
+    } //!< Cereal serialisation
+
     BoundaryCondition(Coordinates coordinates = ORTHOGONAL, BoundaryXYZ boundary = {FIXED, FIXED, FIXED})
         : coordinates(coordinates), direction(boundary){};
 };
@@ -95,8 +100,11 @@ class GeometryImplementation : public GeometryBase {
 
     virtual ~GeometryImplementation();
 
-    //! A unique pointer to a copy of self. To be used in copy constructors.
+    //!< A unique pointer to a copy of self. To be used in copy constructors.
     virtual std::unique_ptr<GeometryImplementation> clone() const = 0;
+
+    //!< Cereal serialisation
+    template <class Archive> void serialize(Archive &archive) { archive(boundary_conditions); }
 };
 
 /**
@@ -124,6 +132,11 @@ class Cuboid : public GeometryImplementation {
     std::unique_ptr<GeometryImplementation> clone() const override {
         return std::make_unique<Cuboid>(*this);
     }; //!< A unique pointer to a copy of self.
+
+    //!< Cereal serialisation
+    template <class Archive> void serialize(Archive &archive) {
+        archive(cereal::base_class<GeometryImplementation>(this), box, box_half, box_inv);
+    }
 };
 
 /**
@@ -166,6 +179,11 @@ class Sphere : public GeometryImplementation {
     std::unique_ptr<GeometryImplementation> clone() const override {
         return std::make_unique<Sphere>(*this);
     }; //!< A unique pointer to a copy of self.
+
+    //!< Cereal serialisation
+    template <class Archive> void serialize(Archive &archive) {
+        archive(cereal::base_class<GeometryImplementation>(this), radius);
+    }
 };
 
 class Hypersphere2d : public Sphere {
@@ -202,6 +220,11 @@ class Cylinder : public GeometryImplementation {
     std::unique_ptr<GeometryImplementation> clone() const override {
         return std::make_unique<Cylinder>(*this);
     }; //!< A unique pointer to a copy of self.
+
+    //!< Cereal serialisation
+    template <class Archive> void serialize(Archive &archive) {
+        archive(cereal::base_class<GeometryImplementation>(this), radius, height);
+    }
 };
 
 /**
@@ -236,6 +259,11 @@ class HexagonalPrism : public GeometryImplementation {
     std::unique_ptr<GeometryImplementation> clone() const override {
         return std::make_unique<HexagonalPrism>(*this);
     }; //!< A unique pointer to a copy of self.
+
+    //!< Cereal serialisation
+    template <class Archive> void serialize(Archive &archive) {
+        archive(cereal::base_class<GeometryImplementation>(this), rhombic2cartesian, cartesian2rhombic, box);
+    }
 };
 
 /**
@@ -259,6 +287,11 @@ class TruncatedOctahedron : public GeometryImplementation {
     std::unique_ptr<GeometryImplementation> clone() const override {
         return std::make_unique<TruncatedOctahedron>(*this);
     }; //!< A unique pointer to a copy of self.
+
+    //!< Cereal serialisation
+    template <class Archive> void serialize(Archive &archive) {
+        archive(cereal::base_class<GeometryImplementation>(this), side);
+    }
 };
 
 /**

--- a/src/geometry.h
+++ b/src/geometry.h
@@ -55,7 +55,7 @@ struct BoundaryCondition {
 
     template <class Archive> void serialize(Archive &archive) {
         archive(coordinates, direction);
-    } //! Cereal serialisation
+    } //!< Cereal serialisation
 
     BoundaryCondition(Coordinates coordinates = ORTHOGONAL, BoundaryXYZ boundary = {FIXED, FIXED, FIXED})
         : coordinates(coordinates), direction(boundary){};
@@ -100,7 +100,7 @@ class GeometryImplementation : public GeometryBase {
 
     virtual ~GeometryImplementation();
 
-    //!< A unique pointer to a copy of self. To be used in copy constructors.
+    //! A unique pointer to a copy of self. To be used in copy constructors.
     virtual std::unique_ptr<GeometryImplementation> clone() const = 0;
 
     //! Cereal serialisation

--- a/src/geometry_test.h
+++ b/src/geometry_test.h
@@ -367,6 +367,28 @@ TEST_CASE("[Faunus] Chameleon") {
         compare_boundary(chameleon, geo, box);
         compare_vdist(chameleon, geo, box);
     }
+
+    SUBCASE("Cereal serialisation") {
+        double x = 2.0, y = 3.0, z = 4.0;
+        { // write
+            Cuboid geo(x, y, z);
+            // Chameleon chameleon(geo, CUBOID);
+            std::ofstream os("out.cereal", std::ios::binary);
+            cereal::BinaryOutputArchive archive(os);
+            archive(geo);
+        }
+
+        { // read
+            Cuboid geo(10, 20, 30);
+            // Chameleon chameleon(geo, CUBOID);
+            std::ifstream is("out.cereal", std::ios::binary);
+            cereal::BinaryInputArchive archive(is);
+            archive(geo);
+            CHECK(geo.getLength().x() == Approx(x));
+            CHECK(geo.getLength().y() == Approx(y));
+            CHECK(geo.getLength().z() == Approx(z));
+        }
+    }
 }
 
 TEST_CASE("[Faunus] anyCenter") {

--- a/src/geometry_test.h
+++ b/src/geometry_test.h
@@ -3,6 +3,7 @@
 #include <Eigen/Geometry>
 #include <range/v3/view/sample.hpp>
 #include <range/v3/view/bounded.hpp>
+#include <cereal/archives/binary.hpp>
 
 namespace Faunus {
 namespace Geometry {

--- a/src/geometry_test.h
+++ b/src/geometry_test.h
@@ -371,19 +371,17 @@ TEST_CASE("[Faunus] Chameleon") {
 
     SUBCASE("Cereal serialisation") {
         double x = 2.0, y = 3.0, z = 4.0;
+        std::ostringstream os(std::stringstream::binary);
         { // write
             Cuboid geo(x, y, z);
-            // Chameleon chameleon(geo, CUBOID);
-            std::ofstream os("out.cereal", std::ios::binary);
             cereal::BinaryOutputArchive archive(os);
             archive(geo);
         }
 
         { // read
             Cuboid geo(10, 20, 30);
-            // Chameleon chameleon(geo, CUBOID);
-            std::ifstream is("out.cereal", std::ios::binary);
-            cereal::BinaryInputArchive archive(is);
+            std::istringstream in(os.str());
+            cereal::BinaryInputArchive archive(in);
             archive(geo);
             CHECK(geo.getLength().x() == Approx(x));
             CHECK(geo.getLength().y() == Approx(y));

--- a/src/group.h
+++ b/src/group.h
@@ -187,4 +187,8 @@ namespace Faunus {
 void to_json(json&, const Group<Particle>&);
 void from_json(const json&, Group<Particle>&);
 
+template <class Archive, class T> void serialize(Archive &archive, Group<T> &g) {
+    archive(g.id, g.confid, g.cm, g.compressible, g.atomic);
+} //!< Cereal serialisation
+
 }//end of faunus namespace

--- a/src/group_test.h
+++ b/src/group_test.h
@@ -178,7 +178,45 @@ TEST_CASE("[Faunus] Group") {
             auto gvec3 = gvec1;
             CHECK((*gvec1[0].begin()).id == (*gvec3[0].begin()).id);
         }
-    }
+
+        SUBCASE("cerial serialisation") {
+            std::ostringstream out(std::stringstream::binary);
+            { // serialize g2
+                std::vector<Particle> p2(5);
+                Group<Particle> g2(p2.begin(), p2.end());
+                p2.front().id = 8;
+                p2.back().pos.x() = -10;
+                g2.id = 100;
+                g2.atomic = true;
+                g2.compressible = true;
+                g2.cm = {1, 0, 0};
+                g2.confid = 20;
+                g2.resize(4);
+                cereal::BinaryOutputArchive archive(out);
+                archive(g2);
+            }
+
+            {                                     // deserialize into g1
+                std::istringstream in(out.str()); // not pretty...
+                cereal::BinaryInputArchive archive(in);
+                std::vector<Particle> p1(5);
+                Group<Particle> g1(p1.begin(), p1.end());
+                archive(g1);
+
+                CHECK(g1.id == 100);
+                CHECK(g1.atomic == true);
+                CHECK(g1.compressible == true);
+                CHECK(g1.cm.x() == 1);
+                CHECK(g1.confid == 20);
+                CHECK(g1.size() == 4);
+                CHECK(g1.capacity() == 5);
+                CHECK(g1.begin()->id == 8);
+                CHECK(p1.front().id == 8);
+                CHECK(p1.back().pos.x() == -10);
+                CHECK(p1.back().ext == nullptr);
+            }
+        }
+}
 
 TEST_SUITE_END();
 } // namespace Faunus

--- a/src/io_test.h
+++ b/src/io_test.h
@@ -48,7 +48,7 @@ TEST_CASE("[Faunus] FormatPQR") {
         CHECK(spc.p[i].charge == double(i));
         d += 0.5;
     }
-};
+}
 
 #endif
 } // namespace Faunus

--- a/src/particle.h
+++ b/src/particle.h
@@ -24,7 +24,7 @@ struct ParticlePropertyBase {
     virtual void from_json(const json &j) = 0; //!< Convert from JSON object
     void rotate(const Eigen::Quaterniond &q, const Eigen::Matrix3d &); //!< Internal rotation
     virtual ~ParticlePropertyBase() = default;
-    template <class Archive> void serialize(Archive &) {} //! Cereal serialisation
+    template <class Archive> void serialize(Archive &) {} //!< Cereal serialisation
 };
 
 template <typename... Ts>
@@ -190,7 +190,7 @@ class Particle {
         archive(ext, id, charge, pos);
         // if (ext != nullptr)
         //    ext->serialize(archive);
-    } //! Cereal serialisation
+    } //!< Cereal serialisation
 
     bool hasExtension() const; //!< check if particle has extensions (dipole etc.)
 

--- a/src/particle.h
+++ b/src/particle.h
@@ -24,7 +24,7 @@ struct ParticlePropertyBase {
     virtual void from_json(const json &j) = 0; //!< Convert from JSON object
     void rotate(const Eigen::Quaterniond &q, const Eigen::Matrix3d &); //!< Internal rotation
     virtual ~ParticlePropertyBase() = default;
-    template <class Archive> void serialize(Archive &) {} //!< Cereal serialisation
+    template <class Archive> void serialize(Archive &) {} //! Cereal serialisation
 };
 
 template <typename... Ts>
@@ -190,7 +190,7 @@ class Particle {
         archive(ext, id, charge, pos);
         // if (ext != nullptr)
         //    ext->serialize(archive);
-    } //!< Cereal serialisation
+    } //! Cereal serialisation
 
     bool hasExtension() const; //!< check if particle has extensions (dipole etc.)
 

--- a/src/particle_test.h
+++ b/src/particle_test.h
@@ -56,6 +56,44 @@ TEST_CASE("[Faunus] Particle") {
     CHECK(p1.getExt().Q(1, 1) == Approx(4));
     CHECK(p1.getExt().Q(1, 2) == Approx(-2));
     CHECK(p1.getExt().Q(2, 2) == Approx(1));
+
+    SUBCASE("Cereal serialisation") {
+        Particle p;
+        p.pos = {10, 20, 30};
+        p.charge = -1;
+        p.id = 8;
+        p.ext = std::make_shared<Particle::ParticleExtension>();
+        p.getExt().mu = {0.1, 0.2, 0.3};
+        p.getExt().mulen = 104;
+
+        { // write
+            std::ofstream os("out.cereal", std::ios::binary);
+            cereal::BinaryOutputArchive archive(os);
+            archive(p);
+        }
+
+        // set to zero
+        p.pos = {0, 0, 0};
+        p.charge = 0;
+        p.id = 0;
+        p.getExt().mu.setZero();
+        p.getExt().mulen = 0;
+
+        { // read
+            std::ifstream is("out.cereal", std::ios::binary);
+            cereal::BinaryInputArchive archive(is);
+            archive(p);
+            CHECK(p.id == 8);
+            CHECK(p.charge == -1);
+            CHECK(p.pos.x() == 10);
+            CHECK(p.pos.y() == 20);
+            CHECK(p.pos.z() == 30);
+            CHECK(p.getExt().mu.x() == 0.1);
+            CHECK(p.getExt().mu.y() == 0.2);
+            CHECK(p.getExt().mu.z() == 0.3);
+            CHECK(p.getExt().mulen == 104);
+        }
+    }
 }
 
 TEST_SUITE_END();


### PR DESCRIPTION
This add support for [Cereal serialisation](https://uscilab.github.io/cereal/) used to implement a zlib compressed trajectory format storing all information from `Space` (geometry is still missing, though). Related to #196.
