### PR TITLE
Skip lengthy benchmarks in unittests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ script:
     make faunus || travis_terminate 1
     ./faunus --version || travis_terminate 1
     make pyfaunus || travis_terminate 1
-    make unittests || travis_terminate 1
+    make unittests -tce="*Benchmark*" || travis_terminate 1
     ctest --output-on-failure -R unittests || travis_terminate 1
     if [[ "$TRAVIS_COMPILER" == "clang" ]]; then
     # check with SID and MPI enabled

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ script:
     make faunus || travis_terminate 1
     ./faunus --version || travis_terminate 1
     make pyfaunus || travis_terminate 1
-    make unittests -tce="*Benchmark*" || travis_terminate 1
+    make unittests || travis_terminate 1
     ctest --output-on-failure -R unittests || travis_terminate 1
     if [[ "$TRAVIS_COMPILER" == "clang" ]]; then
     # check with SID and MPI enabled

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -114,8 +114,9 @@ endif()
 add_executable(unittests unittests.cpp ${tsts})
 target_link_libraries(unittests libfaunus)
 target_compile_definitions(unittests PRIVATE SPDLOG_COMPILED_LIB)
-#set_target_properties(unittests PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
-add_test(NAME unittests COMMAND unittests)
+add_test(
+    NAME unittests
+    COMMAND sh -c "$<TARGET_FILE:unittests> --test-case-exclude=*Benchmark*")
 
 # target: faunus
 add_executable(faunus faunus.cpp)


### PR DESCRIPTION
Running the unit tests may call travis to stall