### PR TITLE
Scattering OMP parallelisation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ set(CMAKE_CXX_EXTENSIONS NO)
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(PythonInterp 3 REQUIRED)
 find_package(Threads REQUIRED)
-find_package(zlib REQUIRED)
+find_package(ZLIB REQUIRED)
 enable_testing()
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
@@ -187,6 +187,16 @@ FetchContent_Declare(
     URL https://github.com/pybind/pybind11/archive/v2.4.3.tar.gz
     URL_HASH MD5=62254c40f89925bb894be421fe4cdef2)
 
+# NANOBENCH
+FetchContent_Declare(
+    nanobench
+    URL "https://github.com/martinus/nanobench/archive/v3.1.0.tar.gz"
+    URL_HASH MD5=e646fb61164a60921c1a1834fbca24bc)
+FetchContent_GetProperties(nanobench)
+if(NOT nanobench_POPULATED)
+    FetchContent_Populate(nanobench)
+endif()
+
 # EIGEN
 FetchContent_Declare(
     eigen
@@ -297,6 +307,7 @@ endif ()
 # Add third-party headers to include path. Note this is done with SYSTEM
 # to disable potential compiler warnings
 include_directories(SYSTEM ${eigen_SOURCE_DIR} ${doctest_SOURCE_DIR} ${modernjson_SOURCE_DIR}/include ${rangev3_SOURCE_DIR}/include
+    ${nanobench_SOURCE_DIR}/src/include
     ${Pybind11IncludeDir} ${DocoptIncludeDir} ${CppsidIncludeDir} ${XdrfileIncludeDir} ${SpdlogIncludeDir}
     ${ProgressTrackerIncludeDir} ${exprtk_SOURCE_DIR} ${cereal_SOURCE_DIR}/include ${zstr_SOURCE_DIR}/src)
 

--- a/docs/_docs/analysis.md
+++ b/docs/_docs/analysis.md
@@ -149,8 +149,8 @@ and as a function of separation, _r_. In addition, the radial distribution funct
 
 ### Structure Factor
 
-The isotropically averaged static structure factor between
-$N$ point scatterers is calculated using the [Debye formula](http://doi.org/dmb9wm),
+The isotropically averaged static structure factor between $N$ point scatterers is calculated using
+the [Debye formula](http://doi.org/dmb9wm),
 
 $$
     S(q) = 1 + \frac{2}{N} \left \langle
@@ -158,10 +158,12 @@ $$
            \right \rangle
 $$
 
-The selected `molecules` can be treated either as single
-point scatterers (`com=true`) or as a group of individual
-point scatterers of equal intensity, i.e. with a 
-form factor of unity.
+The selected `molecules` can be treated either as single point scatterers (`com=true`) or as a group of individual
+point scatterers of equal intensity, i.e., with a  form factor of unity.
+
+The computation of the structure factor is rather computationally intensive task, scaling quadratically with the number
+of particles and linearly with the number of scattering vector mesh points. If OpenMP is available, multiple threads
+may be utilized in parallel to speed it up the analysis.
 
 `scatter`   | Description
 ----------- | ------------------------------------------
@@ -174,10 +176,11 @@ form factor of unity.
 `com=true`  | Treat molecular mass centers as single point scatterers
 `pmax=15`   | Multiples of $(h,k,l)$ when using the `explicit` scheme
 `scheme=explicit` | The following schemes are available: `debye`, `explicit`
+`stepsave=false`  | Save every sample to disk
 
-The `explicit` scheme is recommended for cuboids with PBC and the calculation is performed by explicitly
-averaging the following equation over the 3+6+4 directions obtained by permuting
-the crystallographic index `[100]`, `[110]`, `[111]` to define the scattering vector
+The `explicit` scheme is recommended for cuboids with PBC and the calculation is performed by explicitly averaging
+the following equation over the 3+6+4 directions obtained by permuting the crystallographic index
+`[100]`, `[110]`, `[111]` to define the scattering vector
 $\mathbf{q} = 2\pi p/L(h,k,l)$ where $p=1,2,\dots,p\_{max}$.
 
 $$

--- a/docs/_docs/install.md
+++ b/docs/_docs/install.md
@@ -177,4 +177,3 @@ Instead of uploading to anaconda.org, install a local copy directly after the bu
 ~~~ bash
 conda install -c USER faunus --use-local
 ~~~
-

--- a/docs/_docs/running.md
+++ b/docs/_docs/running.md
@@ -127,7 +127,20 @@ Tip: Redirect the standard error output to a log file.
 faunus -v 5 -i in.json 2>> error.log
 ~~~
 
-## Message Passing Interface (MPI)
+## Parallelization
+
+### OpenMP
+
+Several routines in Faunus can run in parallel using multiple threads. The only prerequisite is that Faunus was
+compiled with OpenMP support (which is default). The number of threads is controlled with an environment variable.
+The following example demonstrates how to run Faunus using 4 threads:  
+
+~~~ bash
+export OMP_NUM_THREADS=4
+faunus -i in.json
+~~~
+
+### Message Passing Interface (MPI)
 
 Only few routines in Faunus are currently parallelisable using MPI, for example
 parallel tempering, and penalty function energies.

--- a/docs/schema.yml
+++ b/docs/schema.yml
@@ -717,6 +717,7 @@ properties:
                         scheme:
                             description: Scattering method
                             enum: [debye, explicit]
+                        stepsave: {type: boolean, default: false, description: Save every sample to disk}
                         required: [nstep, molecules, scheme]
                     additionalProperties: false
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -84,6 +84,7 @@ set(tsts
     ${CMAKE_SOURCE_DIR}/src/molecule_test.h
     ${CMAKE_SOURCE_DIR}/src/particle_test.h
     ${CMAKE_SOURCE_DIR}/src/potentials_test.h
+    ${CMAKE_SOURCE_DIR}/src/scatter_test.h
     ${CMAKE_SOURCE_DIR}/src/space_test.h
     ${CMAKE_SOURCE_DIR}/src/tensor_test.h
     )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -73,6 +73,7 @@ set(hdrs
 # faunus header files
 set(tsts
     ${CMAKE_SOURCE_DIR}/src/atomdata_test.h
+    ${CMAKE_SOURCE_DIR}/src/auxiliary_test.h
     ${CMAKE_SOURCE_DIR}/src/bonds_test.h
     ${CMAKE_SOURCE_DIR}/src/core_test.h
     ${CMAKE_SOURCE_DIR}/src/energy_test.h

--- a/src/analysis.cpp
+++ b/src/analysis.cpp
@@ -1339,6 +1339,7 @@ void ScatteringFunction::_to_json(json &j) const {
     case EXPLICIT:
         j["scheme"] = "explicit";
         j["pmax"] = explicit_average->pmax;
+        j["ipbc"] = explicit_average->ipbc;
         break;
     }
 }
@@ -1362,7 +1363,8 @@ ScatteringFunction::ScatteringFunction(const json &j, Space &spc) try : spc(spc)
     } else if (scheme_str == "explicit") {
         scheme = EXPLICIT;
         int pmax = j.value("pmax", 15);
-        explicit_average = std::make_shared<Scatter::StructureFactor<double>>(pmax);
+        bool ipbc = j.value("ipbc", false);
+        explicit_average = std::make_shared<Scatter::StructureFactor<double>>(pmax, ipbc);
         // todo: add warning if used a non-cubic system
     } else
         throw std::runtime_error("unknown scheme");

--- a/src/analysis.cpp
+++ b/src/analysis.cpp
@@ -1313,33 +1313,49 @@ void ScatteringFunction::_sample() {
     for (int id : ids) { // loop over molecule names
         auto groups = spc.findMolecules(id);
         for (auto &g : groups) // loop over groups
-            if (usecom && !g.atomic)
+            if (use_com && !g.atomic)
                 p.push_back(g.cm);
             else
                 for (auto &i : g) // loop over particle index in group
                     p.push_back(i.pos);
     }
+
+    // zero-padded suffix to use with `save_after_sample`
+    std::string suffix = fmt::format("{:07d}", cnt);
     switch (scheme) {
     case DEBYE:
         debye->sample(p, spc.geo.getVolume());
+        if (save_after_sample)
+            IO::write(filename + "." + suffix, debye->getIntensity());
         break;
-    case EXPLICIT:
-        explicit_average->sample(p, spc.geo.getLength().x());
+    case EXPLICIT_PBC:
+        explicit_average_pbc->sample(p, spc.geo.getLength().x());
+        if (save_after_sample)
+            IO::write(filename + "." + suffix, explicit_average_pbc->getSampling());
+        break;
+    case EXPLICIT_IPBC:
+        explicit_average_ipbc->sample(p, spc.geo.getLength().x());
+        if (save_after_sample)
+            IO::write(filename + "." + suffix, explicit_average_ipbc->getSampling());
         break;
     }
 }
 void ScatteringFunction::_to_json(json &j) const {
-    j = {{"molecules", names}, {"com", usecom}};
+    j = {{"molecules", names}, {"com", use_com}};
     switch (scheme) {
     case DEBYE:
         j["scheme"] = "debye";
-        j["qmin"] = debye->qmin;
-        j["qmax"] = debye->qmax;
+        std::tie(j["qmin"], j["qmax"], std::ignore) = debye->getQMeshParameters();
         break;
-    case EXPLICIT:
+    case EXPLICIT_PBC:
         j["scheme"] = "explicit";
-        j["pmax"] = explicit_average->pmax;
-        j["ipbc"] = explicit_average->ipbc;
+        j["pmax"] = explicit_average_pbc->getQMultiplier();
+        j["ipbc"] = false;
+        break;
+    case EXPLICIT_IPBC:
+        j["scheme"] = "explicit";
+        j["pmax"] = explicit_average_ipbc->getQMultiplier();
+        j["ipbc"] = true;
         break;
     }
 }
@@ -1347,7 +1363,8 @@ void ScatteringFunction::_to_json(json &j) const {
 ScatteringFunction::ScatteringFunction(const json &j, Space &spc) try : spc(spc) {
     from_json(j);
     name = "scatter";
-    usecom = j.value("com", true);
+    use_com = j.value("com", true);
+    save_after_sample = j.value("stepsave", false);   // save to disk for each sample
     filename = j.at("file").get<std::string>();
     names = j.at("molecules").get<decltype(names)>(); // molecule names
     ids = names2ids(molecules, names);                // names --> molids
@@ -1361,10 +1378,15 @@ ScatteringFunction::ScatteringFunction(const json &j, Space &spc) try : spc(spc)
         //    faunus_logger->warn("{0}: '{1}' scheme used on PBC system; consider 'explicit' instead", name,
         //    scheme_str);
     } else if (scheme_str == "explicit") {
-        scheme = EXPLICIT;
-        int pmax = j.value("pmax", 15);
         bool ipbc = j.value("ipbc", false);
-        explicit_average = std::make_shared<Scatter::StructureFactor<double>>(pmax, ipbc);
+        int pmax = j.value("pmax", 15);
+        if (ipbc) {
+            scheme = EXPLICIT_IPBC;
+            explicit_average_ipbc = std::make_shared<Scatter::StructureFactorIPBC<>>(pmax);
+        } else {
+            scheme = EXPLICIT_PBC;
+            explicit_average_pbc = std::make_shared<Scatter::StructureFactorPBC<>>(pmax);
+        }
         // todo: add warning if used a non-cubic system
     } else
         throw std::runtime_error("unknown scheme");
@@ -1375,10 +1397,13 @@ ScatteringFunction::ScatteringFunction(const json &j, Space &spc) try : spc(spc)
 void ScatteringFunction::_to_disk() {
     switch (scheme) {
     case DEBYE:
-        debye->save(filename);
+        IO::write(filename, debye->getIntensity());
         break;
-    case EXPLICIT:
-        explicit_average->save(filename);
+    case EXPLICIT_PBC:
+        IO::write(filename, explicit_average_pbc->getSampling());
+        break;
+    case EXPLICIT_IPBC:
+        IO::write(filename, explicit_average_ipbc->getSampling());
         break;
     }
 }

--- a/src/analysis.h
+++ b/src/analysis.h
@@ -420,10 +420,11 @@ class MultipoleDistribution : public Analysisbase {
  */
 class ScatteringFunction : public Analysisbase {
   private:
-    enum Schemes { DEBYE, EXPLICIT }; // two different schemes
+    enum Schemes { DEBYE, EXPLICIT_PBC, EXPLICIT_IPBC}; // three different schemes
     Schemes scheme = DEBYE;
     Space &spc;
-    bool usecom;                    // scatter from mass center, only?
+    bool use_com;                   // scatter from mass center, only?
+    bool save_after_sample = false; // if true, save average S(q) after each sample point
     std::string filename;           // output file name
     std::vector<Point> p;           // vector of scattering points
     std::vector<int> ids;           // Molecule ids
@@ -431,8 +432,8 @@ class ScatteringFunction : public Analysisbase {
     typedef Scatter::FormFactorUnity<double> Tformfactor;
 
     std::shared_ptr<Scatter::DebyeFormula<Tformfactor>> debye;
-    std::shared_ptr<Scatter::StructureFactor<double>> explicit_average;
-
+    std::shared_ptr<Scatter::StructureFactorPBC<>> explicit_average_pbc;
+    std::shared_ptr<Scatter::StructureFactorIPBC<>> explicit_average_ipbc;
     void _sample() override;
     void _to_disk() override;
     void _to_json(json &j) const override;

--- a/src/auxiliary.h
+++ b/src/auxiliary.h
@@ -25,6 +25,30 @@ namespace Faunus
         } //!< Round to int
 
     /**
+     * @brief Convert floating point number to integral number. Perform range check and rounding.
+     * @tparam TOut integral type
+     * @tparam TIn floating point type
+     * @param number (floating point type)
+     * @return number (integral type)
+     * @throw std::overflow_error
+     */
+    template <typename TOut, typename TIn> inline TOut numeric_cast(const TIn number) {
+        static_assert(std::is_floating_point<TIn>::value, "TIn must be floating point.");
+        static_assert(std::is_integral<TOut>::value, "TOut must be integer.");
+        if (std::isfinite(number)) {
+            // The number is finite ...
+            if (number < std::nextafter(static_cast<TIn>(std::numeric_limits<TOut>::max()), 0) &&
+                number > std::nextafter(static_cast<TIn>(std::numeric_limits<TOut>::min()), 0)) {
+                // ... and fits into the integral type range.
+                // The nextafter function is used to mitigate possible rounding up or down.
+                return static_cast<TOut>(number >= 0 ? number + 0.5 : number - 0.5); // round before cast
+            }
+        }
+        // not-a-number, infinite, or outside the representable range
+        throw std::overflow_error("numeric cast overflow");
+    }
+
+    /**
      * @brief Iterate over pairs in container, call a function on the elements, and sum results
      * @tparam T Floating point type. Default: `double)`
      * @param begin Begin iterator

--- a/src/auxiliary_test.h
+++ b/src/auxiliary_test.h
@@ -1,0 +1,31 @@
+#include "auxiliary.h"
+#include <cmath>
+
+namespace Faunus {
+
+using doctest::Approx;
+
+TEST_SUITE_BEGIN("Auxiliary");
+
+TEST_CASE("numeric_cast") {
+    CHECK_EQ(numeric_cast<int>(2.2), 2);
+    CHECK_EQ(numeric_cast<int>(-2.2), -2);
+    CHECK_EQ(numeric_cast<int>(2.8), 3);
+    CHECK_EQ(numeric_cast<int>(-2.8), -3);
+
+    double short_overflow = std::numeric_limits<short>::max() + 1;
+    double short_underflow = std::numeric_limits<short>::min() - 1;
+    CHECK_NOTHROW(numeric_cast<int>(short_overflow));
+    CHECK_THROWS_AS(numeric_cast<short>(short_overflow), std::overflow_error);
+    CHECK_NOTHROW(numeric_cast<int>(short_underflow));
+    CHECK_THROWS_AS(numeric_cast<short>(short_underflow), std::overflow_error);
+    CHECK_NOTHROW(numeric_cast<int>(-1.0));
+    CHECK_THROWS_AS(numeric_cast<unsigned>(-1.0), std::overflow_error);
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wdiv-by-zero"
+    CHECK_THROWS_AS(numeric_cast<int>(1. / 0), std::overflow_error);
+    #pragma GCC diagnostic pop
+}
+
+TEST_SUITE_END();
+} // namespace Faunus

--- a/src/geometry.h
+++ b/src/geometry.h
@@ -169,6 +169,7 @@ class Sphere : public GeometryImplementation {
     double getVolume(int dim = 3) const override;
     Point setVolume(double volume, VolumeMethod method = ISOTROPIC) override;
     Point vdist(const Point &a, const Point &b) const override;
+    double sqdist(const Point &a, const Point &b) const { return (a - b).squaredNorm(); };
     void boundary(Point &a) const override;
     bool collision(const Point &a) const override;
     void randompos(Point &m, Random &rand) const override;

--- a/src/io.h
+++ b/src/io.h
@@ -27,6 +27,37 @@ bool writeFile(const std::string &file, const std::string &s,
 
 void strip(std::vector<std::string> &string_vector, const std::string &pattern); //!< Strip lines matching a pattern
 
+/**
+ * Write a map to an output stream as key-value pairs
+ * @tparam TKey
+ * @tparam TValue
+ * @param stream Output stream
+ * @param data
+ */
+template <typename TKey, typename TValue>
+void write(std::ostream &stream, const std::map<TKey, TValue> &data, const std::string &sep = " ", const std::string &end = "\n") {
+    if (stream) {
+        for (auto [key, value] : data) {
+            stream << key << sep << value << end;
+        }
+    }
+}
+
+/**
+ * Write a map to a file as key-value pairs
+ * @tparam TKey
+ * @tparam TValue
+ * @param filename
+ * @param data
+ */
+template<typename TKey, typename TValue>
+void write(const std::string &filename, const std::map<TKey, TValue>& data) {
+    if (!data.empty()) {
+        std::ofstream file(filename);
+        write(file, data);
+    }
+}
+
 } // namespace IO
 
 /**

--- a/src/io.h
+++ b/src/io.h
@@ -50,8 +50,7 @@ void write(std::ostream &stream, const std::map<TKey, TValue> &data, const std::
  * @param filename
  * @param data
  */
-template<typename TKey, typename TValue>
-void write(const std::string &filename, const std::map<TKey, TValue>& data) {
+template <typename TKey, typename TValue> void write(const std::string &filename, const std::map<TKey, TValue> &data) {
     if (!data.empty()) {
         std::ofstream file(filename);
         write(file, data);

--- a/src/scatter.h
+++ b/src/scatter.h
@@ -2,10 +2,12 @@
 
 #include <fstream>
 #include <algorithm>
+#include <cmath>
 
 namespace Faunus {
 
-/** @brief Routines related to scattering */
+/** @brief Routines related to scattering.
+ */
 namespace Scatter {
 
 /** @brief Form factor, `F(q)`, for a hard sphere of radius `R`.
@@ -20,7 +22,7 @@ template <class T = float> class FormFactorSphere {
   public:
     /**
      * @param q q value in inverse angstroms
-     * @param a particle to take radius, \c R from.
+     * @param a particle to take radius, \c R from
      * @returns
      * @f$I(q)=\left [\frac{3}{(qR)^3}\left (\sin{qR}-qR\cos{qR}\right )\right ]^2@f$
      */
@@ -33,168 +35,212 @@ template <class T = float> class FormFactorSphere {
 };
 
 /**
- * @brief Unity form factor (q independent)
+ * @brief Unity form factor (q independent).
  */
 template <class T = float> struct FormFactorUnity {
     template <class Tparticle> T operator()(T, const Tparticle &) const { return 1; }
 };
 
 /**
- * @brief Calculates scattering intensity, I(q) using the Debye formula
+ * @brief Calculate scattering intensity, I(q), on a mesh using the Debye formula.
  *
- * It is important to note that distances should be calculated without
- * periodicity and if molecules cross periodic boundaries, these
- * must be made whole before performing the analysis.
+ * It is important to note that distances should be calculated without periodicity and if molecules cross
+ * periodic boundaries, these must be made whole before performing the analysis.
+ *
  * The JSON object is scanned for the following keywords:
  *
- * - `qmin` Minimum q value (1/angstrom)
- * - `qmax` Maximum q value (1/angstrom)
- * - `dr` q spacing (1/angstrom)
- * - `cutoff` Cutoff distance (angstrom). *Experimental!*
+ * - `qmin` minimum q value (1/angstrom)
+ * - `qmax` maximum q value (1/angstrom)
+ * - `dq` q mesh spacing (1/angstrom)
+ * - `cutoff` cutoff distance (angstrom); *Experimental!*
  *
- * See also <http://dx.doi.org/10.1016/S0022-2860(96)09302-7>
+ * @see http://dx.doi.org/10.1016/S0022-2860(96)09302-7
  */
-template <class Tformfactor, class Tgeometry = Geometry::Chameleon, class T = float> class DebyeFormula {
-  protected:
-    Tformfactor F;    // scattering from a single particle
-    Tgeometry geo;    // geometry to use for distance calculations
-    std::map<T, T> I; //!< Sampled, average I(q)
-    std::map<T, T> S; //!< Weighted number of samplings
-    T rc;
+template <class Tformfactor, class T = float> class DebyeFormula {
+    static constexpr T r_cutoff_infty = 1e9; //<! a cutoff distance in angstrom considered to be infinity
+    T q_mesh_min, q_mesh_max, q_mesh_step; //<! q_mesh parameters in inverse angstrom; used for inline lambda-functions
+
+    /**
+     * @param m mesh point index
+     * @return the scattering vector magnitude q at the mesh point m
+     */
+    #pragma omp declare simd uniform(this) linear(m:1)
+    inline T q_mesh(int m) {
+        return q_mesh_min + m * q_mesh_step;
+    }
+
+    /**
+     * @brief Initialize mesh for intensity and sampling.
+     * @param q_min Minimum q-value to sample (1/A)
+     * @param q_max Maximum q-value to sample (1/A)
+     * @param q_step Spacing between mesh points (1/A)
+     */
+    void init_mesh(T q_min, T q_max, T q_step) {
+        if (q_step <= 0 || q_min <= 0 || q_max <= 0 || q_min > q_max ||
+            q_step / q_max < 4 * std::numeric_limits<T>::epsilon()) {
+            throw std::range_error("DebyeFormula: Invalid mesh parameters for q");
+        }
+        q_mesh_min = q_min < 1e-6 ? q_step : q_min; // ensure that q > 0
+        q_mesh_max = q_max;
+        q_mesh_step = q_step;
+        try {
+            // resolution of the 1D mesh approximation of the scattering vector magnitude q
+            const int q_resolution = numeric_cast<int>(1 + std::floor((q_max - q_min) / q_step));
+            intensity.resize(q_resolution, 0.0);
+            sampling.resize(q_resolution, 0.0);
+        } catch (std::overflow_error &e) {
+            throw std::range_error("DebyeFormula: Too many samples");
+        }
+    }
+
+    Geometry::Sphere geo = Geometry::Sphere(r_cutoff_infty / 2); //!< geometry to use for distance calculations
+    T r_cutoff;                   //!< cut-off distance for scattering contributions (angstrom)
+    Tformfactor form_factor;      //!< scattering from a single particle
+    std::vector<T> intensity;     //!< sampled average I(q)
+    std::vector<T> sampling;      //!< weighted number of samplings
 
   public:
-    T qmin, qmax, dq;
+    DebyeFormula(T q_min, T q_max, T q_step, T r_cutoff) : r_cutoff(r_cutoff) { init_mesh(q_min, q_max, q_step); };
 
-    DebyeFormula(const json &j) {
-        geo = R"( { "type": "sphere", "radius": 1e9 } )"_json;
-        dq = j.at("dq").get<double>();
-        qmin = j.at("qmin").get<double>();
-        qmax = j.at("qmax").get<double>();
-        rc = j.value("cutoff", 1.0e9);
+    DebyeFormula(T q_min, T q_max, T q_step) : DebyeFormula(r_cutoff_infty, q_min, q_max, q_step) {};
 
-        if (dq <= 0 || qmin <= 0 || qmax <= 0 || qmin > qmax)
-            throw std::runtime_error("DebyeFormula: invalid q parameters");
-    }
+    explicit DebyeFormula(const json &j)
+        : DebyeFormula(j.at("qmin").get<double>(), j.at("qmax").get<double>(), j.at("dq").get<double>(),
+                       j.value("cutoff", r_cutoff_infty)){};
 
     /**
-     * @brief Sample I(q) and add to average
+     * @brief Sample I(q) and add to average.
+     * @param p particle vector
+     * @param weight weight of sampled configuration in biased simulations
+     * @param volume simulation volume (angstrom cubed) used only for cut-off correction
      *
-     * The q range is read from input as `qmin`, `qmax`, `dq` in units of
-     * inverse angstrom.
-     * It is also possible to specify an isotropic correction beyond
-     * a given cut-off -- see for example
-     * <https://debyer.readthedocs.org/en/latest/>.
-     * The cut-off distance - which should be smaller than half the
-     * box length for a cubic system is read specific by the
-     * keyword `sofq_cutoff`.
+     * An isotropic correction is added beyond a given cut-off distance. For physics details see for example
+     * @see https://debyer.readthedocs.org/en/latest/.
+     *
+     * O(N^2) * O(M) complexity where N is the number of particles and M the number of mesh points. The quadratic
+     * complexity in N comes from the fact that the radial distribution function has to be computed.
+     * The current implementation supports OpenMP parallelization. Roughly half of the execution time is spend
+     * on computing sin values, e.g., in sinf_avx2.
      */
-    template <class Tpvec> void sample(const Tpvec &p, T f = 1, T V = -1) {
-        assert(qmin > 0 && qmax > 0 && dq > 0 && "q range invalid.");
-        sample(p, qmin, qmax, dq, f, V);
-    }
+    template <class Tpvec> void sample(const Tpvec &p, const T weight = 1, const T volume = -1) {
+        const int N = (int) p.size(); // number of particles
+        const int M = (int) intensity.size(); // number of mesh points
+        std::vector<T> intensity_sum(M, 0.0);
 
-    /**
-     * @brief Sample I(q) and add to average
-     * @param p Particle vector
-     * @param qmin Minimum q-value to sample (1/A)
-     * @param qmax Maximum q-value to sample (1/A)
-     * @param dq q spacing (1/A)
-     * @param f weight of sampled configuration in biased simulations
-     * @param V Simulation volume (angstrom^3) used only for cut-off correction
-     */
-    template <class Tpvec> void sample(const Tpvec &p, T qmin, T qmax, T dq, T f = 1, T V = -1) {
-        if (qmin < 1e-6)
-            qmin = dq; // ensure that q>0
-
-        // Temporary f(q) functions - initialized to
-        // enable O(N) complexity iteration in inner loop.
-        std::map<T, T> _I, _ff;
-        for (T q = qmin; q <= qmax; q += dq)
-            _I[q] = _ff[q] = 0;
-
-        int N = (int)p.size();
-        for (int i = 0; i < N - 1; ++i) {
-            for (int j = i + 1; j < N; ++j) {
-                T r = geo.sqdist(p[i], p[j]);
-                if (r < rc * rc) {
-                    r = sqrt(r);
-                    for (auto &m : _I) { // O(N) complexity
-                        T q = m.first;
-                        m.second += F(q, p[i]) * F(q, p[j]) * sin(q * r) / (q * r);
+        // Allow parallelization with a hand written reduction of intensity_sum at the end.
+        // https://gcc.gnu.org/gcc-9/porting_to.html#ompdatasharing
+        // #pragma omp parallel default(none) shared(N, M) shared(geo, r_cutoff, p) shared(intensity_sum)
+        #pragma omp parallel default(shared) shared(intensity_sum)
+        {
+            std::vector<T> intensity_sum_private(M, 0.0); // a temporal private intensity_sum
+            #pragma omp for schedule(dynamic)
+            for (int i = 0; i < N - 1; ++i) {
+                for (int j = i + 1; j < N; ++j) {
+                    T r = geo.sqdist(p[i], p[j]); // the square root follows
+                    if (r < r_cutoff * r_cutoff) {
+                        r = std::sqrt(r);
+                        // Black magic: The q_mesh function must be inlineable otherwise the loop cannot be unrolled
+                        // using advanced SIMD instructions leading to a huge performance penalty (a factor of 4).
+                        // The unrolled loop uses a different sin implementation, which may be spotted when profiling.
+                        // TODO: Optimize also for other compilers than GCC by using a vector math library, e.g.,
+                        // TODO: https://github.com/vectorclass/version2
+                        // #pragma GCC unroll 16 // for diagnostics, GCC issues warning when cannot unroll
+                        for (int m = 0; m < M; ++m) {
+                            const T q = q_mesh(m);
+                            intensity_sum_private[m] +=
+                                form_factor(q, p[i]) * form_factor(q, p[j]) * std::sin(q * r) / (q * r);
+                        }
                     }
                 }
             }
+            // reduce intensity_sum_private into intensity_sum
+            #pragma omp critical
+            std::transform(intensity_sum.begin(), intensity_sum.end(), intensity_sum_private.begin(),
+                           intensity_sum.begin(), std::plus<T>());
         }
-        for (int i = 0; i < N; i++)
-            for (T q = qmin; q <= qmax; q += dq)
-                _ff[q] += pow(F(q, p[i]), 2);
 
-        for (auto &i : _I) {
-            T q = i.first, Icorr = 0;
-            if (rc < 1e9 && V > 0)
-                Icorr = 4 * pc::pi * N / (V * pow(q, 3)) * (q * rc * cos(q * rc) - sin(q * rc));
-            S[q] += f;
-            I[q] += ((2 * i.second + _ff[q]) / N + Icorr) * f; // add to average I(q)
-        }
-    }
-
-    /**
-     * @brief Sample between all groups
-     *
-     * Instead of looping over all particles, this will ignore all internal
-     * group distances.
-     *
-     * @param p Particle vector
-     * @param groupList Vector of group pointers - i.e. as returned from `Space::groupList()`.
-     * @note Particle form factors are always set to unity, i.e. F(q) is ignored.
-     *
-     * @warning Untested
-     */
-    template <class Tpvec, class Tg> void sampleg2g(const Tpvec &p, Tg groupList) {
-        assert(qmin > 0 && qmax > 0 && dq > 0 && "q range invalid.");
-        sampleg2g(p, qmin, qmax, dq, groupList);
-    }
-
-    template <class Tpvec, class Tg> void sampleg2g(const Tpvec &p, T qmin, T qmax, T dq, Tg groupList) {
-        std::vector<T> _I(int((qmax - qmin) / dq + 0.5));
-        // loop over all pairs of groups, then over particles
-        for (int k = 0; k < (int)groupList.size() - 1; k++)
-            for (int l = k + 1; l < (int)groupList.size(); l++)
-                for (auto i : *groupList.at(k))
-                    for (auto j : *groupList.at(l)) {
-                        T r = geo.vdist(p[i].pos, p[j].pos).norm();
-                        int cnt = 0;
-                        for (T q = qmin; q <= qmax; q += dq)
-                            _I.at(cnt++) += sin(q * r) / (q * r);
-                    }
-        int cnt = 0, N = p.size();
-        for (T q = qmin; q <= qmax; q += dq)
-            I[q] += 2. * _I.at(cnt++) / N + 1; // add to average I(q)
-    }
-
-    /**
-     * @brief Save I(q) to disk
-     */
-    void save(const std::string &filename) {
-        if (!I.empty()) {
-            std::ofstream f(filename.c_str());
-            if (f) {
-                for (auto &i : I) {
-                    if (not S.empty())
-                        f << i.first << " " << i.second / S[i.first] << "\n";
-                    else
-                        f << i.first << " " << i.second << "\n";
-                }
+        // https://gcc.gnu.org/gcc-9/porting_to.html#ompdatasharing
+        // #pragma omp parallel for default(none) shared(N, M, weight, volume) shared(p, r_cutoff, intensity_sum) shared(sampling, intensity)
+        #pragma omp parallel for shared(sampling, intensity)
+        for (int m = 0; m < M; ++m) {
+            const T q = q_mesh(m);
+            T intensity_self_sum = 0;
+            for (int i = 0; i < N; ++i) {
+                intensity_self_sum += std::pow(form_factor(q, p[i]), 2);
             }
+            T intensity_corr = 0;
+            if (r_cutoff < r_cutoff_infty && volume > 0) {
+                intensity_corr = 4 * pc::pi * N / (volume * std::pow(q, 3)) *
+                         (q * r_cutoff * std::cos(q * r_cutoff) - std::sin(q * r_cutoff));
+            }
+            sampling[m] += weight;
+            intensity[m] += ((2 * intensity_sum[m] + intensity_self_sum) / N + intensity_corr) * weight;
         }
+    }
+
+    /**
+     * @return a tuple of min, max, and step parameters of a q-mash
+     */
+    auto getQMeshParameters() {
+        return std::make_tuple(q_mesh_min, q_mesh_max, q_mesh_step);
+    }
+
+    /**
+     * @return a map containing q (key) and average intensity (value)
+     */
+    auto getIntensity() {
+        std::map<T, T> averaged_intensity;
+        for (size_t m = 0; m < intensity.size(); ++m) {
+            const T average = intensity[m] / (sampling[m] != 0.0 ? sampling[m] : 1.0);
+            averaged_intensity.emplace(q_mesh(m), average);
+        }
+        return averaged_intensity;
     }
 };
 
+
 /**
- * @brief Structor factor calculation using explicit q averaging
+ * A policy for collecting samples. To be used together with StructureFactor class templates.
  *
- * This averages over the thirteen permutations of
- * the Miller index [100], [110], [101] using:
+ * @tparam T float or double
+ */
+template <typename T> class SamplingPolicy {
+  public:
+    struct sampled_value {
+        T value;
+        T weight;
+    };
+    typedef std::map<T, sampled_value> TSampledValueMap;
+  private:
+    TSampledValueMap samples;
+    const T precision = 10000.0; //!< precision of the key for better binning
+
+  public:
+    std::map<T, T> getSampling() const {
+        std::map<T, T> average;
+        for (auto [key, sample] : samples) {
+            average.emplace(key, sample.value / sample.weight);
+        }
+        return average;
+    }
+
+    /**
+     * @param key_approx is subject of rounding for better binning
+     * @param value
+     * @param weight
+     */
+    void addSampling(T key_approx, T value, T weight = 1.0) {
+        const T key = std::round(key_approx * precision) / precision; // round |q| for better binning
+        samples[key].value += value * weight;
+        samples[key].weight += weight;
+    }
+};
+
+
+/**
+ * @brief Calculate structure factor using explicit q averaging.
+ *
+ * This averages over the thirteen permutations of the Miller index [100], [110], [101] using:
  *
  * @f[ S(\mathbf{q}) = \frac{1}{N} \left <
  *    \left ( \sum_i^N \sin(\mathbf{qr}_i) \right )^2 +
@@ -202,74 +248,122 @@ template <class Tformfactor, class Tgeometry = Geometry::Chameleon, class T = fl
  *   \right >
  * @f]
  *
- * For more information, see http://doi.org/d8zgw5 and http://doi.org/10.1063/1.449987
- *
- * @todo Add OpenMP pragmas and particle formfactors or std::execution::par when available
+ * For more information, see @see http://doi.org/d8zgw5 and @see http://doi.org/10.1063/1.449987.
  */
-template <typename T = double> class StructureFactor {
-  private:
-    std::map<T, T> S; //!< Average S(q)
-    std::map<T, T> W; //!< Weighted number of samplings
-
-    // Sample directions (h,k,l)
-    std::vector<Point> directions = {
+template <typename T = float, typename TSamplingPolicy = SamplingPolicy<T>> class StructureFactorPBC : private TSamplingPolicy {
+    //! sample directions (h,k,l)
+    const std::vector<Point> directions = {
         {1, 0, 0}, {0, 1, 0},  {0, 0, 1},                                      // 3 permutations
         {1, 1, 0}, {0, 1, 1},  {1, 0, 1},  {-1, 1, 0}, {-1, 0, 1}, {0, -1, 1}, // 6 permutations
         {1, 1, 1}, {-1, 1, 1}, {1, -1, 1}, {1, 1, -1}                          // 4 permutations
     };
 
-    T precision = 10000.0; //!< Output precision used for better binning
+    const int p_max;  //!< multiples of q to be sampled
+    using TSamplingPolicy::addSampling;
 
   public:
-    StructureFactor(int number_of_scalings, bool ipbc = false) : pmax(number_of_scalings), ipbc(ipbc) {
-        // due to symmetry in IPBC we need not consider permutations
-        if (ipbc)
-            directions = {{1, 0, 0}, {1, 1, 0}, {1, 1, 1}};
-    }
+    StructureFactorPBC(int q_multiplier) : p_max(q_multiplier){}
 
-    int pmax;  //!< Multiples of q to be sampled
-    bool ipbc; //!< True if using isotropic periodic boundaries
-
-    template <class Tpvec> void sample(const Tpvec &positions, double boxlength) {
-        auto func = [&](Point &dir) {
-            T f = (ipbc) ? std::pow(2, dir.count()) : 1.0;     // 2 ^ number of non-zero elements if IPBC
-            for (int p = 1; p <= pmax; p++) {                  // loop over multiples of q
-                Point _q = (2 * pc::pi * p / boxlength) * dir; // scattering vector
-                double sum_sin = 0, sum_cos = 0;               // temporary sums
-                if (ipbc) {
-                    for (auto &r : positions) { // loop over positions
-                        double product = cos(_q[0] * r[0]);
-                        if (_q[1] > 0)
-                            product *= cos(_q[1] * r[1]);
-                        if (_q[2] > 0)
-                            product *= cos(_q[2] * r[2]);
-                        sum_cos += product;
-                        // sum_cos += cos(_q[0]*r[0]) * cos(_q[1]*r[1]) * cos(_q[2]*r[2]);
-                    }
-                } else {
-                    for (auto &r : positions) { // loop over positions
-                        T qr = _q.dot(r);       // scalar product q*r
-                        sum_sin += sin(qr);
-                        sum_cos += cos(qr);
-                    }
+    template <class Tpvec> void sample(const Tpvec &positions, const double boxlength) {
+        // https://gcc.gnu.org/gcc-9/porting_to.html#ompdatasharing
+        // #pragma omp parallel for collapse(2) default(none) shared(directions, p_max, boxlength) shared(positions)
+        #pragma omp parallel for collapse(2) default(shared)
+        for (int i = 0; i < directions.size(); ++i) {
+            for (int p = 1; p <= p_max; ++p) {                                // loop over multiples of q
+                const Point q = (2 * pc::pi * p / boxlength) * directions[i]; // scattering vector
+                #ifdef __GNUC__
+                // When sine and cosine is computed in separate loops, advanced sine and cosine implementation
+                // utilizing SIMD instructions may be used to get at least 4 times performance boost.
+                // As of January 2020, only GCC exploits this using libmvec library if --ffast-math is enabled.
+                std::vector<T> qr_products(positions.size());
+                std::transform(positions.begin(), positions.end(), qr_products.begin(),
+                               [&q](auto &r) { return q.dot(r); });
+                // as of January 2020 the std::transform_reduce is not implemented in libc++
+                T sum_sin = 0;
+                for (auto &qr : qr_products) {
+                    sum_sin += std::sin(qr);
                 }
+                // as of January 2020 the std::transform_reduce is not implemented in libc++
+                T sum_cos = 0;
+                for (auto &qr : qr_products) {
+                    sum_cos += std::cos(qr);
+                }
+                #else
+                // TODO: Optimize also for other compilers than GCC by using a vector math library, e.g.,
+                // TODO: https://github.com/vectorclass/version2
+                T sum_sin = 0, sum_cos = 0;
+                for (auto &r : positions) { // loop over positions
+                    T qr = _q.dot(r);       // scalar product q*r
+                    sum_sin += sin(qr);
+                    sum_cos += cos(qr);
+                }
+                #endif
                 // collect average, `norm()` gives the scattering vector length
-                T qlen = std::round(_q.norm() * precision) / precision; // round |q| for better binning
-                S[qlen] += (sum_sin * sum_sin + sum_cos * sum_cos) / T(positions.size()) * f;
-                W[qlen] += 1.0;
+                const T sf = (sum_sin * sum_sin + sum_cos * sum_cos) / (float)(positions.size());
+                #pragma omp critical
+                // avoid race conditions when updating the map
+                addSampling(q.norm(), sf, 1.0);
             }
-        };
-        std::for_each(directions.begin(), directions.end(), func); // loop over 3+6+4=13 directions; add std::execution::par policy?
-    }
-
-    void save(const std::string &filename) {
-        if (not S.empty()) {
-            std::ofstream f(filename.c_str());
-            if (f)
-                for (auto &i : S)
-                    f << i.first << " " << i.second / W[i.first] << "\n";
         }
     }
+
+    int getQMultiplier() {
+        return p_max;
+    }
+
+    using TSamplingPolicy::getSampling;
+};
+
+
+/**
+ * @brief Calculate structure factor using explicit q averaging in isotropic periodic boundary conditions (IPBC).
+ *
+ * The sample directions reduce to 3 compared to 13 in regular periodic boundary conditions. Overall simplification
+ * shall yield roughly 10 times faster computation.
+ */
+template <typename T = float, typename TSamplingPolicy = SamplingPolicy<T>> class StructureFactorIPBC : private TSamplingPolicy {
+    //! Sample directions (h,k,l).
+    //! Due to the symmetry in IPBC we need not consider permutations of directions.
+    std::vector<Point> directions = {{1, 0, 0}, {1, 1, 0}, {1, 1, 1}};
+
+    int p_max;  //!< multiples of q to be sampled
+    using TSamplingPolicy::addSampling;
+
+  public:
+    StructureFactorIPBC(int q_multiplier) : p_max(q_multiplier){}
+
+    template <class Tpvec> void sample(const Tpvec &positions, const double boxlength) {
+        // https://gcc.gnu.org/gcc-9/porting_to.html#ompdatasharing
+        // #pragma omp parallel for collapse(2) default(none) shared(directions, p_max, positions, boxlength)
+        #pragma omp parallel for collapse(2) default(shared)
+        for (size_t i = 0; i < directions.size(); ++i) {
+            for (int p = 1; p <= p_max; ++p) {                                // loop over multiples of q
+                const Point q = (2 * pc::pi * p / boxlength) * directions[i]; // scattering vector
+                T sum_cos = 0;
+                for (auto &r : positions) { // loop over positions
+                    // if q[i] == 0 then its cosine == 1 hence we can avoid cosine computation for performance reasons
+                    T product = cos(q[0] * r[0]);
+                    if (q[1] != 0)
+                        product *= cos(q[1] * r[1]);
+                    if (q[2] != 0)
+                        product *= cos(q[2] * r[2]);
+                    sum_cos += product;
+                }
+                // collect average, `norm()` gives the scattering vector length
+                const T ipbc_factor = std::pow(2, directions[i].count()); // 2 ^ number of non-zero elements
+                const T sf = (sum_cos * sum_cos) / (float)(positions.size()) * ipbc_factor;
+                #pragma omp critical
+                // avoid race conditions when updating the map
+                addSampling(q.norm(), sf, 1.0);
+            }
+        }
+    }
+
+    int getQMultiplier() {
+        return p_max;
+    }
+
+    using TSamplingPolicy::getSampling;
 };
 
 } // namespace Scatter

--- a/src/scatter_test.h
+++ b/src/scatter_test.h
@@ -1,0 +1,58 @@
+#include "analysis.h"
+#include "io.h"
+
+#define ANKERL_NANOBENCH_IMPLEMENT
+#include "nanobench.h"
+
+namespace Faunus {
+namespace Scatter {
+
+using doctest::Approx;
+
+double box = 80;
+const std::vector<Point> positions = {
+    {10, 20, 30},  {-32, 19, 1},  {34, -2, 23}, {0, 0, 1},     {25, 0, -12},
+    {-6, -4, -29}, {-12, 23, -3}, {3, 1, -4},   {-31, 29, -20}}; // random position vector
+
+TEST_CASE_TEMPLATE("[Faunus] StructureFactorPBC", T, StructureFactorPBC<float, SIMD>,
+                   StructureFactorPBC<float, EIGEN>, StructureFactorPBC<float, GENERIC>) {
+    size_t cnt = 0;
+    std::vector<float> result = {0.0785, 1.48621,  0.1111, 0.567279, 0.136,  1.39515,
+                                 0.1571, 0.730579, 0.2221, 0.701547, 0.2721, 0.692064};
+    T scatter(2);
+    scatter.sample(positions, box);
+    for (auto [q, S] : scatter.getSampling()) {
+        CHECK(q == Approx(result[cnt++]));
+        CHECK(S == Approx(result[cnt++]));
+    }
+    CHECK(cnt == result.size());
+}
+
+#ifdef ANKERL_NANOBENCH_H_INCLUDED
+TEST_CASE("Benchmark") {
+    std::vector<Point> pos(1000);
+    for (auto &p : pos)
+        p = Eigen::Vector3d::Random() * box;
+    ankerl::nanobench::Config bench;
+    bench.minEpochIterations(100);
+    bench.run("SIMD", [&] { StructureFactorPBC<double, SIMD>(10).sample(pos, box); }).doNotOptimizeAway();
+    bench.run("EIGEN", [&] { StructureFactorPBC<double, EIGEN>(10).sample(pos, box); }).doNotOptimizeAway();
+    bench.run("GENERIC", [&] { StructureFactorPBC<double, GENERIC>(10).sample(pos, box); }).doNotOptimizeAway();
+}
+#endif
+
+TEST_CASE("[Faunus] StructureFactorIPBC") {
+    size_t cnt = 0;
+    std::vector<double> result = {0.0785, 0.384363, 0.1111, 1.51652, 0.136,  1.18027,
+                                  0.1571, 1.40662,  0.2221, 2.06042, 0.2721, 1.53482};
+    StructureFactorIPBC scatter(2);
+    scatter.sample(positions, box);
+    for (auto [q, S] : scatter.getSampling()) {
+        CHECK(q == Approx(result[cnt++]));
+        CHECK(S == Approx(result[cnt++]));
+    }
+    CHECK(cnt == result.size());
+}
+
+} // namespace Scatter
+} // namespace Faunus

--- a/src/unittests.cpp
+++ b/src/unittests.cpp
@@ -26,6 +26,7 @@
 #include "space_test.h"
 #include "tensor_test.h"
 #include "externalpotential_test.h"
+#include "scatter_test.h"
 
 #include "mpicontroller.h"
 #include "auxiliary.h"

--- a/src/unittests.cpp
+++ b/src/unittests.cpp
@@ -14,6 +14,7 @@
 #include "random.h"
 
 #include "atomdata_test.h"
+#include "auxiliary_test.h"
 #include "bonds_test.h"
 #include "core_test.h"
 #include "energy_test.h"


### PR DESCRIPTION
# Description

Refactor and paralellise scattering analysis
    
OpenMP is enabled for loops in the sample methods that have O(N^2) complexity, where N is number of particles.
    
Furthermore, the sample methods are rewritten to allow automatic vectorisation of trigonometric functions in GCC by using `libmvec` vector math library when `--ffast-math` is enabled. This speeds up the analysis by factor of 4 on modern processors.

## Checklist

- No unit tests were provided.
- [x] code naming scheme follows the convention
  - Constants for OMP ranges are single capital letters here, which is a grey zone of naming rules. Other rules should be honoured. Variables have been extensively renamed from a single letter physicist convention to English words to follow our programmers convention.
- [x] the source code is well documented
- [x] the user-manual is updated regarding the effective parallelisation
- [ ] performance is checked in supported configurations: (GCC, Clang) × (GNU/Linux, MacOSX)

## Note

The pull request includes and thus obsoletes the pull request #241.