### PR TITLE
Refactor nonbonded energy

### DIFF
--- a/docs/_docs/energy.md
+++ b/docs/_docs/energy.md
@@ -113,23 +113,6 @@ combinations:
       protein water: 60
 ~~~
 
-### OpenMP Control
-
-If compiled with OpenMP, the following keywords can be used to control parallelisation
-for non-bonded interactions. The best combination depends on the simulated system size and
-composition. Currently, parallelisation is disabled by default.
-
-~~~ yaml
-- nonbonded:
-    openmp: [g2g, i2all]
-~~~
-
-`openmp`  | Description
---------- | -------------------------------------------
-`g2g`     | Distribute on a molecule-to-molecule basis 
-`i2all`   | Parallelise single particle energy evaluations
-
-
 ## Electrostatics
 
  `coulomb`             |  Description

--- a/src/atomdata.h
+++ b/src/atomdata.h
@@ -75,23 +75,25 @@ void from_json(const json &j, std::vector<AtomData> &v);
 extern std::vector<AtomData> atoms; //!< Global instance of atom list
 
 /**
- * @brief Find the first element with a member `name` matching the input.
+ * @brief Finds the first element with a member attribute `name` matching the input.
+ *
+ * @param rng  a range of elements
+ * @param name  a name to look for
+ * @return an iterator to the first element, or `last` if not found
  * @see obtainName()
- * @param rng a range
- * @param name a name to look for
- * @return an iterator to the first element or `last` if not found
  */
 template <class Trange> auto findName(Trange &rng, const std::string &name) {
     return std::find_if(rng.begin(), rng.end(), [&name](auto &i) { return i.name == name; });
 }
 
 /**
- * @brief Find the first element with a member `name` matching the input. Throw an exception if not found.
- * @see findName()
- * @throw std::range_error if such an element not found
- * @param rng a range
- * @param name a name to look for
+ * @brief Finds the first element with a member attribute `name` matching the input. Throws an exception if not found.
+ *
+ * @param rng  a range of elements
+ * @param name  a name to look for
  * @return an iterator to the first element
+ * @throw std::range_error if such an element not found
+ * @see findName()
  */
 template <class Trange> auto obtainName(Trange &rng, const std::string &name) {
     const auto result = findName(rng, name);

--- a/src/atomdata.h
+++ b/src/atomdata.h
@@ -74,9 +74,32 @@ void from_json(const json &j, std::vector<AtomData> &v);
 
 extern std::vector<AtomData> atoms; //!< Global instance of atom list
 
+/**
+ * @brief Find the first element with a member `name` matching the input.
+ * @see obtainName()
+ * @param rng a range
+ * @param name a name to look for
+ * @return an iterator to the first element or `last` if not found
+ */
 template <class Trange> auto findName(Trange &rng, const std::string &name) {
     return std::find_if(rng.begin(), rng.end(), [&name](auto &i) { return i.name == name; });
-} //!< Returns iterator to first element with member `name` matching input
+}
+
+/**
+ * @brief Find the first element with a member `name` matching the input. Throw an exception if not found.
+ * @see findName()
+ * @throw std::range_error if such an element not found
+ * @param rng a range
+ * @param name a name to look for
+ * @return an iterator to the first element
+ */
+template <class Trange> auto obtainName(Trange &rng, const std::string &name) {
+    const auto result = findName(rng, name);
+    if(result == rng.end()) {
+        throw std::out_of_range(name + " not found");
+    }
+    return result;
+}
 
 template <class Trange> std::vector<int> names2ids(Trange &rng, const std::vector<std::string> &names) {
     std::vector<AtomData::Tid> index;

--- a/src/energy.h
+++ b/src/energy.h
@@ -242,6 +242,38 @@ class Bonded : public Energybase {
 };
 
 /**
+ *  @section Non-bonded energy
+ *
+ *  Several classes (class templates are) used together to allow computation in change of the non-bonded energy upon
+ *  a MC move.
+ *
+ *  The energy change is calculated by the @see Nonbonded class. It internally uses one of the pairing policies
+ *  to efficiently get all pair interactions affected by the MC move (as described by the Change object).
+ *
+ *  Pairing policies @see PairingBasePolicy allow efficient summation of pair energies of a whole system,
+ *  between groups, inside a group, etc. The pairing policy are optimized for performance in a different execution
+ *  environment, e.g. sequential or OMP parallelism.
+ *
+ *  Policies have direct access to the pair interaction energy functor represented by a simple @see PairEnergy
+ *  template. Furthermore, the @see Cutoff object is provided to limit free energy computation using a cutoff distance
+ *  between respective groups.
+ */
+
+/**
+ * @brief Provide a complementary set with respect to the iota set of a given size.
+ *
+ * @param size the iota superset contains all integers in the range [0, size)
+ * @param set an original set of integers
+ * @return a set of integers complementary to the original set
+ */
+template <typename T, typename TSet> inline auto indexComplement(const T size, const TSet &set) {
+    assert(size <= std::numeric_limits<int>::max());
+    return ranges::views::ints(0, static_cast<int>(size)) | ranges::views::remove_if([&set](T i) {
+      return std::binary_search(set.begin(), set.end(), i);
+    });
+}
+
+/**
  * @brief Determine if two groups are separated beyond the cutoff distance.
  *
  * The cutoff distance can be specified independently for each group pair to override the default value.
@@ -272,7 +304,7 @@ class Cutoff {
     }
 
     /**
-     * @brief Functor alias for @see cut
+     * @brief Functor alias for @see cut.
      */
     template <typename... Args> inline auto operator()(Args &&... args) { return cut(std::forward<Args>(args)...); }
 
@@ -283,423 +315,690 @@ void from_json(const json &j, Cutoff &c);
 void to_json(json &j, const Cutoff &c);
 
 /**
- * @brief Nonbonded energy using a pair-potential
- * @tparam Tpairpot Pair potential to inject
- * @tparam allow_anisotropic_pair_potential If true, a distance vector is passed to the pair potential
+ * @brief Provide a fast inlineable interface for non-bonded pair potential energy computation.
+ * @tparam TPairPotential a pair potential to compute with
+ * @tparam allow_anisotropic_pair_potential pass also a distance vector to the pair potential, slower
  */
-template <typename Tpairpot, bool allow_anisotropic_pair_potential = true> class Nonbonded : public Energybase {
-  private:
-    std::vector<const Particle *> i_interact_with_these;
+template <typename TPairPotential, bool allow_anisotropic_pair_potential = true> class PairEnergy {
+    Space &spc;                                //!< space to operate on; only its geometry is used
+    BasePointerVector<Energybase> &potentials; //!< registered non-bonded potentials; @see addPairPotentialSelfEnergy
+    TPairPotential pair_potential;             //!< pair potential function/functor
 
-    TimeRelativeOfTotal<> timer_g_internal;
+  public:
+    /**
+     * @param spc
+     * @param potentials registered non-bonded potentials
+     */
+    PairEnergy(Space &spc, BasePointerVector<Energybase> &potentials) : spc(spc), potentials(potentials) {}
 
-  protected:
-    typedef typename Space::Tgroup Tgroup;
-    // control of when OpenMP should be used
-    bool omp_enable = false;
-    bool omp_i2all = false;
-    bool omp_g2g = false;
-    bool omp_p2p = false;
-
-    void to_json(json &j) const override {
-        j["pairpot"] = pairpot;
-        if (omp_enable) {
-            json _a = json::array();
-            if (omp_p2p)
-                _a.push_back("p2p");
-            if (omp_g2g)
-                _a.push_back("g2g");
-            if (omp_i2all)
-                _a.push_back("i2all");
-            j["openmp"] = _a;
-        }
-        j["timings"] = {{"g_internal", timer_g_internal.result()}};
-        Energy::to_json(j, cut);
-    }
-
-    Cutoff cut;
-
-    template <typename T> inline double i2i(const T &a, const T &b) {
+    /**
+     * @brief Compute pair potential energy.
+     * @param a
+     * @param b
+     * @return pair potential energy between particles a and b
+     */
+    template <typename T> inline double potential(const T &a, const T &b) const {
         assert(&a != &b); // a and b cannot be the same particle
         if constexpr (allow_anisotropic_pair_potential) {
             Point r = spc.geo.vdist(a.pos, b.pos);
-            return pairpot(a, b, r.squaredNorm(), r);
+            return pair_potential(a, b, r.squaredNorm(), r);
         } else {
-            return pairpot(a, b, spc.geo.sqdist(a.pos, b.pos), {0, 0, 0});
+            return pair_potential(a, b, spc.geo.sqdist(a.pos, b.pos), {0, 0, 0});
+        }
+    }
+
+    // just a temporary placement until PairForce class template will be implemented
+    template <typename T> inline Point force(const T &a, const T &b) const {
+        assert(&a != &b); // a and b cannot be the same particle
+        if constexpr (allow_anisotropic_pair_potential) {
+            Point r = spc.geo.vdist(a.pos, b.pos);
+            return pair_potential.force(a, b, r.squaredNorm(), r);
+        } else {
+            return pair_potential.force(a, b, spc.geo.sqdist(a.pos, b.pos), {0, 0, 0});
         }
     }
 
     /**
-     * Internal energy in group, calculating all with all or, if `index`
-     * is given, only a subset. Index specifies the internal index (starting
-     * from zero) of changed particles within the group.
-     *
-     * @todo investigate overhead of `fixed_index` filtering
+     * @brief Functor alias for @see potential.
      */
-    double g_internal(const Tgroup &g, const std::vector<int> &moved_index = std::vector<int>()) {
-        timer_g_internal.start(); // measure time spent in this subroutine
-        using namespace ranges;
-        double u = 0;
-        auto &moldata = g.traits();
-        if (moldata.rigid)
-            return u;
-
-        switch (moved_index.size()) {
-
-        // if zero, assume all particles have changed
-        case 0:
-            for (int i = 0; i < (int)g.size() - 1; i++)
-                for (int j = i + 1; j < (int)g.size(); j++)
-                    if (not moldata.isPairExcluded(i, j))
-                        u += i2i(g[i], g[j]);
-            break; // exit switch
-
-        // a single particle has changed in an atomic group; no exclusion check
-        case 1:
-            if (g.atomic) {
-                size_t i = moved_index[0];
-                for (size_t j = 0; j < i; j++)
-                    u += i2i(g[i], g[j]);
-                for (size_t j = i + 1; j < g.size(); j++)
-                    u += i2i(g[i], g[j]);
-                break; // exit switch only if atomic group, otherwise continue to default:
-            }
-            [[fallthrough]];
-
-        // one or more particle(s) have changed
-        default:
-            auto fixed_index = ranges::views::ints(0, int(g.size())) | ranges::views::remove_if([&moved_index](int i) {
-                                   return std::binary_search(moved_index.begin(), moved_index.end(), i);
-                               }); // index of all static particles
-            for (int i : moved_index) {
-                for (int j : fixed_index) // moved <-> static
-                    if (not moldata.isPairExcluded(i, j))
-                        u += i2i(g[i], g[j]);
-                for (int j : moved_index) // moved <-> moved
-                    if (j > i)
-                        if (not moldata.isPairExcluded(i, j))
-                            u += i2i(g[i], g[j]);
-            }
-        }
-        timer_g_internal.stop();
-        return u;
+    template <typename... Args> inline auto operator()(Args &&... args) {
+        return potential(std::forward<Args>(args)...);
     }
 
-    /*
-     * Calculates the interaction energy of a particle, `i`,
-     * and checks (1) if it is already part of Space, or (2)
-     * external to space.
+    /**
+     * @brief Register the potential self-energy to @see Hamiltonian::Hamiltonian if needed.
      */
-    double i2all(const typename Space::Tparticle &i) {
-        if (omp_enable and omp_i2all) {
-            return i2all_parallel(i);
-        }
-        double u = 0;
-        auto it = spc.findGroupContaining(i); // iterator to group
-        if (it != spc.groups.end()) {         // check if i belongs to group in space
-            for (size_t ig = 0; ig < spc.groups.size(); ig++) {
-                auto &g = spc.groups[ig];
-                if (&g != &(*it))         // avoid self-interaction
-                    if (not cut(g, *it))  // check g2g cut-off
-                        for (auto &j : g) // loop over particles in other group
-                            u += i2i(i, j);
-            }
-            std::ptrdiff_t i_ndx = &i - &(*(it->begin()));   // fixme c++ style
-            u += g_internal(*it, {static_cast<int>(i_ndx)}); // only int indices are used internally
-        } else {                          // particle does not belong to any group
-            for (auto &g : spc.groups) {  // i with all other *active* particles
-                for (auto &j : g) {       // (this will include only active particles)
-                    u += i2i(i, j);
-                }
-            }
-        }
-        return u;
-    }
-
-    double i2all_parallel(const Particle &p_i) {
-        using ranges::cpp20::views::filter;
-        using ranges::cpp20::views::transform;
-
-        i_interact_with_these.clear(); // vector of particle pointers to interact with
-        double u = 0;
-        auto own_group = spc.findGroupContaining(p_i); // iterator to group containing p_i
-        if (own_group != spc.groups.end()) {           // check if p_i belongs to group in space
-            for (auto &g : spc.groups) {
-                if (&g != &(*own_group))        // avoid self-interaction
-                    if (not cut(g, *own_group)) // check g2g cut-off
-                        std::transform(g.begin(), g.end(), std::back_inserter(i_interact_with_these),
-                                       [](auto &p) { return &p; });
-            }
-            // p_i with all particles in own group - avoid self interaction
-            auto f = *own_group | filter([&](auto &j) { return &j != &p_i; }) | transform([](auto &j) { return &j; });
-            i_interact_with_these.insert(i_interact_with_these.end(), f.begin(), f.end());
-        } else {                                         // particle does not belong to any group
-            for (auto &g : spc.groups)                   // i with all other *active* particles
-                for (auto &j : g)                        // (this will include only active particles)
-                    i_interact_with_these.push_back(&j); // u += i2i(i, j);
-        }
-
-#pragma omp parallel for reduction(+ : u) if (omp_enable and omp_i2all)
-        for (size_t k = 0; k < i_interact_with_these.size(); k++)
-            u += i2i(p_i, *i_interact_with_these[k]);
-        return u;
-    }
-
-    /*
-     * Group-to-group energy. A subset of `g1` can be given with `index` which refers
-     * to the internal index (starting at zero) of the first group, `g1
-     * NOTE: the interpretation of this function is extended to also consider the mutual interactions
-     * of a subset of each group and in such case returns sub1 <-> 2 and !sub1<->sub2,
-     * hence excluding !sub1 <-> !sub2 in comparision to calling onconstrained g2g. In absence
-     * of sub1 any sub2 is ignored.
-     */
-    virtual double g2g(const Tgroup &g1, const Tgroup &g2, const std::vector<int> &index = std::vector<int>(),
-                       const std::vector<int> &jndex = std::vector<int>()) {
-        using namespace ranges;
-        double u = 0;
-        if (not cut(g1, g2)) {
-            if (index.empty() && jndex.empty()) // if index is empty, assume all in g1 have changed
-#pragma omp parallel for reduction(+ : u) schedule(dynamic) if (omp_enable and omp_p2p)
-                for (size_t i = 0; i < g1.size(); i++)
-                    for (size_t j = 0; j < g2.size(); j++)
-                        u += i2i(g1[i], g2[j]);
-            else { // only a subset of g1
-                for (auto i : index)
-                    for (auto j = g2.begin(); j != g2.end(); ++j)
-                        u += i2i(g1[i], *j);
-                if (not jndex.empty()) {
-                    auto fixed = ranges::views::ints(0, int(g1.size())) | ranges::views::remove_if([&index](int i) {
-                                     return std::binary_search(index.begin(), index.end(), i);
-                                 });
-                    for (auto i : jndex)     // moved2        <-|
-                        for (auto j : fixed) // static1   <-|
-                            u += i2i(g2[i], g1[j]);
-                }
-            }
-        }
-        return u;
-    }
-
-    // add self energy term to Hamiltonian if appropriate
     void addPairPotentialSelfEnergy() {
-        if (pairpot.selfEnergy) { // only add if self energy is defined
-            faunus_logger->debug("{} is adding self-energy from {} to Hamiltonian", name, pairpot.name);
-            pot.emplace_back<Energy::ParticleSelfEnergy>(spc, pairpot.selfEnergy);
+        if (pair_potential.selfEnergy) { // only add if self energy is defined
+            faunus_logger->debug("Adding self-energy from {} to hamiltonian", pair_potential.name);
+            potentials.emplace_back<Energy::ParticleSelfEnergy>(spc, pair_potential.selfEnergy);
         }
     }
 
-    void configureOpenMP(const json &j) {
-        auto it = j.find("openmp");
-        if (it != j.end())
-            if (it->is_array())
-                if (it->size() > 0) {
-                    omp_enable = true;
-                    for (const std::string &k : *it)
-                        if (k == "g2g")
-                            omp_g2g = true;
-                        else if (k == "p2p")
-                            omp_p2p = true;
-                        else if (k == "i2all")
-                            omp_i2all = true;
-#ifndef _OPENMP
-                    faunus_logger->warn("{}: requested openmp unavailable", name);
-#endif
-                }
+    void from_json(const json &j) {
+        pair_potential.from_json(j);
+        if (!pair_potential.isotropic && !allow_anisotropic_pair_potential) {
+            throw std::logic_error("Only isotropic pair potentials are allowed.");
+        }
+        addPairPotentialSelfEnergy();
     }
+
+    void to_json(json &j) { pair_potential.to_json(j); }
+};
+
+/**
+ * @brief Particle pairing to calculate non-bonded pair potential energies.
+ *
+ * A complete basic (serial) implementation of particle-particle pairing. The class shall not be used directly.
+ * The derived template class @see PairingPolicy shall be used instead.
+ *
+ * Method arguments are generally not checked for correctness because of performance reasons.
+ */
+template <typename TPairEnergy> class PairingBasePolicy {
+  protected:
+    Space &spc;              //!< space to operate on
+    TPairEnergy pair_energy; //!< functor to compute non-bonded energy between two particles, @see PairEnergy template
 
   public:
-    Space &spc; //!< Space to operate on
-    BasePointerVector<Energybase> &pot;
-    Tpairpot pairpot; //!< Pair potential
+    // FIXME shall be protected after refactorisation of NonbondedCached
+    Cutoff cut; //!< cutoff functor to determine if energy computation between two given groups can be skipped
 
-    Nonbonded(const json &j, Space &spc, BasePointerVector<Energybase> &pot) : cut(spc), spc(spc), pot(pot) {
-        name = "nonbonded";
-        pairpot.from_json(j);
+    /**
+     * @param spc
+     * @param potentials registered non-bonded potentials
+     */
+    PairingBasePolicy(Space &spc, BasePointerVector<Energybase> &potentials)
+        : spc(spc), pair_energy(spc, potentials), cut(spc) {}
 
-        if (!pairpot.isotropic and !allow_anisotropic_pair_potential)
-            throw std::runtime_error("Only isotropic pair potentials are allowed");
+    void from_json(const json &j) {
+        Energy::from_json(j, cut);
+        pair_energy.from_json(j);
+    }
 
-        // some pair-potentials give rise to self-energies (Wolf etc.)
-        // which are added here if needed
-        addPairPotentialSelfEnergy();
+    void to_json(json &j) {
+        Energy::to_json(j, cut);
+        pair_energy.to_json(j);
+    }
 
-        configureOpenMP(j);
-        from_json(j, cut);
+    template <typename T> inline double particle2particle(const T &a, const T &b) const {
+        return pair_energy.potential(a, b);
     }
 
     /**
-     * Calculates the force on all particles
-     * @todo Change to reflect only active particle, see Space::activeParticles()
+     * @brief Internal energy of a group.
+     *
+     * All non-bonded pair interaction within the group are summed up. The pair exclusions defined in the molecule
+     * topology are honoured.
+     *
+     * @param group
+     * @return energy sum between particle pairs
      */
-    void force(std::vector<Point> &forces) override {
-        auto &p = spc.p; // alias to particle vector (reference)
-        assert(forces.size() == p.size() && "the forces size must match the particle size");
-        for (size_t i = 0; i < p.size() - 1; i++) {
-            for (size_t j = i + 1; j < p.size(); j++) {
-                Point r = spc.geo.vdist(p[i].pos, p[j].pos); // minimum distance vector
-                Point f = pairpot.force(p[i], p[j], r.squaredNorm(), r);
+    template <typename TGroup> double groupInternal(const TGroup &group) {
+        double u = 0;
+        auto &moldata = group.traits();
+        if (!moldata.rigid) {
+            const int group_size = group.size();
+            for (int i = 0; i < group_size - 1; ++i) {
+                for (int j = i + 1; j < group_size; ++j) {
+                    if (group.atomic || !moldata.isPairExcluded(i, j)) {
+                        u += particle2particle(group[i], group[j]);
+                    }
+                }
+            }
+        }
+        return u;
+    }
+
+    /**
+     * @brief Partial internal energy of a group limited to interactions of a single particle within the group.
+     *
+     * The pair exclusions defined in the molecule topology are honoured.
+     *
+     * @param group
+     * @param index internal index of the selected particle within the group
+     * @return energy sum between particle pairs
+     */
+    template <typename TGroup> double groupInternal(const TGroup &group, const int index) {
+        double u = 0;
+        auto &moldata = group.traits();
+        if (!moldata.rigid) {
+            if (group.atomic) {
+                // speed optimization: non-bonded interaction exclusions do not need to be checked for atomic groups
+                for (size_t i = 0; i < index; ++i) {
+                    u += particle2particle(group[index], group[i]);
+                }
+                for (size_t i = index + 1; i < group.size(); ++i) {
+                    u += particle2particle(group[index], group[i]);
+                }
+            } else {
+                for (size_t i = 0; i < index; ++i) {
+                    if (!moldata.isPairExcluded(index, i)) {
+                        u += particle2particle(group[index], group[i]);
+                    }
+                }
+                for (size_t i = index + 1; i < group.size(); ++i) {
+                    if (!moldata.isPairExcluded(index, i)) {
+                        u += particle2particle(group[index], group[i]);
+                    }
+                }
+            }
+        }
+        return u;
+    }
+
+    /**
+     * @brief Partial internal energy of the group limited to the particles present in the index.
+     *
+     * Only such non-bonded pair interactions within the group are considered if at least one particle is present
+     * in the index. The pair exclusions defined in the molecule topology are honoured.
+     *
+     * @param group
+     * @param index internal indices of particles within the group
+     * @return energy sum between particle pairs
+     */
+    template <typename TGroup, typename TIndex> double groupInternal(const TGroup &group, const TIndex &index) {
+        double u = 0;
+        auto &moldata = group.traits();
+        if (!moldata.rigid) {
+            if (index.size() == 1) {
+                u = groupInternal(group, index[0]);
+            } else {
+                // TODO investigate overhead of `index_complement` filtering;
+                // TODO perhaps allow different strategies based on the index-size/group-size ratio
+                auto index_complement = indexComplement(group.size(), index);
+                // moved <-> static
+                for (int i : index) {
+                    for (int j : index_complement) {
+                        if (!moldata.isPairExcluded(i, j)) {
+                            u += particle2particle(group[i], group[j]);
+                        }
+                    }
+                }
+                // moved <-> moved
+                for (auto i_it = index.begin(); i_it < index.end(); ++i_it) {
+                    for (auto j_it = std::next(i_it); j_it < index.end(); ++j_it) {
+                        if (!moldata.isPairExcluded(*i_it, *j_it)) {
+                            u += particle2particle(group[*i_it], group[*j_it]);
+                        }
+                    }
+                }
+            }
+        }
+        return u;
+    }
+
+    /**
+     * @brief Complete cartesian pairing of particles in two groups.
+     *
+     * group1 × group2
+     *
+     * If the distance between the groups is greater or equal to the cutoff distance, no calculation is performed.
+     * The group intersection must be an empty set, i.e., no particle is included in both groups. This is not verified
+     * for performance reason.
+     *
+     * @param group1
+     * @param group2
+     * @return energy sum between particle pairs
+     */
+    template <typename TGroup> double group2group(const TGroup &group1, const TGroup &group2) {
+        double u = 0;
+        if (!cut(group1, group2)) {
+            for (auto &particle1 : group1) {
+                for (auto &particle2 : group2) {
+                    u += particle2particle(particle1, particle2);
+                }
+            }
+        }
+        return u;
+    }
+
+    /**
+     * @brief Cross pairing of particles in two groups. Only a cartesian subset of the complete cartesian product is
+     * considered as the particles in the first group must be also present in the index. The aim is to capture only
+     * interactions that involve changing (indexed) particles.
+     *
+     * ⊕group1 × group2, where ⊕ denotes a filter by an index
+     *
+     * If the distance between the groups is greater or equal to the cutoff distance, no calculation is performed.
+     * The group intersection must be an empty set, i.e., no particle is included in both groups. This is not verified
+     * for performance reason.
+
+     * @param group1
+     * @param group2
+     * @param index1 list of particle indices in group1 relative to the group beginning
+     * @return Energy sum between particle pairs
+     */
+    template <typename TGroup>
+    double group2group(const TGroup &group1, const TGroup &group2, const std::vector<int> &index1) {
+        double u = 0;
+        if (!cut(group1, group2)) {
+            for (auto particle1_ndx : index1) {
+                for (auto &particle2 : group2) {
+                    u += particle2particle(*(group1.begin() + particle1_ndx), particle2);
+                }
+            }
+        }
+        return u;
+    }
+
+    /**
+     * @brief Cross pairing of particles in two groups. Only a non-cartesian subset of the complete cartesian product
+     * is considered as at least one particles in the pair must be also present in the respective index. The aim is
+     * to capture only interactions that involve changing (indexed) particles, i.e., to avoid pairs containing only
+     * non-indexed particles.
+     *
+     * (⊕group1 × ∁⊕group2) + (∁⊕group1 × ⊕group2) + (⊕group1 × ⊕group2) =
+     * = group1 × group2 − (∁⊕group2 × ∁⊕group2), where ⊕ denotes a filter by an index and ∁ a complement
+     *
+     * If the distance between the groups is greater or equal to the cutoff distance, no calculation is performed.
+     * The group intersection must be an empty set, i.e., no particle is included in both groups. This is not verified
+     * for performance reason.
+     *
+     * @param group1
+     * @param group2
+     * @param index1 list of particle indices in group1 relative to the group beginning
+     * @param index2 list of particle indices in group2 relative to the group beginning
+     * @return energy sum between particle pairs
+     */
+    template <typename TGroup>
+    double group2group(const TGroup &group1, const TGroup &group2, const std::vector<int> &index1,
+                       const std::vector<int> &index2) {
+        double u = 0;
+        if (!cut(group1, group2)) {
+            if (!index2.empty()) {
+                // (∁⊕group1 × ⊕group2) + (⊕group1 × ⊕group2) = group1 × ⊕group2
+                u += group2group(group2, group1, index2);
+                // + (⊕group1 × ∁⊕group2)
+                auto index2_complement = indexComplement(group2.size(), index2);
+                for (auto particle1_ndx : index1) {
+                    for (auto particle2_ndx : index2_complement) {
+                        u += particle2particle(group2[particle2_ndx], group1[particle1_ndx]);
+                    }
+                }
+            } else if (!index1.empty()) {
+                // (⊕group1 × ∁⊕group2) + (⊕group1 × ⊕group2) = ⊕group1 × group2
+                u += group2group(group1, group2, index1);
+                // + (∁⊕group1 × ⊕group2) = Ø as ⊕group2 is empty
+            } else {
+                // both indices empty hence nothing to do
+            }
+        }
+        return u;
+    }
+
+    /**
+     * @brief Complete cartesian pairing between particles in a group and a union of groups.
+     *
+     * group × (∪ groups)
+     *
+     * If the distance between the groups is greater or equal to the cutoff distance, the particle pairing between them
+     * is skipped. The internal energy of the group is not computed even if the group is also present in the union
+     * of groups.
+     *
+     * @param group
+     * @param groups
+     * @return energy sum between particle pairs
+     */
+    template <typename TGroup, typename TGroups> double group2groups(const TGroup &group, const TGroups &groups) {
+        double u = 0;
+        for (auto &other_group : groups) {
+            if (&other_group != &group) {
+                u += group2group(group, other_group);
+            }
+        }
+        return u;
+    }
+
+    /**
+     * @brief Cross pairing of particles in a group and a union of groups. Only a cartesian subset of the complete
+     * cartesian product is considered as the particles of the first group must be also present in the index. The aim
+     * is to capture only interactions that involve changing (indexed) particles.
+     *
+     * ⊕group × (∪ groups), where ⊕ denotes a filter by an index
+     *
+     * If the distance between the groups is greater or equal to the cutoff distance, the particle pairing between them
+     * is skipped. The internal energy of the group is not computed even if the group is also present in the union
+     * of groups.
+     *
+     * @param group
+     * @param group_index groups as indices in Space::groups
+     * @param index list of particle indices in the group relative to the group beginning
+     * @return energy sum between particle pairs
+     */
+    template <typename TGroup, typename TGroups>
+    double group2groups(const TGroup &group, const TGroups &group_index, const std::vector<int> &index) {
+        double u = 0;
+        for (auto other_group_ndx : group_index) {
+            const auto &other_group = spc.groups[other_group_ndx];
+            if (&other_group != &group) {
+                u += group2group(group, other_group, index);
+            }
+        }
+        return u;
+    }
+
+    /**
+     * @brief Complete cartesian pairing between particles in a group and particles in other groups in space.
+     *
+     * group × (space ∖ group)
+     *
+     * If the distance between the groups is greater or equal to the cutoff distance, the particle pairing between them
+     * is skipped.
+     *
+     * @param group
+     * @return energy sum between particle pairs
+     */
+    template <typename Tgroup> double group2all(const Tgroup &group) {
+        double u = 0;
+        for (auto &other_group : spc.groups) {
+            if (&other_group != &group) {
+                u += group2group(group, other_group);
+            }
+        }
+        return u;
+    }
+
+    /**
+     * @brief Complete cartesian pairing between a single particle in a group and particles in other groups in space.
+     *
+     * ⊕group × (space ∖ group), where ⊕ denotes a filter by an index (here a single particle)
+     *
+     * If the distance between the groups is greater or equal to the cutoff distance, the particle pairing between them
+     * is skipped. This method is performance-optimized version of the multiple indices method.
+     *
+     * @param group
+     * @param index a particle index relative to the group beginning
+     * @return energy sum between particle pairs
+     */
+    template <typename TGroup> double group2all(const TGroup &group, const int index) {
+        double u = 0;
+        const auto &particle = group[index];
+        for (auto &other_group : spc.groups) {
+            if (&other_group != &group) {                      // avoid self-interaction
+                if (!cut(other_group, group)) {                // check g2g cut-off
+                    for (auto &other_particle : other_group) { // loop over particles in other group
+                        u += particle2particle(particle, other_particle);
+                    }
+                }
+            }
+        }
+        return u;
+    }
+
+    /**
+     * @brief Complete cartesian pairing between selected particles in a group and particles in other groups in space.
+     *
+     * ⊕group × (space ∖ group), where ⊕ denotes a filter by an index
+     *
+     * If the distance between the groups is greater or equal to the cutoff distance, the particle pairing between them
+     * is skipped.
+     *
+     * @param group
+     * @param index list of particle indices in the group relative to the group beginning
+     * @return energy sum between particle pairs
+     */
+    template <typename Tgroup> double group2all(const Tgroup &group, const std::vector<int> &index) {
+        double u = 0;
+        if (index.size() == 1) {
+            u = group2all(group, index[0]);
+        } else {
+            for (auto &other_group : spc.groups) {
+                if (&other_group != &group) {
+                    u += group2group(group, other_group, index);
+                }
+            }
+        }
+        return u;
+    }
+
+    /**
+     * @brief Cross pairing of particles among a union of groups. No internal pairs within any group are considered.
+     *
+     * If the distance between any two groups is greater or equal to the cutoff distance, the particle pairing between
+     * them is skipped.
+     *
+     * @param group_index list of groups
+     * @return energy sum between particle pairs
+     */
+    template <typename T> double groups2self(const T &group_index) {
+        double u = 0;
+        for (auto group1_ndx_it = group_index.begin(); group1_ndx_it < group_index.end(); ++group1_ndx_it) {
+            // u += groupInternal(spc.groups[*group_it]);
+            for (auto group2_ndx_it = std::next(group1_ndx_it); group2_ndx_it < group_index.end(); group2_ndx_it++) {
+                u += group2group(spc.groups[*group1_ndx_it], spc.groups[*group2_ndx_it]);
+            }
+        }
+        return u;
+    }
+
+    /**
+     * @brief Cross pairing of particles between a union of groups and its complement in space.
+     *
+     * If the distance between any two groups is greater or equal to the cutoff distance, the particle pairing between
+     * them is skipped.
+     *
+     * @param group_index list of groups
+     * @return energy sum between particle pairs
+     */
+    template <typename T> double groups2all(const T &group_index) {
+        double u = 0;
+        u += groups2self(group_index);
+        auto index_complement = indexComplement(spc.groups.size(), group_index);
+        for (auto group1_ndx : group_index) {
+            for (auto group2_ndx : index_complement) {
+                u += group2group(spc.groups[group1_ndx], spc.groups[group2_ndx]);
+            }
+        }
+        return u;
+    }
+
+    /**
+     * @brief Cross pairing between all particles in the space.
+     *
+     * If the distance between particles' groups is greater or equal to the cutoff distance, no calculation is
+     * performed.
+     *
+     * @return energy sum between particle pairs
+     */
+    double all() {
+        double u = 0;
+        for (auto group_it = spc.groups.begin(); group_it < spc.groups.end(); ++group_it) {
+            u += groupInternal(*group_it);
+            for (auto other_group_it = std::next(group_it); other_group_it < spc.groups.end(); other_group_it++) {
+                u += group2group(*group_it, *other_group_it);
+            }
+        }
+        return u;
+    }
+
+    /**
+     * @brief Cross pairing between all particles in the space.
+     *
+     * If the distance between particles' groups is greater or equal to the cutoff distance, no calculation is
+     * performed.
+     *
+     * @param condition a group filter if internal energy of the group shall be add
+     * @return energy sum between particle pairs
+     */
+    template <typename TCondition> double all(TCondition condition) {
+        double u = 0;
+        for (auto group_it = spc.groups.begin(); group_it < spc.groups.end(); ++group_it) {
+            if (condition(*group_it)) {
+                u += groupInternal(*group_it);
+            }
+            for (auto other_group_it = std::next(group_it); other_group_it < spc.groups.end(); other_group_it++) {
+                u += group2group(*group_it, *other_group_it);
+            }
+        }
+        return u;
+    }
+
+    void force(std::vector<Point> &forces) {
+        // just a temporary hack; perhaps better to allow PairForce instead of the PairEnergy template
+        assert(forces.size() == spc.p.size() && "the forces size must match the particle size");
+        for (size_t i = 0; i < spc.p.size() - 1; i++) {
+            for (size_t j = i + 1; j < spc.p.size(); j++) {
+                const Point f = pair_energy.force(spc.p[i], spc.p[j]);
                 forces[i] += f;
                 forces[j] -= f;
             }
         }
     }
+};
 
-    double energy(Change &change) override {
+template <typename TPairEnergy, bool parallel = false> class PairingPolicy : public PairingBasePolicy<TPairEnergy> {
+  public:
+    using PairingBasePolicy<TPairEnergy>::PairingBasePolicy;
+};
+
+/**
+ * @brief Compute change in the non-bonded energy, assuming pair-wise additive energy terms.
+ * @tparam TPairingPolicy pairing policy to effectively sum up the pair-wise additive non-bonded energy
+ */
+template <typename TPairingPolicy> class Nonbonded : public Energybase {
+  protected:
+    Space &spc;             //!< space to operate on
+    TPairingPolicy pairing; //!< pairing policy to effectively sum up the pair-wise additive non-bonded energy
+
+    /**
+     * @brief Compute non-bonded energy contribution if only a single group has changed.
+     * @param change
+     * @return energy sum between particle pairs
+     */
+    double energyGroup(Change &change) {
         double u = 0;
-
-        if (change) {
-            // there's a change in system volume
-            if (change.dV) {
-#pragma omp parallel for reduction(+ : u) schedule(dynamic) if (omp_enable and omp_g2g)
-                for (auto i = spc.groups.begin(); i < spc.groups.end(); ++i) {
-                    for (auto j = i; ++j != spc.groups.end();)
-                        u += g2g(*i, *j);
-                    if (i->atomic or i->compressible)
-                        u += g_internal(*i);
-                }
-                return u;
+        const auto &change_data = change.groups[0];
+        const auto &group = spc.groups.at(change_data.index);
+        if (change_data.atoms.size() == 1) {
+            // faster algorithm if only a single particle moves
+            u = pairing.group2all(group, change_data.atoms[0]);
+            if (change_data.internal) {
+                u += pairing.groupInternal(group, change_data.atoms[0]);
             }
-
-            // did everything change?
-            if (change.all) {
-#pragma omp parallel for reduction(+ : u) schedule(dynamic) if (omp_enable and omp_g2g)
-                for (auto i = spc.groups.begin(); i < spc.groups.end(); ++i) {
-                    for (auto j = i; ++j != spc.groups.end();)
-                        u += g2g(*i, *j);
-                    u += g_internal(*i);
-                }
-                // more todo here...
-                return u;
+        } else {
+            const bool change_all = change_data.atoms.empty(); // all particles or only their subset?
+            u = change_all ? pairing.group2all(group) : pairing.group2all(group, change_data.atoms);
+            if (change_data.internal) {
+                u += change_all ? pairing.groupInternal(group) : pairing.groupInternal(group, change_data.atoms);
             }
-
-            // if exactly ONE molecule is changed
-            if (change.groups.size() == 1 && not change.dN) {
-                auto &d = change.groups[0];
-                auto gindex = spc.groups.at(d.index).to_index(spc.p.begin()).first;
-
-                // exactly one atom has moved
-                if (d.atoms.size() == 1)
-                    return i2all(spc.p.at(gindex + d.atoms[0]));
-
-                // more atoms moved
-                auto &g1 = spc.groups.at(d.index);
-                // for (auto &g2 : spc.groups)
-#pragma omp parallel for reduction(+ : u) schedule(dynamic) if (omp_enable and omp_g2g)
-                for (size_t i = 0; i < spc.groups.size(); i++) {
-                    auto &g2 = spc.groups[i];
-                    if (&g1 != &g2)
-                        u += g2g(g1, g2, d.atoms);
-                }
-                if (d.internal)
-                    u += g_internal(g1, d.atoms);
-                return u;
-            }
-
-            auto moved = change.touchedGroupIndex(); // index of moved groups
-            auto fixed = ranges::views::ints(0, int(spc.groups.size())) | ranges::views::remove_if([&moved](int i) {
-                             return std::binary_search(moved.begin(), moved.end(), i);
-                         }); // index of static groups
-
-            if (change.dN) {
-                /*auto moved = change.touchedGroupIndex(); // index of moved groups
-                std::vector<int> Moved;
-                for (auto i: moved) {
-                    Moved.push_back(i);
-                }
-                std::sort( Moved.begin(), Moved.end() );
-                auto fixed = ranges::views::ints( 0, int(spc.groups.size()) )
-                    | view::remove_if(
-                            [&Moved](int i){return std::binary_search(Moved.begin(), Moved.end(), i);}
-                            ); // index of static groups*/
-                for (auto cg1 = change.groups.begin(); cg1 < change.groups.end();
-                     ++cg1) {                              // Loop over all changed groups
-                    std::vector<int> ifiltered, jfiltered; // Active atoms
-                    auto g1 = &spc.groups.at(cg1->index);
-                    for (auto i : cg1->atoms) {
-                        if (i < g1->size())
-                            ifiltered.push_back(i);
-                    }
-                    // Skip if the group is empty
-                    if (not ifiltered.empty())
-                        for (auto j : fixed)
-                            u += g2g(*g1, spc.groups[j], ifiltered, jfiltered);
-
-                    for (auto cg2 = cg1; ++cg2 != change.groups.end();) {
-                        for (auto i : cg2->atoms)
-                            if (i < spc.groups.at(cg2->index).size())
-                                jfiltered.push_back(i);
-                        // Skip if both groups are empty
-                        if (not(ifiltered.empty() && jfiltered.empty()))
-                            u += g2g(*g1, spc.groups.at(cg2->index), ifiltered, jfiltered);
-                        jfiltered.clear();
-                    }
-                    if (not ifiltered.empty() and not molecules.at(g1->id).rigid) {
-                        if (cg1->all) {
-                            u += g_internal(*g1);
-                        } else
-                            u += g_internal(*g1, ifiltered);
-                    }
-                }
-                return u;
-            }
-
-            // moved<->moved
-            if (change.moved2moved) {
-                for (auto i = moved.begin(); i != moved.end(); ++i)
-                    for (auto j = i; ++j != moved.end();)
-                        u += g2g(spc.groups[*i], spc.groups[*j]);
-            }
-
-            // moved<->static
-            if (omp_enable and omp_g2g) {
-                std::vector<std::pair<int, int>> pairs(size(moved) * range_size(fixed));
-                size_t cnt = 0;
-                for (auto i : moved)
-                    for (auto j : fixed)
-                        pairs[cnt++] = {i, j};
-#pragma omp parallel for reduction(+ : u) schedule(dynamic) if (omp_enable and omp_g2g)
-                for (size_t i = 0; i < pairs.size(); i++)
-                    u += g2g(spc.groups[pairs[i].first], spc.groups[pairs[i].second]);
-            } else
-                for (auto i : moved)
-                    for (auto j : fixed)
-                        u += g2g(spc.groups[i], spc.groups[j]);
-
-            // more todo!
         }
         return u;
     }
 
-}; //!< Nonbonded, pair-wise additive energy term
+    /**
+     * @brief Compute non-bonded energy difference if the number of particles have changed.
+     *
+     * Particles have to be explicitly enumerated in the atom indices of the changed group. Implicit addition of atoms
+     * with a group is not supported yet. Note that we do not have to care about missing (removed) particles at all.
+     * They are taken into account in the original (old) space where they are present.
+     *
+     * @param change
+     * @return energy sum between particle pairs
+     */
+    double energySpeciation(Change &change) {
+        double u = 0;
+        const auto &moved = change.touchedGroupIndex(); // index of moved groups
+        const auto &fixed = indexComplement(int(spc.groups.size()), moved) | ranges::to<std::vector>; // index of static groups
+        auto filter_active = [](int size){return ranges::views::filter([size](const auto i) { return i < size; }); };
 
-template <typename Tpairpot> class NonbondedCached : public Nonbonded<Tpairpot> {
+        // loop over all changed groups
+        for (auto change_group1_it = change.groups.begin(); change_group1_it < change.groups.end(); ++change_group1_it) {
+            auto &group1 = spc.groups.at(change_group1_it->index);
+            // filter only active particles
+            const std::vector<int> index1 = change_group1_it->atoms | filter_active(group1.size()) | ranges::to<std::vector>;
+            if (!index1.empty()) {
+                // particles added into the group: compute (changed group) <-> (static group)
+                u += pairing.group2groups(group1, fixed, index1);
+            }
+            // loop over successor changed groups (hence avoid double counting group1×group2 and group2×group1)
+            for (auto change_group2_it = std::next(change_group1_it); change_group2_it < change.groups.end(); ++change_group2_it) {
+                auto &group2 = spc.groups.at(change_group2_it->index);
+                const std::vector<int> index2 = change_group2_it->atoms | filter_active(group2.size()) | ranges::to<std::vector>;
+                if (!index1.empty() || !index2.empty()) {
+                    // particles added into one or other group: compute (changed group) <-> (changed group)
+                    u += pairing.group2group(group1, group2, index1, index2);
+                }
+            }
+            if (!index1.empty() && !molecules.at(group1.id).rigid) {
+                // compute internal energy in the changed group
+                u += change_group1_it->all ? pairing.groupInternal(group1) : pairing.groupInternal(group1, index1);
+            }
+        }
+        return u;
+    }
+
+  public:
+    Nonbonded(const json &j, Space &spc, BasePointerVector<Energybase> &pot) : spc(spc), pairing(spc, pot) {
+        name = "nonbonded";
+        pairing.from_json(j);
+    }
+
+    /**
+     * @brief Calculate the force on all particles.
+     *
+     * @todo A stub. Change to reflect only active particle, see Space::activeParticles().
+     */
+    void force(std::vector<Point> &forces) override { pairing.force(forces); }
+
+    /**
+     * @brief Compute non-bonded energy contribution from changed particles.
+     *
+     * The internal energy contribution, i.e., the contribution from the intra group interactions, is added
+     * only if a single group is changed or if all changed.
+     *
+     * @param change
+     * @return energy sum between particle pairs
+     */
+    double energy(Change &change) override {
+        double u = 0;
+        if (change.all) {
+            u = pairing.all();
+        } else if (change.dV) {
+            // sum all interaction energies except the internal energies of incompressible molecules
+            u = pairing.all([](auto &group) { return group.atomic || group.compressible; });
+        } else if (!change.dN) {
+            if (change.groups.size() == 1) {
+                // if only a single group changes use faster algorithm and optionally add the internal energy
+                u = energyGroup(change);
+            } else {
+                // if multiple groups move, no internal energies are computed
+                const auto &moved = change.touchedGroupIndex(); // index of moved groups
+                u = pairing.groups2all(moved);
+            }
+        } else { // change.dN
+            u = energySpeciation(change);
+        }
+        return u;
+    }
+};
+
+
+template <typename Tpairpot> class NonbondedCached : public Nonbonded<PairingPolicy<PairEnergy<Tpairpot>>> {
   private:
-    typedef Nonbonded<Tpairpot> base;
+    typedef Nonbonded<PairingPolicy<PairEnergy<Tpairpot>>> base;
     typedef typename Space::Tgroup Tgroup;
     Eigen::MatrixXf cache;
     Space &spc;
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-    double g2g(const Tgroup &g1, const Tgroup &g2, const std::vector<int> &index = std::vector<int>(),
-               const std::vector<int> &jndex = std::vector<int>()) override {
-#pragma GCC diagnostic pop
-        //assert(index.empty() && "unimplemented");
-        //assert(jndex.empty() && "unimplemented");
-
+    double g2g(const Tgroup &g1, const Tgroup &g2) {
         int i = &g1 - &base::spc.groups.front();
         int j = &g2 - &base::spc.groups.front();
         if (j < i)
             std::swap(i, j);
         if (base::key == Energybase::NEW) { // if this is from the trial system,
             double u = 0;
-            if (not base::cut(g1, g2)) {
+            if (not base::pairing.cut(g1, g2)) { // ugly
                 for (auto &i : g1)
                     for (auto &j : g2)
-                        u += base::i2i(i, j);
+                        u += base::pairing.particle2particle(i, j);
             }
             cache(i, j) = u;
         }
         return cache(i, j); // return (cached) value
+    }
+
+    double g2g(const Tgroup &g1, const Tgroup &g2, [[maybe_unused]] const std::vector<int> &index) {
+        // index not implemented
+        return g2g(g1, g2);
     }
 
   public:
@@ -712,16 +1011,16 @@ template <typename Tpairpot> class NonbondedCached : public Nonbonded<Tpairpot> 
         cache.resize(spc.groups.size(), spc.groups.size());
         cache.setZero();
         for (auto i = base::spc.groups.begin(); i < base::spc.groups.end(); ++i) {
-            for (auto j = i; ++j != base::spc.groups.end();) {
+            for (auto j = std::next(i); j != base::spc.groups.end(); ++j) {
                 int k = &(*i) - &base::spc.groups.front();
                 int l = &(*j) - &base::spc.groups.front();
                 if (l < k)
                     std::swap(k, l);
                 double u = 0;
-                if (!base::cut(*i, *j)) {
+                if (!base::pairing.cut(*i, *j)) { // ugly
                     for (auto &k : *i)
                         for (auto &l : *j)
-                            u += base::i2i(k, l);
+                            u += base::pairing.particle2particle(k, l);
                 }
                 cache(k, l) = u;
             }
@@ -734,7 +1033,6 @@ template <typename Tpairpot> class NonbondedCached : public Nonbonded<Tpairpot> 
         if (change) {
 
             if (change.all || change.dV) {
-#pragma omp parallel for reduction(+ : u) schedule(dynamic) if (this->omp_enable)
                 for (auto i = base::spc.groups.begin(); i < base::spc.groups.end(); ++i) {
                     for (auto j = i; ++j != base::spc.groups.end();)
                         u += g2g(*i, *j);
@@ -747,7 +1045,6 @@ template <typename Tpairpot> class NonbondedCached : public Nonbonded<Tpairpot> 
                 auto &d = change.groups[0];
                 auto &g1 = base::spc.groups.at(d.index);
 
-#pragma omp parallel for reduction(+ : u) schedule(dynamic) if (this->omp_enable and this->omp_g2g)
                 for (size_t i = 0; i < spc.groups.size(); i++) {
                     auto &g2 = spc.groups[i];
                     if (&g1 != &g2)
@@ -768,16 +1065,15 @@ template <typename Tpairpot> class NonbondedCached : public Nonbonded<Tpairpot> 
                     for (auto j = i; ++j != moved.end();)
                         u += g2g(base::spc.groups[*i], base::spc.groups[*j]);
             // moved<->static
-            if (this->omp_enable and this->omp_g2g) {
-                std::vector<std::pair<int, int>> pairs(size(moved) * range_size(fixed));
-                size_t cnt = 0;
-                for (auto i : moved)
-                    for (auto j : fixed)
-                        pairs[cnt++] = {i, j};
-#pragma omp parallel for reduction(+ : u) schedule(dynamic) if (this->omp_enable and this->omp_g2g)
-                for (size_t i = 0; i < pairs.size(); i++)
-                    u += g2g(spc.groups[pairs[i].first], spc.groups[pairs[i].second]);
-            } else
+//            if (this->omp_enable and this->omp_g2g) {
+//                std::vector<std::pair<int, int>> pairs(size(moved) * rng_size(fixed));
+//                size_t cnt = 0;
+//                for (auto i : moved)
+//                    for (auto j : fixed)
+//                        pairs[cnt++] = {i, j};
+//                for (size_t i = 0; i < pairs.size(); i++)
+//                    u += g2g(spc.groups[pairs[i].first], spc.groups[pairs[i].second]);
+//            } else
                 for (auto i : moved)
                     for (auto j : fixed)
                         u += g2g(base::spc.groups[i], base::spc.groups[j]);

--- a/src/group.h
+++ b/src/group.h
@@ -26,7 +26,7 @@ namespace Faunus {
             void resize(size_t n) { end() += n-size(); assert(size()==n); }
             bool empty() const { return this->first==this->second; }
             void clear() { this->second = this->first; assert(empty()); }
-            std::pair<int,int> to_index(T reference) {
+            std::pair<int,int> to_index(T reference) const {
                 return {std::distance(reference, begin()), std::distance(reference, end()-1)};
             } //!< Returns index pair relative to reference
         }; //!< Turns a pair of iterators into a range

--- a/src/units.h
+++ b/src/units.h
@@ -11,6 +11,7 @@ namespace Faunus {
         typedef double T; //!< Float size
         constexpr T infty = std::numeric_limits<T>::infinity(), //!< Numerical infinity
             epsilon_dbl = std::numeric_limits<T>::epsilon(),    //!< Numerical precision
+            max_value = std::numeric_limits<T>::max(),          //!< Maximal (finite) representable value
             max_exp_argument =
                 709.782712893384,    //!< Largest value exp() can take before overflow (hard-coded for double)
             pi = 3.141592653589793,  //!< Pi


### PR DESCRIPTION
# Description

- Separate the logic determining which particles have changed upon a move from a general particle pairing logic. Introduce a basic pairing policy. Another pairing policies , e.g., OMP optimized, may be added later to allow faster nonbonded energy computation.
- Extensively document the code.

As unintended side effect, some example tests exhibit a rather huge speed-up (GCC 9.2 and Clang 10 on Linux).

<table>
<thead>
<tr><th rowspan=2> example </th><th colspan=2>GCC 9.2</th><th colspan=2>Clang 10</th></tr>
<tr><th> master (s) </th><th> pull request (s)</th><th> master (s) </th><th> pull request (s)</th></tr>
</thead>
<tbody>
<tr><td><code>swapconf</code></td><td>  5.78</td><td>  1.90</td> <td> 10.44</td> <td>  2.66</td></tr>
<tr><td><code>virial</code></td><td> 67.14</td><td>  3.92</td> <td>  3.91</td> <td>  2.03</td></tr>
<tr><td><code>chain</code></td><td> 14.99</td><td> 14.91</td> <td> 11.36</td> <td> 11.61</td></tr>
<tr><td><code>polymers</code></td><td> 17.95</td><td>  9.65</td> <td> 24.18</td> <td> 10.32</td></tr>
<tr><td><code>speciation_group</code></td><td> 67.41</td><td>  8.84</td> <td> 39.46</td> <td>  8.80</td></tr>
<tr><td><code>titration</code></td><td>  9.81</td><td>  9.85</td> <td> 12.77</td> <td> 12.65</td></tr>
<tr><td><code>water-ewald-NOCHECKS</code></td><td> 53.56</td><td> 11.34</td> <td>101.85</td> <td> 28.65</td></tr>
<tr><td><code>cluster</code></td><td> 43.49</td><td> 23.83</td> <td> 78.58</td> <td> 36.80</td></tr>
<tr><td><code>cluster-ideal</code></td><td>  6.39</td><td>  6.54</td> <td> 13.61</td> <td> 13.62</td></tr>
<tr><td><code>stockmayer</code></td><td>125.64</td><td>124.67</td><td>100.19</td><td> 99.16</td></tr>
</tbody>
</table>

Note that OpenMP in particle pairing is effectively disabled with this pull request until OpenMP pairing strategy is introduced.

## Checklist

- [x] `make test` passes with no errors
- [x] the source code is well documented
- [ ] new functionality includes unittests
- [x] the user-manual has been updated to reflect the changes

Ready for _Rebase and merge_ strategy.