### PR TITLE
Refactoring of Ewald summation policies and Energy class

### DIFF
--- a/docs/_docs/energy.md
+++ b/docs/_docs/energy.md
@@ -242,7 +242,7 @@ self energies are automatically added to the Hamiltonian, activating additional 
 --------------------- | ---------------------------------------------------------------------
 `kcutoff`             | Reciprocal-space cutoff
 `epss=0`              | Dielectric constant of surroundings, $\varepsilon_{surf}$ (0=tinfoil)
-`ipbc=false`          | Use isotropic periodic boundary conditions, [IPBC](http://doi.org/css8). Holds also for Yukawa-type interactions.
+`ewaldscheme=PBC`     | Periodic (`PBC`) or isotropic periodic ([`IPBC`](http://doi.org/css8)) boundary conditions
 `spherical_sum=true`  | Spherical/ellipsoidal summation in reciprocal space; cubic if `false`.
 `debyelength=`$\infty$| Debye length (Å)
 
@@ -266,12 +266,12 @@ $$
 $$
 
 $$
-A_k = \frac{e^{-( k^2 + \kappa^2 )/4\alpha^2}}{k^2}
+A\_k = \frac{e^{-( k^2 + \kappa^2 )/4\alpha^2}}{k^2}
 \quad \quad Q^{q\mu} = Q^{q} + Q^{\mu}
 $$
 
 $$
-Q^{q} = \sum_{j}q_je^{i({\bf k}\cdot {\bf r}_j)} \quad Q^{\mu} = \sum_{j}i({\boldsymbol{\mu}}_j\cdot {\bf k})  e^{i({\bf k}\cdot {\bf r}_j)}
+Q^{q} = \sum_{j}q\_je^{i({\bf k}\cdot {\bf r}\_j)} \quad Q^{\mu} = \sum_{j}i({\boldsymbol{\mu}}\_j\cdot {\bf k})  e^{i({\bf k}\cdot {\bf r}\_j)}
 $$
 
 $$

--- a/docs/schema.yml
+++ b/docs/schema.yml
@@ -221,7 +221,7 @@ properties:
                           alpha: {type: number}
                           kcutoff: {type: number}
                           ipbc: {type: boolean, default: false}
-                          ewaldtype: {type: string, enum: [PBC, IPBC], default: PBC}
+                          ewaldscheme: {type: string, enum: [PBC, PBCEigen, IPBC], default: PBCEigen}
                       required: [cutoff, epss, alpha, kcutoff]
 
         mixing_rule:

--- a/docs/schema.yml
+++ b/docs/schema.yml
@@ -221,6 +221,7 @@ properties:
                           alpha: {type: number}
                           kcutoff: {type: number}
                           ipbc: {type: boolean, default: false}
+                          ewaldtype: {type: string, enum: [PBC, IPBC], default: PBC}
                       required: [cutoff, epss, alpha, kcutoff]
 
         mixing_rule:

--- a/examples/water/ewald.yml
+++ b/examples/water/ewald.yml
@@ -1,0 +1,40 @@
+#!/usr/bin/env yason.py
+temperature: 300
+random: {seed: fixed}
+geometry: {type: cuboid, length: 18.6}
+mcloop: {macro: 5, micro: 10}
+
+atomlist:
+    - OW: {q: -0.8476, sigma: 3.166, eps: 0.650, mw: 15.999}
+    - HW: {q: 0.4238,  sigma: 2, eps: 0, mw: 1.007}
+
+moleculelist:
+    - water:
+        structure:
+            - OW: [2.30, 6.28, 1.13]
+            - HW: [ 1.37,6.26, 1.50]
+            - HW: [2.31, 5.89, 0.21]
+
+insertmolecules:
+    - water: {N: 256}
+
+energy:
+    - isobaric: {P/atm: 1}
+    - nonbonded_coulomblj:
+        lennardjones: {mixing: LB}
+        coulomb: {type: ewald, epsr: 1, cutoff: 9, kcutoff: 7.3, epss: 0, alpha: 0.2, ewaldscheme: IPBC}
+        cutoff_g2g: 10
+
+moves:
+    - moltransrot: {molecule: water, dp: 0.4, dprot: 0.4, repeat: N}
+    - volume: {dV: 0.03, method: isotropic}
+
+analysis:
+    - sanity: {nstep: 100}
+    - atomrdf: {file: rdf.dat, nstep: 5, dr: 0.15, name1: OW, name2: OW}
+    - systemenergy: {file: energy.dat, nstep: 50}
+    - xtcfile: {file: traj.xtc, nstep: 10}
+    - savestate: {file: confout.pqr}
+    - savestate: {file: state.ubj}
+    - density: {nstep: 50}
+

--- a/examples/water/ewald.yml
+++ b/examples/water/ewald.yml
@@ -2,7 +2,7 @@
 temperature: 300
 random: {seed: fixed}
 geometry: {type: cuboid, length: 18.6}
-mcloop: {macro: 5, micro: 20}
+mcloop: {macro: 5, micro: 50}
 
 atomlist:
     - OW: {q: -0.8476, sigma: 3.166, eps: 0.650, mw: 15.999}
@@ -22,7 +22,7 @@ energy:
     - isobaric: {P/atm: 1}
     - nonbonded_coulomblj:
         lennardjones: {mixing: LB}
-        coulomb: {type: ewald, epsr: 1, cutoff: 9, kcutoff: 7.3, epss: 0, alpha: 0.2, ewaldscheme: IPBC}
+        coulomb: {type: ewald, epsr: 1, cutoff: 9, kcutoff: 7.3, epss: 0, alpha: 0.2, ewaldscheme: PBCEigen}
         cutoff_g2g: 10
 
 moves:
@@ -31,10 +31,10 @@ moves:
 
 analysis:
     - sanity: {nstep: 100}
-    - atomrdf: {file: rdf.dat, nstep: 5, dr: 0.15, name1: OW, name2: OW}
-    - systemenergy: {file: energy.dat, nstep: 50}
-    - xtcfile: {file: traj.xtc, nstep: 10}
     - savestate: {file: confout.pqr}
     - savestate: {file: state.ubj}
-    - density: {nstep: 50}
+      #- atomrdf: {file: rdf.dat, nstep: 10, dr: 0.15, name1: OW, name2: OW}
+      #- systemenergy: {file: energy.dat, nstep: 50}
+      #- xtcfile: {file: traj.xtc, nstep: 10}
+      #- density: {nstep: 50}
 

--- a/examples/water/ewald.yml
+++ b/examples/water/ewald.yml
@@ -2,7 +2,7 @@
 temperature: 300
 random: {seed: fixed}
 geometry: {type: cuboid, length: 18.6}
-mcloop: {macro: 5, micro: 10}
+mcloop: {macro: 5, micro: 20}
 
 atomlist:
     - OW: {q: -0.8476, sigma: 3.166, eps: 0.650, mw: 15.999}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -258,6 +258,11 @@ add_test(
     WORKING_DIRECTORY ${EXAMPLES_DIR}/speciation)
 
 add_test(
+    NAME water-ewald-NOCHECKS
+    COMMAND sh -c "${PYTHON_EXECUTABLE} ${YASON} ewald.yml | $<TARGET_FILE:faunus>"
+    WORKING_DIRECTORY ${EXAMPLES_DIR}/water)
+
+add_test(
     NAME phosphate
     COMMAND sh -c "${PYTHON_EXECUTABLE} ${YASON} phosphate.yml\
     | $<TARGET_FILE:faunus> --quiet --state phosphate.state.json\

--- a/src/energy.cpp
+++ b/src/energy.cpp
@@ -8,153 +8,171 @@ namespace Energy {
 
 EwaldData::EwaldData(const json &j) {
     alpha = j.at("alpha"); // damping-parameter
-    Rcutoff = j.at("cutoff");   // real space cut-off
-    kcutoff = j.at("kcutoff");  // reciprocal space cut-off
+    r_cutoff = j.at("cutoff");                      // real space cut-off
+    k_cutoff = j.at("kcutoff");                     // reciprocal space cut-off
     spherical_sum = j.value("spherical_sum", true); // Using spherical summation of k-vectors in reciprocal space?
     bjerrum_length = pc::lB(j.at("epsr"));
     surface_dielectric_constant = j.value("epss", 0.0); // dielectric constant of surrounding medium
     const_inf = (surface_dielectric_constant < 1) ? 0 : 1; // if unphysical (<1) use epsr infinity for surrounding medium
     kappa = j.value("kappa", 0.0);
-    kappa2 = kappa * kappa;
+    kappa_squared = kappa * kappa;
 
     if (j.value("ipbc", false)) { // look for legacy bool `ipbc`
         faunus_logger->warn("key `ipbc` is deprecated, use `ewaldscheme: ipbc` instead");
         policy = EwaldData::IPBC;
     } else {
-        std::string name = j.value("ewaldpolicy", "PBC");
-        if (name == "PBC")
-            policy = EwaldData::PBC;
-        else if (name == "IPBC")
-            policy = EwaldData::IPBC;
-        else
-            throw std::runtime_error("invalid `ewaldpolicy`");
+      policy = j.value("ewaldpolicy", EwaldData::PBC);
+      if (policy == EwaldData::INVALID)
+        throw std::runtime_error("invalid `ewaldpolicy`");
     }
 }
 
 void to_json(json &j, const EwaldData &d) {
-    j = {{"lB", d.bjerrum_length},
-         {"epss", d.surface_dielectric_constant},
-         {"alpha", d.alpha},
-         {"cutoff", d.Rcutoff},
-         {"kcutoff", d.kcutoff},
-         {"wavefunctions", d.kVectors.cols()},
-         {"spherical_sum", d.spherical_sum},
-         {"kappa", d.kappa}};
-
-    auto &j_type = j["ewaldscheme"];
-    switch (d.policy) {
-    case EwaldData::PBC:
-        j_type = "PBC";
-        break;
-    case EwaldData::PBCEigen:
-        j_type = "PBC";
-        break;
-    case EwaldData::IPBC:
-        j_type = "IPBC";
-        break;
-    case EwaldData::IPBCEigen:
-        j_type = "IPBC";
-        break;
-    }
+  j = {{"lB", d.bjerrum_length},
+       {"epss", d.surface_dielectric_constant},
+       {"alpha", d.alpha},
+       {"cutoff", d.r_cutoff},
+       {"kcutoff", d.k_cutoff},
+       {"wavefunctions", d.k_vectors.cols()},
+       {"spherical_sum", d.spherical_sum},
+       {"kappa", d.kappa},
+       {"ewaldscheme", d.policy}};
 }
 
 //----------------- Ewald Policies -------------------
 
+std::shared_ptr<EwaldPolicyBase>
+EwaldPolicyBase::makePolicy(EwaldData::Policies policy) {
+  switch (policy) {
+  case EwaldData::PBC:
+    return std::make_shared<PolicyIonIon>();
+  case EwaldData::PBCEigen:
+    return std::make_shared<PolicyIonIonEigen>();
+  case EwaldData::IPBC:
+    return std::make_shared<PolicyIonIonIPBC>();
+  case EwaldData::IPBCEigen:
+    return std::make_shared<PolicyIonIonIPBCEigen>();
+  case EwaldData::INVALID:
+    throw std::runtime_error("invalid Ewald policy");
+  }
+  return nullptr;
+}
+
+PolicyIonIon::PolicyIonIon() { cite = "doi:10.1063/1.481216"; }
+PolicyIonIonIPBC::PolicyIonIonIPBC() { cite = "doi:10/css8"; }
+
 /**
  * Resize k-vectors according to current variables and box length
  */
-void PolicyIonIon::updateBox(EwaldData &data, const Point &box) const {
-    assert(data.policy == EwaldData::PBC or data.policy == EwaldData::PBCEigen);
-    data.L = box;
-    int kcc = ceil(data.kcutoff);
-    data.check_k2_zero = 0.1 * std::pow(2 * pc::pi / data.L.maxCoeff(), 2);
-    int kVectorsLength = (2 * kcc + 1) * (2 * kcc + 1) * (2 * kcc + 1) - 1;
-    if (kVectorsLength == 0) {
-        data.kVectors.resize(3, 1);
-        data.Aks.resize(1);
-        data.kVectors.col(0) = Point(1, 0, 0); // Just so it is not the zero-vector
-        data.Aks[0] = 0;
-        data.num_kvectors = 1;
-        data.Qion.resize(1);
-        data.Qdip.resize(1);
-    } else {
-        double kc2 = data.kcutoff * data.kcutoff;
-        data.kVectors.resize(3, kVectorsLength);
-        data.Aks.resize(kVectorsLength);
-        data.num_kvectors = 0;
-        data.kVectors.setZero();
-        data.Aks.setZero();
-        int startValue = 1;
-        for (int kx = 0; kx <= kcc; kx++) {
-            double dkx2 = double(kx * kx);
-            double factor = (kx>0) ? 2.0 : 1.0; // optimization of PBC Ewald (and always the case for IPBC Ewald)
-            for (int ky = -kcc * startValue; ky <= kcc; ky++) {
-                double dky2 = double(ky * ky);
-                for (int kz = -kcc * startValue; kz <= kcc; kz++) {
-                    Point kv = 2 * pc::pi * Point(kx, ky, kz).cwiseQuotient(data.L);
-                    double k2 = kv.squaredNorm() + data.kappa2; // last term is only for Yukawa-Ewald
-                    if (k2 < data.check_k2_zero) // Check if k2 != 0
-                        continue;
-                    if (data.spherical_sum) {
-                        double dkz2 = double(kz * kz);
-                        if ((dkx2 + dky2 + dkz2) / kc2 > 1)
-                            continue;
-                    }
-                    data.kVectors.col(data.num_kvectors) = kv;
-                    data.Aks[data.num_kvectors] = factor * exp(-k2 / (4 * data.alpha * data.alpha)) / k2;
-                    data.num_kvectors++;
-                }
-            }
+void PolicyIonIon::updateBox(EwaldData &d, const Point &box) const {
+  assert(d.policy == EwaldData::PBC or d.policy == EwaldData::PBCEigen);
+  d.box_length = box;
+  int k_cutoff_ceil = ceil(d.k_cutoff);
+  d.check_k2_zero = 0.1 * std::pow(2 * pc::pi / d.box_length.maxCoeff(), 2);
+  int k_vector_size = std::pow(2 * k_cutoff_ceil + 1, 3) - 1;
+  // int k_vector_size = (2 * k_cutoff_ceil + 1) * (2 * k_cutoff_ceil + 1) * (2
+  // * k_cutoff_ceil + 1) - 1;
+  if (k_vector_size == 0) {
+    d.k_vectors.resize(3, 1);
+    d.Aks.resize(1);
+    d.k_vectors.col(0) = Point(1, 0, 0); // Just so it is not the zero-vector
+    d.Aks[0] = 0;
+    d.num_kvectors = 1;
+    d.Q_ion.resize(1);
+    d.Q_dipole.resize(1);
+  } else {
+    double kc2 = d.k_cutoff * d.k_cutoff;
+    d.k_vectors.resize(3, k_vector_size);
+    d.Aks.resize(k_vector_size);
+    d.num_kvectors = 0;
+    d.k_vectors.setZero();
+    d.Aks.setZero();
+    int startValue = 1;
+    for (int kx = 0; kx <= k_cutoff_ceil; kx++) {
+      double dkx2 = double(kx * kx);
+      double factor = (kx > 0) ? 2.0 : 1.0; // optimization of PBC Ewald (and
+                                            // always the case for IPBC Ewald)
+      for (int ky = -k_cutoff_ceil * startValue; ky <= k_cutoff_ceil; ky++) {
+        double dky2 = double(ky * ky);
+        for (int kz = -k_cutoff_ceil * startValue; kz <= k_cutoff_ceil; kz++) {
+          Point kv = 2 * pc::pi * Point(kx, ky, kz).cwiseQuotient(d.box_length);
+          double k2 = kv.squaredNorm() +
+                      d.kappa_squared; // last term is only for Yukawa-Ewald
+          if (k2 < d.check_k2_zero)    // Check if k2 != 0
+            continue;
+          if (d.spherical_sum) {
+            double dkz2 = double(kz * kz);
+            if ((dkx2 + dky2 + dkz2) / kc2 > 1)
+              continue;
+          }
+          d.k_vectors.col(d.num_kvectors) = kv;
+          d.Aks[d.num_kvectors] =
+              factor * exp(-k2 / (4 * d.alpha * d.alpha)) / k2;
+          d.num_kvectors++;
         }
-        data.Qion.resize(data.num_kvectors);
-        data.Qdip.resize(data.num_kvectors);
-        data.Aks.conservativeResize(data.num_kvectors);
-        data.kVectors.conservativeResize(3, data.num_kvectors);
+      }
     }
+    d.Q_ion.resize(d.num_kvectors);
+    d.Q_dipole.resize(d.num_kvectors);
+    d.Aks.conservativeResize(d.num_kvectors);
+    d.k_vectors.conservativeResize(3, d.num_kvectors);
+  }
 }
 
 void PolicyIonIon::updateComplex(EwaldData &data, Space::Tgvec &groups) const {
-    for (int k = 0; k < data.kVectors.cols(); k++) {
-        const Point &kv = data.kVectors.col(k);
-        EwaldData::Tcomplex Q(0, 0);
-        for (auto &g : groups) {
-            for (auto &p : g) {
-                double dot = kv.dot(p.pos);
-                Q += p.charge * EwaldData::Tcomplex(std::cos(dot), std::sin(dot)); // 'Q^q', see eq. 25 in ref.
-            }
-            data.Qion[k] = Q;
-        }
+  for (int k = 0; k < data.k_vectors.cols(); k++) {
+    const Point &kv = data.k_vectors.col(k);
+    EwaldData::Tcomplex Q(0, 0);
+    for (auto &g : groups) {     // loop over molecules
+      for (auto &particle : g) { // loop over active particles
+        double dot = kv.dot(particle.pos);
+        Q += particle.charge *
+             EwaldData::Tcomplex(std::cos(dot),
+                                 std::sin(dot)); // 'Q^q', see eq. 25 in ref.
+      }
+      data.Q_ion[k] = Q;
+    }
     }
 }
 
 void PolicyIonIonEigen::updateComplex(EwaldData &data, Space::Tgvec &groups) const {
-    auto [pos, charge] = mapGroupsToEigen(groups);
-    Eigen::MatrixXd kr = pos.matrix() * data.kVectors;                        // ( N x 3 ) * ( 3 x K ) = N x K
-    data.Qion.real() = (kr.array().cos().colwise() * charge).colwise().sum(); // real part of 'Q^q', see eq. 25 in ref.
-    data.Qion.imag() = kr.array().sin().colwise().sum(); // imaginary part of 'Q^q', see eq. 25 in ref.
+  auto[pos, charge] = mapGroupsToEigen(groups); // throws if inactive particles
+  Eigen::MatrixXd kr =
+      pos.matrix() * data.k_vectors; // ( N x 3 ) * ( 3 x K ) = N x K
+  data.Q_ion.real() = (kr.array().cos().colwise() * charge)
+                          .colwise()
+                          .sum(); // real part of 'Q^q', see eq. 25 in ref.
+  data.Q_ion.imag() = kr.array()
+                          .sin()
+                          .colwise()
+                          .sum(); // imaginary part of 'Q^q', see eq. 25 in ref.
 }
 
-void PolicyIonIon::updateComplex(EwaldData &data, Change &change, Space::Tgvec &groups, Space::Tgvec &oldgroups) const {
-    assert(groups.size() == oldgroups.size());
-    for (int k = 0; k < data.kVectors.cols(); k++) {
-        auto &Q = data.Qion[k];
-        Point q = data.kVectors.col(k);
+void PolicyIonIon::updateComplex(EwaldData &d, Change &change,
+                                 Space::Tgvec &groups,
+                                 Space::Tgvec &oldgroups) const {
+  assert(groups.size() == oldgroups.size());
+  for (int k = 0; k < d.k_vectors.cols(); k++) {
+    auto &Q = d.Q_ion[k];
+    const Point &q = d.k_vectors.col(k);
 
-        for (auto cg : change.groups) {
-            auto g_new = groups.at(cg.index);
-            auto g_old = oldgroups.at(cg.index);
-            for (auto i : cg.atoms) {
-                if (i < g_new.size()) {
-                    double _new = q.dot((g_new.begin() + i)->pos);
-                    Q += (g_new.begin() + i)->charge * EwaldData::Tcomplex(std::cos(_new), std::sin(_new));
-                }
-                if (i < g_old.size()) {
-                    double _old = q.dot((g_old.begin() + i)->pos);
-                    Q -= (g_old.begin() + i)->charge * EwaldData::Tcomplex(std::cos(_old), std::sin(_old));
-                }
-            }
+    for (auto &changed_group : change.groups) {
+      auto &g_new = groups.at(changed_group.index);
+      auto &g_old = oldgroups.at(changed_group.index);
+      for (auto i : changed_group.atoms) {
+        if (i < g_new.size()) {
+          double qr = q.dot(g_new[i].pos);
+          Q +=
+              g_new[i].charge * EwaldData::Tcomplex(std::cos(qr), std::sin(qr));
         }
+        if (i < g_old.size()) {
+          double qr = q.dot(g_old[i].pos);
+          Q -=
+              g_old[i].charge * EwaldData::Tcomplex(std::cos(qr), std::sin(qr));
+        }
+      }
     }
+  }
 }
 
 //----------------- IPBC Ewald -------------------
@@ -164,78 +182,86 @@ void PolicyIonIon::updateComplex(EwaldData &data, Change &change, Space::Tgvec &
  */
 void PolicyIonIonIPBC::updateBox(EwaldData &data, const Point &box) const {
     assert(data.policy == EwaldData::IPBC or data.policy == EwaldData::IPBCEigen);
-    data.L = box;
-    int kcc = ceil(data.kcutoff);
-    data.check_k2_zero = 0.1 * std::pow(2 * pc::pi / data.L.maxCoeff(), 2);
+    data.box_length = box;
+    int kcc = std::ceil(data.k_cutoff);
+    data.check_k2_zero =
+        0.1 * std::pow(2 * pc::pi / data.box_length.maxCoeff(), 2);
     int kVectorsLength = (2 * kcc + 1) * (2 * kcc + 1) * (2 * kcc + 1) - 1;
     if (kVectorsLength == 0) {
-        data.kVectors.resize(3, 1);
-        data.Aks.resize(1);
-        data.kVectors.col(0) = Point(1, 0, 0); // Just so it is not the zero-vector
-        data.Aks[0] = 0;
-        data.num_kvectors = 1;
-        data.Qion.resize(1);
-        data.Qdip.resize(1);
+      data.k_vectors.resize(3, 1);
+      data.Aks.resize(1);
+      data.k_vectors.col(0) =
+          Point(1, 0, 0); // Just so it is not the zero-vector
+      data.Aks[0] = 0;
+      data.num_kvectors = 1;
+      data.Q_ion.resize(1);
+      data.Q_dipole.resize(1);
     } else {
-        double kc2 = data.kcutoff * data.kcutoff;
-        data.kVectors.resize(3, kVectorsLength);
-        data.Aks.resize(kVectorsLength);
-        data.num_kvectors = 0;
-        data.kVectors.setZero();
-        data.Aks.setZero();
-        int startValue = 0;
-        for (int kx = 0; kx <= kcc; kx++) {
-            double dkx2 = double(kx * kx);
-            double xfactor = (kx>0) ? 2.0 : 1.0; // optimization of PBC Ewald
-            for (int ky = -kcc * startValue; ky <= kcc; ky++) {
-                double dky2 = double(ky * ky);
-                double yfactor = (ky>0) ? 2.0 : 1.0; // optimization of PBC Ewald
-                for (int kz = -kcc * startValue; kz <= kcc; kz++) {
-                    double factor = xfactor * yfactor;
-                    if (kz > 0)
-                        factor *= 2;
-                    Point kv = 2 * pc::pi * Point(kx, ky, kz).cwiseQuotient(data.L);
-                    double k2 = kv.squaredNorm() + data.kappa2; // last term is only for Yukawa-Ewald
-                    if (k2 < data.check_k2_zero)          // Check if k2 != 0
-                        continue;
-                    if (data.spherical_sum) {
-                        double dkz2 = double(kz * kz);
-                        if ((dkx2 + dky2 + dkz2) / kc2 > 1)
-                            continue;
-                    }
-                    data.kVectors.col(data.num_kvectors) = kv;
-                    data.Aks[data.num_kvectors] = factor * exp(-k2 / (4 * data.alpha * data.alpha)) / k2;
-                    data.num_kvectors++;
-                }
+      double kc2 = data.k_cutoff * data.k_cutoff;
+      data.k_vectors.resize(3, kVectorsLength);
+      data.Aks.resize(kVectorsLength);
+      data.num_kvectors = 0;
+      data.k_vectors.setZero();
+      data.Aks.setZero();
+      int startValue = 0;
+      for (int kx = 0; kx <= kcc; kx++) {
+        double dkx2 = double(kx * kx);
+        double xfactor = (kx > 0) ? 2.0 : 1.0; // optimization of PBC Ewald
+        for (int ky = -kcc * startValue; ky <= kcc; ky++) {
+          double dky2 = double(ky * ky);
+          double yfactor = (ky > 0) ? 2.0 : 1.0; // optimization of PBC Ewald
+          for (int kz = -kcc * startValue; kz <= kcc; kz++) {
+            double factor = xfactor * yfactor;
+            if (kz > 0)
+              factor *= 2;
+            Point kv =
+                2 * pc::pi * Point(kx, ky, kz).cwiseQuotient(data.box_length);
+            double k2 =
+                kv.squaredNorm() +
+                data.kappa_squared;      // last term is only for Yukawa-Ewald
+            if (k2 < data.check_k2_zero) // Check if k2 != 0
+              continue;
+            if (data.spherical_sum) {
+              double dkz2 = double(kz * kz);
+              if ((dkx2 + dky2 + dkz2) / kc2 > 1)
+                continue;
             }
+            data.k_vectors.col(data.num_kvectors) = kv;
+            data.Aks[data.num_kvectors] =
+                factor * exp(-k2 / (4 * data.alpha * data.alpha)) / k2;
+            data.num_kvectors++;
+          }
         }
-        data.Qion.resize(data.num_kvectors);
-        data.Qdip.resize(data.num_kvectors);
+        }
+        data.Q_ion.resize(data.num_kvectors);
+        data.Q_dipole.resize(data.num_kvectors);
         data.Aks.conservativeResize(data.num_kvectors);
-        data.kVectors.conservativeResize(3, data.num_kvectors);
+        data.k_vectors.conservativeResize(3, data.num_kvectors);
     }
 }
 
 void PolicyIonIonIPBC::updateComplex(EwaldData &data, Space::Tgvec &groups) const {
     assert(data.policy == EwaldData::IPBC or data.policy == EwaldData::IPBCEigen);
-    for (int k = 0; k < data.kVectors.cols(); k++) {
-        const Point &kv = data.kVectors.col(k);
-        EwaldData::Tcomplex Q(0, 0);
-        for (auto &g : groups) {
-            for (auto &p : g) {
-                Q += kv.cwiseProduct(p.pos).array().cos().prod() * p.charge; // see eq. 2 in doi:10/css8
-            }
+    for (int k = 0; k < data.k_vectors.cols(); k++) {
+      const Point &kv = data.k_vectors.col(k);
+      EwaldData::Tcomplex Q(0, 0);
+      for (auto &g : groups) {
+        for (auto &particle : g) {
+          Q += kv.cwiseProduct(particle.pos).array().cos().prod() *
+               particle.charge; // see eq. 2 in doi:10/css8
         }
-        data.Qion[k] = Q;
+      }
+      data.Q_ion[k] = Q;
     }
 }
 
 void PolicyIonIonIPBCEigen::updateComplex(EwaldData &data, Space::Tgvec &groups) const {
     assert(data.policy == EwaldData::IPBC or data.policy == EwaldData::IPBCEigen);
     auto [pos, charge] = mapGroupsToEigen(groups);
-    data.Qion.real() = (data.kVectors.array().cwiseProduct(pos).array().cos().prod() * charge)
-                           .colwise()
-                           .sum(); // see eq. 2 in doi:10/css8
+    data.Q_ion.real() =
+        (data.k_vectors.array().cwiseProduct(pos).array().cos().prod() * charge)
+            .colwise()
+            .sum(); // see eq. 2 in doi:10/css8
 }
 
 void PolicyIonIonIPBC::updateComplex(EwaldData &data, Change &change, Space::Tgvec &groups,
@@ -243,19 +269,21 @@ void PolicyIonIonIPBC::updateComplex(EwaldData &data, Change &change, Space::Tgv
     assert(data.policy == EwaldData::IPBC or data.policy == EwaldData::IPBCEigen);
     assert(groups.size() == oldgroups.size());
 
-    for (int k = 0; k < data.kVectors.cols(); k++) {
-        auto &Q = data.Qion[k];
-        Point q = data.kVectors.col(k);
-        for (auto cg : change.groups) {
-            auto g_new = groups.at(cg.index);
-            auto g_old = oldgroups.at(cg.index);
-            for (auto i : cg.atoms) {
-                if (i < g_new.size())
-                    Q += q.cwiseProduct((g_new.begin() + i)->pos).array().cos().prod() * (g_new.begin() + i)->charge;
-                if (i < g_old.size())
-                    Q -= q.cwiseProduct((g_old.begin() + i)->pos).array().cos().prod() * (g_old.begin() + i)->charge;
-            }
+    for (int k = 0; k < data.k_vectors.cols(); k++) {
+      auto &Q = data.Q_ion[k];
+      const Point &q = data.k_vectors.col(k);
+      for (auto &changed_group : change.groups) {
+        auto &g_new = groups.at(changed_group.index);
+        auto &g_old = oldgroups.at(changed_group.index);
+        for (auto i : changed_group.atoms) {
+          if (i < g_new.size())
+            Q += q.cwiseProduct(g_new[i].pos).array().cos().prod() *
+                 g_new[i].charge;
+          if (i < g_old.size())
+            Q -= q.cwiseProduct(g_old[i].pos).array().cos().prod() *
+                 g_old[i].charge;
         }
+      }
     }
 }
 
@@ -263,38 +291,46 @@ double PolicyIonIon::surfaceEnergy(const EwaldData &d, Change &change, Space::Tg
     if (d.const_inf < 0.5)
         return 0;
     Point qr(0, 0, 0);
-    if (change.all or change.dV)
-        for (auto g : groups)
-            for (auto i : g)
-                qr += i.charge * i.pos;
-    else if (change.groups.size() > 0) {
-        for (auto cg : change.groups) {
-            auto g = groups.at(cg.index);
-            for (auto i : cg.atoms)
-                if (i < g.size())
-                    qr += (g.begin() + i)->charge * (g.begin() + i)->pos;
+    if (change.all or change.dV) {
+      for (auto &g : groups) {
+        for (auto &particle : g) {
+          qr += particle.charge * particle.pos;
         }
+      }
+    } else if (change.groups.size() > 0) {
+      for (auto &changed_group : change.groups) {
+        auto &g = groups.at(changed_group.index);
+        for (auto i : changed_group.atoms) {
+          if (i < g.size()) {
+            qr += g[i].charge * g[i].pos;
+          }
+        }
+      }
     }
-    double volume = d.L.x() * d.L.y() * d.L.z();
+    double volume = d.box_length.prod();
     return d.const_inf * 2 * pc::pi / ((2 * d.surface_dielectric_constant + 1) * volume) * qr.dot(qr) *
            d.bjerrum_length;
 }
 
 double PolicyIonIon::selfEnergy(const EwaldData &d, Change &change, Space::Tgvec &groups) {
-    double Eq = 0;
-    if (change.dN) {
-        for (auto cg : change.groups) {
-            auto g = groups.at(cg.index);
-            for (auto i : cg.atoms)
-                if (i < g.size())
-                    Eq += std::pow((g.begin() + i)->charge, 2);
+  double energy = 0;
+  if (change.dN) {
+    for (auto &changed_group : change.groups) {
+      auto &g = groups.at(changed_group.index);
+      for (auto i : changed_group.atoms) {
+        if (i < g.size()) {
+          energy += std::pow((g.begin() + i)->charge, 2);
         }
-    } else if (change.all and not change.dV) {
-        for (auto g : groups)
-            for (auto i : g)
-                Eq += i.charge * i.charge;
+      }
     }
-    return -d.alpha * Eq / std::sqrt(pc::pi) * d.bjerrum_length;
+    } else if (change.all and not change.dV) {
+      for (auto &g : groups) {
+        for (auto &particle : g) {
+          energy += particle.charge * particle.charge;
+        }
+      }
+    }
+    return -d.alpha * energy * d.bjerrum_length / std::sqrt(pc::pi);
 }
 
 /**
@@ -302,28 +338,22 @@ double PolicyIonIon::selfEnergy(const EwaldData &d, Change &change, Space::Tgvec
  * See eqs. 24 and 25 in ref. for PBC Ewald, and eq. 2 in doi:10/css8 for IPBC Ewald.
  */
 double PolicyIonIon::reciprocalEnergy(const EwaldData &d) {
-    double E = 0;
-    for (int k = 0; k < d.Qion.size(); k++)
-        E += d.Aks[k] * std::norm(d.Qion[k]);
-    double volume = d.L.x() * d.L.y() * d.L.z();
-    return 2 * pc::pi / volume * E * d.bjerrum_length;
+  double energy = 0;
+  for (int k = 0; k < d.Q_ion.size(); k++) {
+    energy += d.Aks[k] * std::norm(d.Q_ion[k]);
+  }
+  return 2 * pc::pi * energy * d.bjerrum_length / d.box_length.prod();
 }
 
 double PolicyIonIonEigen::reciprocalEnergy(const EwaldData &d) {
-    double E = d.Aks.cwiseProduct(d.Qion.cwiseAbs2()).sum();
-    double volume = d.L.x() * d.L.y() * d.L.z();
-    return 2 * pc::pi / volume * E * d.bjerrum_length;
+  double energy = d.Aks.cwiseProduct(d.Q_ion.cwiseAbs2()).sum();
+  return 2 * pc::pi * d.bjerrum_length * energy / d.box_length.prod();
 }
 
 Ewald::Ewald(const json &j, Space &spc) : data(j), spc(spc) {
     name = "ewald";
-    if (data.policy == EwaldData::IPBC or data.policy == EwaldData::IPBCEigen) {
-        policy = std::make_shared<PolicyIonIonIPBC>();
-        cite = "doi:10/css8";
-    } else {
-        policy = std::make_shared<PolicyIonIon>();
-        cite = "doi:10.1063/1.481216";
-    }
+    policy = EwaldPolicyBase::makePolicy(data.policy);
+    cite = policy->cite;
     init();
 }
 
@@ -341,9 +371,10 @@ double Ewald::energy(Change &change) {
                 policy->updateBox(data, spc.geo.getLength());
                 policy->updateComplex(data, spc.groups); // update all (expensive!)
             } else { // much cheaper partial update
-                if (change.groups.size() > 0)
-                    assert(oldgroups!=nullptr);
-                    policy->updateComplex(data, change, spc.groups, *oldgroups);
+              if (change.groups.size() > 0) {
+                assert(old_groups != nullptr);
+                policy->updateComplex(data, change, spc.groups, *old_groups);
+              }
             }
         }
         // the selfEnergy() is omitted as this is added as a separate term in `Hamiltonian`
@@ -356,8 +387,11 @@ double Ewald::energy(Change &change) {
 void Ewald::sync(Energybase *basePtr, Change &) {
     auto other = dynamic_cast<decltype(this)>(basePtr);
     assert(other);
-    if (other->key == OLD)
-        oldgroups = &(other->spc.groups); // give NEW access to OLD space for optimized updates
+    if (other->key == OLD) {
+      old_groups =
+          &(other->spc
+                .groups); // give NEW access to OLD space for optimized updates
+    }
     data = other->data;              // copy everything!
 }
 

--- a/src/energy.h
+++ b/src/energy.h
@@ -63,7 +63,7 @@ struct EwaldData {
     double alpha = 0;
     double const_inf = 0;
     double check_k2_zero = 0;
-    bool spherical_sum = true;
+    bool use_spherical_sum = true;
     int num_kvectors = 0;
     Point box_length = {0.0, 0.0, 0.0};                        //!< Box dimensions
     enum Policies { PBC, PBCEigen, IPBC, IPBCEigen, INVALID }; //!< Possible k-space updating schemes
@@ -86,7 +86,6 @@ void to_json(json &, const EwaldData &);
  */
 class EwaldPolicyBase {
   public:
-    typedef typename ParticleVector::iterator iter;
     std::string cite; //!< Optional reference, preferably DOI, to further information
     virtual ~EwaldPolicyBase() = default;
     virtual void updateBox(EwaldData &, const Point &) const = 0; //!< Prepare k-vectors according to given box vector

--- a/src/energy_test.h
+++ b/src/energy_test.h
@@ -3,8 +3,8 @@
 #include "core.h"
 #include "units.h"
 
-
 namespace Faunus {
+namespace Energy {
 
 using doctest::Approx;
 
@@ -13,9 +13,87 @@ TEST_SUITE_BEGIN("Energy");
 // Furthermore, construction of multiple independent spaces is not straightforwardly possible because of
 // the global variables containing atom and molecule types.
 
+TEST_CASE("[Faunus] Ewald - EwaldData") {
+    using doctest::Approx;
+
+    EwaldData data(R"({
+                "epsr": 1.0, "alpha": 0.894427190999916, "epss": 1.0,
+                "kcutoff": 11.0, "spherical_sum": true, "cutoff": 5.0})"_json);
+
+    data.update(Point(10, 10, 10));
+
+    CHECK(data.policy == EwaldData::PBC);
+    CHECK(data.const_inf == 1);
+    CHECK(data.alpha == 0.894427190999916);
+    CHECK(data.kVectors.cols() == 2975);
+    CHECK(data.Qion.size() == data.kVectors.cols());
+
+    data.policy = EwaldData::IPBC;
+    data.update(Point(10, 10, 10));
+    CHECK(data.kVectors.cols() == 846);
+    CHECK(data.Qion.size() == data.kVectors.cols());
+}
+
+TEST_CASE("[Faunus] Ewald - IonIonPolicy") {
+    using doctest::Approx;
+    Space spc;
+    spc.p.resize(2);
+    spc.geo = R"( {"type": "cuboid", "length": 10} )"_json;
+    spc.p[0] = R"( {"pos": [0,0,0], "q": 1.0} )"_json;
+    spc.p[1] = R"( {"pos": [1,0,0], "q": -1.0} )"_json;
+    Group<Particle> g(spc.p.begin(), spc.p.end());
+    spc.groups.push_back(g);
+
+    EwaldData data = R"({
+                "epsr": 1.0, "alpha": 0.894427190999916, "epss": 1.0,
+                "kcutoff": 11.0, "spherical_sum": true, "cutoff": 5.0})"_json;
+    Change c;
+    c.all = true;
+    data.policy = EwaldData::PBC;
+
+    SUBCASE("PBC") {
+        PolicyIonIon ionion(spc);
+        data.update(spc.geo.getLength());
+        ionion.updateComplex(data);
+        CHECK(ionion.selfEnergy(data, c) == Approx(-1.0092530088080642 * data.bjerrum_length));
+        CHECK(ionion.surfaceEnergy(data, c) == Approx(0.0020943951023931952 * data.bjerrum_length));
+        CHECK(ionion.reciprocalEnergy(data) == Approx(0.21303063979675319 * data.bjerrum_length));
+    }
+
+    SUBCASE("PBCEigen") {
+        PolicyIonIonEigen ionion(spc);
+        data.update(spc.geo.getLength());
+        ionion.updateComplex(data);
+        CHECK(ionion.selfEnergy(data, c) == Approx(-1.0092530088080642 * data.bjerrum_length));
+        CHECK(ionion.surfaceEnergy(data, c) == Approx(0.0020943951023931952 * data.bjerrum_length));
+        CHECK(ionion.reciprocalEnergy(data) == Approx(0.21303063979675319 * data.bjerrum_length));
+    }
+
+    SUBCASE("IPBC") {
+        PolicyIonIonIPBC ionion(spc);
+        data.policy = EwaldData::IPBC;
+        data.update(spc.geo.getLength());
+        ionion.updateComplex(data);
+        CHECK(ionion.selfEnergy(data, c) == Approx(-1.0092530088080642 * data.bjerrum_length));
+        CHECK(ionion.surfaceEnergy(data, c) == Approx(0.0020943951023931952 * data.bjerrum_length));
+        CHECK(ionion.reciprocalEnergy(data) == Approx(0.0865107467 * data.bjerrum_length));
+    }
+
+    // IPBCEigen is under construction
+    /*SUBCASE("IPBCEigen") {
+        PolicyIonIonIPBCEigen ionion(spc);
+        data.type = EwaldData::IPBCEigen;
+        data.update(spc.geo.getLength());
+        ionion.updateComplex(data);
+        CHECK(ionion.selfEnergy(data, c) == Approx(-1.0092530088080642 * data.lB));
+        CHECK(ionion.surfaceEnergy(data, c) == Approx(0.0020943951023931952 * data.lB));
+        CHECK(ionion.reciprocalEnergy(data) == Approx(0.0865107467 * data.lB));
+    }*/
+}
+
 #ifdef ENABLE_FREESASA
-TEST_CASE( "[Faunus] FreeSASA") {
-    Change change;          // change object telling that a full energy calculation
+TEST_CASE("[Faunus] FreeSASA") {
+    Change change; // change object telling that a full energy calculation
     change.all = true;
     pc::temperature = 300.0_K;
     atoms = R"([
@@ -30,30 +108,28 @@ TEST_CASE( "[Faunus] FreeSASA") {
         "insertmolecules": [ { "M": { "N": 1 } } ]
     })"_json;
     Space spc = j;
-    spc.p[0].pos = {0.0,0.0,0.0};
-    spc.p[1].pos = {0.0,0.0,20.0};
+    spc.p[0].pos = {0.0, 0.0, 0.0};
+    spc.p[1].pos = {0.0, 0.0, 20.0};
 
     SUBCASE("Separated atoms") {
-        Energy::SASAEnergy sasa(spc, 1.5_molar, 1.4_angstrom);
-        CHECK(sasa.energy(change) == Approx(4*pc::pi*(3.4*3.4 + 2.6*2.6) * 1.5 * 1.0_kJmol));
+        SASAEnergy sasa(spc, 1.5_molar, 1.4_angstrom);
+        CHECK(sasa.energy(change) == Approx(4 * pc::pi * (3.4 * 3.4 + 2.6 * 2.6) * 1.5 * 1.0_kJmol));
     }
 
     SUBCASE("Intersecting atoms") {
-        Energy::SASAEnergy sasa(spc, 1.5_molar, 1.4_angstrom);
+        SASAEnergy sasa(spc, 1.5_molar, 1.4_angstrom);
         std::vector<double> distance = {0.0, 2.5, 5.0, 7.5, 10.0};
         std::vector<double> sasa_energy = {87.3576, 100.4612, 127.3487, 138.4422, 138.4422};
-        for(size_t i = 0; i < distance.size(); ++i) {
-            spc.p[1].pos = {0.0,0.0, distance[i]};
+        for (size_t i = 0; i < distance.size(); ++i) {
+            spc.p[1].pos = {0.0, 0.0, distance[i]};
             CHECK(sasa.energy(change) == Approx(sasa_energy[i]).epsilon(0.02));
         }
-
     }
 
-    SUBCASE("PBC") {
-
-    }
+    SUBCASE("PBC") {}
 }
 #endif
 
 TEST_SUITE_END();
+} // namespace Energy
 } // namespace Faunus

--- a/src/energy_test.h
+++ b/src/energy_test.h
@@ -26,14 +26,14 @@ TEST_CASE("[Faunus] Ewald - EwaldData") {
     CHECK(data.alpha == 0.894427190999916);
 
     // Check number of wave-vectors using PBC
-    PolicyIonIon ionion(spc);
+    PolicyIonIon ionion;
     ionion.updateBox(data, Point(10, 10, 10));
     CHECK(data.kVectors.cols() == 2975);
     CHECK(data.Qion.size() == data.kVectors.cols());
 
     // Check number of wave-vectors using IPBC
     data.policy = EwaldData::IPBC;
-    PolicyIonIonIPBC ionionIPBC(spc);
+    PolicyIonIonIPBC ionionIPBC;
     ionionIPBC.updateBox(data, Point(10, 10, 10));
     CHECK(data.kVectors.cols() == 846);
     CHECK(data.Qion.size() == data.kVectors.cols());
@@ -57,41 +57,41 @@ TEST_CASE("[Faunus] Ewald - IonIonPolicy") {
     data.policy = EwaldData::PBC;
 
     SUBCASE("PBC") {
-        PolicyIonIon ionion(spc);
+        PolicyIonIon ionion;
         ionion.updateBox(data, spc.geo.getLength());
-        ionion.updateComplex(data);
-        CHECK(ionion.selfEnergy(data, c) == Approx(-1.0092530088080642 * data.bjerrum_length));
-        CHECK(ionion.surfaceEnergy(data, c) == Approx(0.0020943951023931952 * data.bjerrum_length));
+        ionion.updateComplex(data, spc.groups);
+        CHECK(ionion.selfEnergy(data, c, spc.groups) == Approx(-1.0092530088080642 * data.bjerrum_length));
+        CHECK(ionion.surfaceEnergy(data, c, spc.groups) == Approx(0.0020943951023931952 * data.bjerrum_length));
         CHECK(ionion.reciprocalEnergy(data) == Approx(0.21303063979675319 * data.bjerrum_length));
     }
 
     SUBCASE("PBCEigen") {
-        PolicyIonIonEigen ionion(spc);
+        PolicyIonIonEigen ionion;
         ionion.updateBox(data, spc.geo.getLength());
-        ionion.updateComplex(data);
-        CHECK(ionion.selfEnergy(data, c) == Approx(-1.0092530088080642 * data.bjerrum_length));
-        CHECK(ionion.surfaceEnergy(data, c) == Approx(0.0020943951023931952 * data.bjerrum_length));
+        ionion.updateComplex(data, spc.groups);
+        CHECK(ionion.selfEnergy(data, c, spc.groups) == Approx(-1.0092530088080642 * data.bjerrum_length));
+        CHECK(ionion.surfaceEnergy(data, c, spc.groups) == Approx(0.0020943951023931952 * data.bjerrum_length));
         CHECK(ionion.reciprocalEnergy(data) == Approx(0.21303063979675319 * data.bjerrum_length));
     }
 
     SUBCASE("IPBC") {
-        PolicyIonIonIPBC ionion(spc);
+        PolicyIonIonIPBC ionion;
         data.policy = EwaldData::IPBC;
         ionion.updateBox(data, spc.geo.getLength());
-        ionion.updateComplex(data);
-        CHECK(ionion.selfEnergy(data, c) == Approx(-1.0092530088080642 * data.bjerrum_length));
-        CHECK(ionion.surfaceEnergy(data, c) == Approx(0.0020943951023931952 * data.bjerrum_length));
+        ionion.updateComplex(data, spc.groups);
+        CHECK(ionion.selfEnergy(data, c, spc.groups) == Approx(-1.0092530088080642 * data.bjerrum_length));
+        CHECK(ionion.surfaceEnergy(data, c, spc.groups) == Approx(0.0020943951023931952 * data.bjerrum_length));
         CHECK(ionion.reciprocalEnergy(data) == Approx(0.0865107467 * data.bjerrum_length));
     }
 
     // IPBCEigen is under construction
     /*SUBCASE("IPBCEigen") {
-        PolicyIonIonIPBCEigen ionion(spc);
+        PolicyIonIonIPBCEigen ionion();
         data.type = EwaldData::IPBCEigen;
         ionion.updateBox(data, spc.geo.getLength());
-        ionion.updateComplex(data);
-        CHECK(ionion.selfEnergy(data, c) == Approx(-1.0092530088080642 * data.lB));
-        CHECK(ionion.surfaceEnergy(data, c) == Approx(0.0020943951023931952 * data.lB));
+        ionion.updateComplex(data, spc.groups);
+        CHECK(ionion.selfEnergy(data, c, spc.groups) == Approx(-1.0092530088080642 * data.lB));
+        CHECK(ionion.surfaceEnergy(data, c, spc.groups) == Approx(0.0020943951023931952 * data.lB));
         CHECK(ionion.reciprocalEnergy(data) == Approx(0.0865107467 * data.lB));
     }*/
 }


### PR DESCRIPTION
This refactors Ewald policies and `Energy::Ewald` with separate policy objects for PBC, IPBC with and without Eigen optimisations. The policy is changed from static to dynamic and unittests and an ewald example is provided. Effectively this means that all Ewald code has moved from headers to cpp.

- [x] Class policies for PBC, IPBC with and without Eigen optimisation
- [x] Documentation
- [x] JSON schema
- [x] Unittests
- [x] Ewald/water example (@bjornstenqvist)
  - [ ] add test values; should not run for more than a minute
- [ ] Static condition for `spherical_sum`
- [ ] Detailed code comments from @bjornstenqvist
- [ ] Nanobench benchmarks
  - [ ] all policies; OMP
