### PR TITLE
Fix broken travis build on MacOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ addons:
         packages:
             - sdl2
             - open-mpi
+        update: true
     apt:
         packages:
             - python-ruamel.yaml


### PR DESCRIPTION
Since early 2020, MacOS builds have been failing due to an issue with brew. This adds a proposed, temporary fix: https://travis-ci.community/t/macos-build-fails-because-of-homebrew-bundle-unknown-command/7296/7