### PR TITLE
Add bitmask selectors for Group

### DIFF
--- a/src/group.cpp
+++ b/src/group.cpp
@@ -73,42 +73,6 @@ template <class T> void Group<T>::translate(const Point &d, Geometry::BoundaryFu
 }
 
 /**
- * @param mask Bitmask build from enum `Group::Selectors`
- * @return true if ALL enabled bits in the mask are satisfied
- *
- * Note that for `INACTIVE | NEUTRAL`, the criterion is applied
- * to all (inactive) particles, i.e. until `trueend()`.
- */
-template <class T> bool Group<T>::match(unsigned int mask) const {
-    assert(mask != 0);
-    if (mask & Selectors::ACTIVE) {
-        if (size() == 0)
-            return false;
-    } else if (mask & Selectors::INACTIVE) {
-        if (!empty())
-            return false;
-    }
-    if (mask & Selectors::FULL) {
-        if (end() != trueend())
-            return false;
-    }
-    if (mask & Selectors::ATOMIC) {
-        if (!atomic)
-            return false;
-    } else if (mask & Selectors::MOLECULAR) {
-        if (atomic)
-            return false;
-    }
-    if (mask & Selectors::NEUTRAL) {
-        auto _end = (mask & Selectors::INACTIVE) ? trueend() : end();
-        double charge = std::accumulate(begin(), _end, 0.0, [](double sum, auto &i) { return sum + i.charge; });
-        if (std::fabs(charge) > pc::epsilon_dbl)
-            return false;
-    }
-    return true;
-}
-
-/**
  * @param mask Bitmask based on enum `Group::Selectors`
  * @return Lambda function that returns true if group matches mask
  *
@@ -117,9 +81,9 @@ template <class T> bool Group<T>::match(unsigned int mask) const {
  * bool b = filter(mygroup); // true if mygroup is active and uncharged
  * ~~~
  */
-std::function<bool(const Group<Particle> &)> getGroupFilter(unsigned int mask) {
-    return [mask = mask](const Group<Particle> &g) { return g.match(mask); };
-}
+// constexpr std::function<bool(const Group<Particle> &)> getGroupFilter(unsigned int mask) {
+//    return [mask = mask](const Group<Particle> &g) { return g.match<mask>(); };
+//}
 
 template class Group<Particle>;
 

--- a/src/group.cpp
+++ b/src/group.cpp
@@ -45,10 +45,7 @@ template <class T> bool Group<T>::contains(const T &a, bool include_inactive) co
 }
 
 template <class T> double Group<T>::mass() const {
-    double m=0;
-    for (auto &i : *this)
-        m += atoms[i.id].mw;
-    return m;
+    return std::accumulate(begin(), end(), 0.0, [](double sum, auto &i) { return sum + i.traits().mw; });
 }
 
 template <class T> std::vector<std::reference_wrapper<Point>> Group<T>::positions() const {
@@ -124,7 +121,7 @@ std::function<bool(const Group<Particle> &)> getGroupFilter(unsigned int mask) {
     return [mask = mask](const Group<Particle> &g) { return g.match(mask); };
 }
 
-template struct Group<Particle>;
+template class Group<Particle>;
 
 void to_json(json &j, const Group<Particle> &g) {
     j = {

--- a/src/group.cpp
+++ b/src/group.cpp
@@ -75,6 +75,55 @@ template <class T> void Group<T>::translate(const Point &d, Geometry::BoundaryFu
     }
 }
 
+/**
+ * @param mask Bitmask build from enum `Group::Selectors`
+ * @return true if ALL enabled bits in the mask are satisfied
+ *
+ * Note that for `INACTIVE | NEUTRAL`, the criterion is applied
+ * to all (inactive) particles, i.e. until `trueend()`.
+ */
+template <class T> bool Group<T>::match(unsigned int mask) const {
+    assert(mask != 0);
+    if (mask & Selectors::ACTIVE) {
+        if (size() == 0)
+            return false;
+    } else if (mask & Selectors::INACTIVE) {
+        if (!empty())
+            return false;
+    }
+    if (mask & Selectors::FULL) {
+        if (end() != trueend())
+            return false;
+    }
+    if (mask & Selectors::ATOMIC) {
+        if (!atomic)
+            return false;
+    } else if (mask & Selectors::MOLECULAR) {
+        if (atomic)
+            return false;
+    }
+    if (mask & Selectors::NEUTRAL) {
+        auto _end = (mask & Selectors::INACTIVE) ? trueend() : end();
+        double charge = std::accumulate(begin(), _end, 0.0, [](double sum, auto &i) { return sum + i.charge; });
+        if (std::fabs(charge) > pc::epsilon_dbl)
+            return false;
+    }
+    return true;
+}
+
+/**
+ * @param mask Bitmask based on enum `Group::Selectors`
+ * @return Lambda function that returns true if group matches mask
+ *
+ * ~~~ cpp
+ * auto filter = Group::getSelectionFilter(Select::ACTIVE | Select::NEUTRAL);
+ * bool b = filter(mygroup); // true if mygroup is active and uncharged
+ * ~~~
+ */
+std::function<bool(const Group<Particle> &)> getGroupFilter(unsigned int mask) {
+    return [mask = mask](const Group<Particle> &g) { return g.match(mask); };
+}
+
 template struct Group<Particle>;
 
 void to_json(json &j, const Group<Particle> &g) {

--- a/src/group.h
+++ b/src/group.h
@@ -101,11 +101,10 @@ namespace Faunus {
             trueend() = neworigin + std::distance(oldorigin, trueend());
         }
 
-    template<class T /** Particle type */>
-        struct Group : public ElasticRange<T> {
+        template <class T /** Particle type */> class Group : public ElasticRange<T> {
+          public:
             typedef ElasticRange<T> base;
             typedef typename base::Titer iter;
-            typedef typename std::vector<T> Tpvec;
             using base::begin;
             using base::empty;
             using base::end;
@@ -130,7 +129,9 @@ namespace Faunus {
             //! Determines if given `Selectors` bitmask matches group
             bool match(unsigned int) const;
 
-            const auto &traits() const { return molecules.at(id); } //!< Convenient access to molecule properties
+            inline const MoleculeData &traits() const {
+                return Faunus::molecules[id];
+            } //!< Convenient access to molecule properties
 
             template<class Trange>
                 Group(Trange &rng) : base(rng.begin(), rng.end()) {
@@ -194,10 +195,10 @@ namespace Faunus {
 
             void rotate(const Eigen::Quaterniond&, Geometry::BoundaryFunction); //!< Rotate all particles in group incl. internal coordinates (dipole moment etc.)
 
-        }; //!< End of Group struct
+        }; //!< End of Group class
 
         // Group<Particle> is instantiated elsewhere (group.cpp)
-    extern template struct Group<Particle>;
+    extern template class Group<Particle>;
 
 void to_json(json&, const Group<Particle>&);
 void from_json(const json&, Group<Particle>&);

--- a/src/group.h
+++ b/src/group.h
@@ -107,13 +107,28 @@ namespace Faunus {
             typedef typename base::Titer iter;
             typedef typename std::vector<T> Tpvec;
             using base::begin;
+            using base::empty;
             using base::end;
             using base::size;
+            using base::trueend;
             int id=-1;           //!< Molecule id
             int confid=0;        //!< Conformation index / id
             Point cm={0,0,0};    //!< Mass center
             bool compressible=false;   //!< Is it a compressible group?
             bool atomic=false;   //!< Is it an atomic group?
+
+            //! Selections to filter groups using `getSelectionFilter()`
+            enum Selectors : unsigned int {
+                ACTIVE = (1u << 1),    //!< Only active groups (non-zero size)
+                INACTIVE = (1u << 2),  //!< Only inactive groups (zero size)
+                NEUTRAL = (1u << 3),   //!< Only groups with zero net charge
+                ATOMIC = (1u << 4),    //!< Only atomic groups
+                MOLECULAR = (1u << 5), //!< Only molecular groups (atomic=false)
+                FULL = (1u << 6)       //!< Only groups where size equals capacity
+            };
+
+            //! Determines if given `Selectors` bitmask matches group
+            bool match(unsigned int) const;
 
             const auto &traits() const { return molecules.at(id); } //!< Convenient access to molecule properties
 
@@ -186,6 +201,9 @@ namespace Faunus {
 
 void to_json(json&, const Group<Particle>&);
 void from_json(const json&, Group<Particle>&);
+
+//! Get lambda function matching given enum Select mask
+std::function<bool(const Group<Particle> &)> getGroupFilter(unsigned int);
 
 /*
  * The following two functions are used to perform a complete

--- a/src/group_test.h
+++ b/src/group_test.h
@@ -84,23 +84,23 @@ TEST_CASE("[Faunus] Group") {
 
         SUBCASE("getGroupFilter(): complete group") {
             typedef Group<Particle> T;
-            auto filter = getGroupFilter(T::Selectors::ACTIVE);
+            auto filter = getGroupFilter<T::Selectors::ACTIVE>();
             CHECK(filter(g) == true);
-            filter = getGroupFilter(T::Selectors::FULL);
+            filter = getGroupFilter<T::Selectors::FULL>();
             CHECK(filter(g) == true);
-            filter = getGroupFilter(T::Selectors::INACTIVE);
+            filter = getGroupFilter<T::Selectors::INACTIVE>();
             CHECK(filter(g) == false);
-            filter = getGroupFilter(T::Selectors::ACTIVE | T::Selectors::NEUTRAL);
+            filter = getGroupFilter<T::Selectors::ACTIVE | T::Selectors::NEUTRAL>();
             CHECK(filter(g) == true);
-            filter = getGroupFilter(T::Selectors::ACTIVE | T::Selectors::MOLECULAR);
+            filter = getGroupFilter<T::Selectors::ACTIVE | T::Selectors::MOLECULAR>();
             CHECK(filter(g) == true);
-            filter = getGroupFilter(T::Selectors::INACTIVE | T::Selectors::MOLECULAR);
+            filter = getGroupFilter<T::Selectors::INACTIVE | T::Selectors::MOLECULAR>();
             CHECK(filter(g) == false);
-            filter = getGroupFilter(T::Selectors::ACTIVE | T::Selectors::ATOMIC);
+            filter = getGroupFilter<T::Selectors::ACTIVE | T::Selectors::ATOMIC>();
             CHECK(filter(g) == false);
 
             g.begin()->charge = 0.1;
-            filter = getGroupFilter(T::Selectors::ACTIVE | T::Selectors::NEUTRAL);
+            filter = getGroupFilter<T::Selectors::ACTIVE | T::Selectors::NEUTRAL>();
             CHECK(filter(g) == false);
             g.begin()->charge = 0.0;
         }
@@ -185,16 +185,16 @@ TEST_CASE("[Faunus] Group") {
             CHECK(p1.front().id == 10);
 
             SUBCASE("getGroupFilter(): incomplete group") {
-                typedef Group<Particle> T;
-                auto filter = getGroupFilter(T::Selectors::FULL);
+                typedef Group<Particle> Tgroup;
+                auto filter = getGroupFilter<Tgroup::FULL>();
                 CHECK(filter(g1) == false);
-                filter = getGroupFilter(T::Selectors::INACTIVE);
+                filter = getGroupFilter<Tgroup::INACTIVE>();
                 CHECK(filter(g1) == false);
-                filter = getGroupFilter(T::Selectors::ACTIVE);
+                filter = getGroupFilter<Tgroup::ACTIVE>();
                 CHECK(filter(g1) == true);
-                filter = getGroupFilter(T::Selectors::ACTIVE | T::Selectors::ATOMIC);
+                filter = getGroupFilter<Tgroup::ACTIVE | Tgroup::ATOMIC>();
                 CHECK(filter(g1) == true);
-                filter = getGroupFilter(T::Selectors::ACTIVE | T::Selectors::MOLECULAR);
+                filter = getGroupFilter<Tgroup::ACTIVE | Tgroup::MOLECULAR>();
                 CHECK(filter(g1) == false);
             }
 

--- a/src/group_test.h
+++ b/src/group_test.h
@@ -82,6 +82,29 @@ TEST_CASE("[Faunus] Group") {
             CHECK( g.contains(p[3]) == false );
         }
 
+        SUBCASE("getGroupFilter(): complete group") {
+            typedef Group<Particle> T;
+            auto filter = getGroupFilter(T::Selectors::ACTIVE);
+            CHECK(filter(g) == true);
+            filter = getGroupFilter(T::Selectors::FULL);
+            CHECK(filter(g) == true);
+            filter = getGroupFilter(T::Selectors::INACTIVE);
+            CHECK(filter(g) == false);
+            filter = getGroupFilter(T::Selectors::ACTIVE | T::Selectors::NEUTRAL);
+            CHECK(filter(g) == true);
+            filter = getGroupFilter(T::Selectors::ACTIVE | T::Selectors::MOLECULAR);
+            CHECK(filter(g) == true);
+            filter = getGroupFilter(T::Selectors::INACTIVE | T::Selectors::MOLECULAR);
+            CHECK(filter(g) == false);
+            filter = getGroupFilter(T::Selectors::ACTIVE | T::Selectors::ATOMIC);
+            CHECK(filter(g) == false);
+
+            g.begin()->charge = 0.1;
+            filter = getGroupFilter(T::Selectors::ACTIVE | T::Selectors::NEUTRAL);
+            CHECK(filter(g) == false);
+            g.begin()->charge = 0.0;
+        }
+
         // find all elements with id=1
         auto slice1 = g.find_id(1);
         CHECK( std::distance(slice1.begin(), slice1.end()) == 2 );
@@ -160,6 +183,20 @@ TEST_CASE("[Faunus] Group") {
             CHECK(g1.size() == 4);
             CHECK(g1.capacity() == 5);
             CHECK(p1.front().id == 10);
+
+            SUBCASE("getGroupFilter(): incomplete group") {
+                typedef Group<Particle> T;
+                auto filter = getGroupFilter(T::Selectors::FULL);
+                CHECK(filter(g1) == false);
+                filter = getGroupFilter(T::Selectors::INACTIVE);
+                CHECK(filter(g1) == false);
+                filter = getGroupFilter(T::Selectors::ACTIVE);
+                CHECK(filter(g1) == true);
+                filter = getGroupFilter(T::Selectors::ACTIVE | T::Selectors::ATOMIC);
+                CHECK(filter(g1) == true);
+                filter = getGroupFilter(T::Selectors::ACTIVE | T::Selectors::MOLECULAR);
+                CHECK(filter(g1) == false);
+            }
 
             std::vector<Group<Particle>> gvec1, gvec2;
             gvec1.push_back(g1);

--- a/src/space.h
+++ b/src/space.h
@@ -207,6 +207,17 @@ struct Space {
         return n;
     } //!< Number of particles, all or active (default)
 
+    /**
+     * @brief Count number of molecules matching criteria
+     * @param molid Molecule id to match
+     * @tparam mask Selection mask based on `Group::Selectors`
+     * @return Number of molecules matching molid and mask
+     */
+    template <unsigned int mask> auto numMolecules(int molid) const {
+        auto filter = [&](const Tgroup &g) { return (g.id == molid) ? g.template match<mask>() : false; };
+        return std::count_if(groups.begin(), groups.end(), filter);
+    }
+
     void sync(Space &other, const Tchange &change); //!< Copy differing data from other (o) Space using Change object
 
     /*

--- a/src/space_test.h
+++ b/src/space_test.h
@@ -78,11 +78,18 @@ TEST_CASE("[Faunus] Space") {
         spc.push_back(0, pvec);
         spc.push_back(0, pvec);
 
+        spc.groups.at(0).id = 0;
+        spc.groups.at(1).id = 1;
+        spc.groups.at(2).id = 0;
+
         for (size_t i = 0; i < spc.p.size(); i++)
             spc.p[i].charge = double(i);
 
         CHECK(spc.p.size() == 9);
         CHECK(spc.groups.size() == 3);
+
+        CHECK(spc.numMolecules<Space::Tgroup::ANY>(0) == 2);
+        CHECK(spc.numMolecules<Space::Tgroup::ANY>(1) == 1);
 
         spc.groups[0].deactivate(spc.p.begin(), spc.p.begin() + 1);
         spc.groups[1].deactivate(spc.groups[1].begin(), spc.groups[1].end());
@@ -90,6 +97,12 @@ TEST_CASE("[Faunus] Space") {
         CHECK(spc.groups[0].size() == 2);
         CHECK(spc.groups[1].size() == 0);
         CHECK(spc.groups[2].size() == 3);
+
+        CHECK(spc.numMolecules<Space::Tgroup::ACTIVE>(0) == 2);
+        CHECK(spc.numMolecules<Space::Tgroup::ACTIVE | Space::Tgroup::NEUTRAL>(0) == 0);
+        CHECK(spc.numMolecules<Space::Tgroup::ACTIVE>(1) == 0);
+        CHECK(spc.numMolecules<Space::Tgroup::INACTIVE>(1) == 1);
+        CHECK(spc.numMolecules<Space::Tgroup::INACTIVE | Space::Tgroup::NEUTRAL>(1) == 0);
 
         auto p = getActiveParticles(spc);
         size_t size = 0;


### PR DESCRIPTION
This implements bitmask selectors for Group to more cleanly select molecules by combining keywords (inactive, active, neutral, atomic, molecular). This commit allows for e.g. future `Space::findMolecules()` to be significantly simplified as well as more efficient. The bitmask is evaluated at compile time and irrelevant conditionals are optimized out. Unittests have been added.