### PR TITLE
Add "molarity" keyword for insertmolecules

### DIFF
--- a/docs/_docs/topology.md
+++ b/docs/_docs/topology.md
@@ -178,13 +178,13 @@ making a union.
 Upon starting a simulation, an initial configuration is required and must be
 specified in the section `insertmolecules` as a list of valid molecule names.
 Molecules are inserted in the given order and may be `inactive`.
-If a group is marked `atomic`, its `atoms` is inserted `N` times.
+If a group is marked `atomic`, its `atoms` are inserted `N` times.
 
 Example:
 
 ~~~ yaml
 insertmolecules:
-  - salt:  { N: 10 }
+  - salt:  { molarity: 0.1 }
   - water: { N: 256 }
   - water: { N: 1, inactive: true }
 ~~~
@@ -194,6 +194,7 @@ The following keywords for each molecule type are available:
 `insertmolecules`    | Description
 -------------------- | ---------------------------------------
 `N`                  | Number of molecules to insert
+`molarity`           | Insert molecules to reach molarity
 `inactive=false`     | Deactivates inserted molecules
 `positions`          | Load positions from file (`aam`, `pqr`, `xyz`)
 `translate=[0,0,0]`  | Displace loaded `positions` with vector
@@ -205,6 +206,10 @@ the file are copied; all other information is ignored.
 
 For `implicit` molecules, only `N` should be given and the molecules are never
 inserted into the simulation box.
+
+The `molarity` keyword is an alternative to `N` and uses the initial
+volume to calculate the number of molecules to insert.
+
 
 ### Overlap Check
 

--- a/docs/_docs/topology.md
+++ b/docs/_docs/topology.md
@@ -208,7 +208,8 @@ For `implicit` molecules, only `N` should be given and the molecules are never
 inserted into the simulation box.
 
 The `molarity` keyword is an alternative to `N` and uses the initial
-volume to calculate the number of molecules to insert.
+volume to calculate the number of molecules to insert. `N` and
+`molarity` are mutually exclusive.
 
 
 ### Overlap Check

--- a/docs/schema.yml
+++ b/docs/schema.yml
@@ -68,9 +68,12 @@ properties:
                 additionalProperties: false
                 properties:
                     N: {type: integer, description: Number of molecules to insert}
+                    molarity: {type: number, description: Insert molecules to reach this molarity}
                     inactive: {type: boolean, default: false, description: Should molecules be inactive?}
                     positions: {type: string, description: Load positions from file}
-                required: [N]
+                oneOf:
+                    - required: [N]
+                    - required: [molarity]
 
     atomlist:
         type: array

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -359,9 +359,10 @@ bool InsertMoleculesInSpace::insertAtomicGroups(MoleculeData &moldata, Space &sp
     }
     return true;
 }
-void InsertMoleculesInSpace::insertMolecularGroups(MoleculeData &moldata, Space &spc, int N, bool inactive) {
+void InsertMoleculesInSpace::insertMolecularGroups(MoleculeData &moldata, Space &spc, int num_molecules,
+                                                   bool inactive) {
     assert(moldata.atomic == false);
-    while (N-- > 0) { // insert molecules
+    while (num_molecules-- > 0) { // insert molecules
         spc.push_back(moldata.id(), moldata.getRandomConformation(spc.geo, spc.p));
         if (inactive) {
             spc.groups.back().unwrap(spc.geo.getDistanceFunc());
@@ -369,10 +370,11 @@ void InsertMoleculesInSpace::insertMolecularGroups(MoleculeData &moldata, Space 
         }
     }
 }
-bool InsertMoleculesInSpace::setPositionsForTrailingGroups(int N, Space &spc, const Faunus::ParticleVector &positions,
+bool InsertMoleculesInSpace::setPositionsForTrailingGroups(Space &spc, int num_molecules,
+                                                           const Faunus::ParticleVector &positions,
                                                            const Point &offset) {
-    assert(spc.groups.size() >= N);
-    if (positions.size() == N * (spc.groups.end() - N)->traits().atoms.size()) {
+    assert(spc.groups.size() >= num_molecules);
+    if (positions.size() == num_molecules * (spc.groups.end() - num_molecules)->traits().atoms.size()) {
         size_t j = spc.p.size() - positions.size();
         for (auto i : positions) {
             i.pos = i.pos + offset;
@@ -384,7 +386,7 @@ bool InsertMoleculesInSpace::setPositionsForTrailingGroups(int N, Space &spc, co
             }
         }
         if (j == positions.size()) {
-            for (auto g = spc.groups.end() - N; g != spc.groups.end(); ++g) {
+            for (auto g = spc.groups.end() - num_molecules; g != spc.groups.end(); ++g) {
                 g->cm = Geometry::massCenter(g->begin(), g->end(), spc.geo.getBoundaryFunc(), -g->begin()->pos);
             }
         }
@@ -394,60 +396,60 @@ bool InsertMoleculesInSpace::setPositionsForTrailingGroups(int N, Space &spc, co
     }
     return true;
 }
-void InsertMoleculesInSpace::insertImplicitGroups(const MoleculeData &mol, Space &spc, int N) {
+void InsertMoleculesInSpace::insertImplicitGroups(const MoleculeData &mol, Space &spc, int num_molecules) {
     assert(mol.isImplicit());
-    spc.getImplicitReservoir()[mol.id()] = N;
+    spc.getImplicitReservoir()[mol.id()] = num_molecules;
 }
-void InsertMoleculesInSpace::insertMolecules(const json &j, Space &spc) {
+void InsertMoleculesInSpace::insertMolecules(const json &json_array, Space &spc) {
     spc.clear();
     assert(spc.geo.getVolume() > 0);
-    if (!j.is_array()) {
+    if (!json_array.is_array()) {
         throw std::runtime_error("syntax error in insertmolecule");
     }
-    for (auto &m : j) { // loop over array of molecules
-        if (!m.is_object() || m.size() != 1) {
+    for (auto &obj : json_array) { // loop over array of molecules
+        if (!obj.is_object() || obj.size() != 1) {
             throw std::runtime_error("syntax error in insertmolecule");
         }
-        for (auto &[molname, value] : m.items()) {
+        for (auto &[molname, properties] : obj.items()) {
             if (auto moldata = findName(Faunus::molecules, molname); moldata != Faunus::molecules.end()) {
-                int N = 0; // number of groups to insert
-                if (auto it = value.find("N"); it != value.end()) {
-                    N = it->get<int>();
+                int num_molecules = 0; // number of groups to insert
+                if (auto it = properties.find("N"); it != properties.end()) {
+                    num_molecules = it->get<int>();
                 } else {
-                    double concentration = value.at("molarity").get<double>() * 1.0_molar;
-                    N = std::round(concentration * spc.geo.getVolume());
+                    double concentration = properties.at("molarity").get<double>() * 1.0_molar;
+                    num_molecules = std::round(concentration * spc.geo.getVolume());
                     if (concentration > pc::epsilon_dbl) {
-                        double rel_error = (concentration - N / spc.geo.getVolume()) / concentration;
+                        double rel_error = (concentration - num_molecules / spc.geo.getVolume()) / concentration;
                         if (rel_error > 0.01) {
                             faunus_logger->warn("initial concentration of '{}' differs by {}% from input", molname,
                                                 rel_error * 100);
                         }
                     }
                 }
-                if (not moldata->isImplicit() and N < 1) {
+                if (not moldata->isImplicit() and num_molecules < 1) {
                     throw std::runtime_error("One or more molecules must be inserted");
                 }
-                bool inactive = value.value("inactive", false); // active or not?
+                bool inactive = properties.value("inactive", false); // active or not?
                 {
                     std::string state = (inactive) ? "inactive" : "active";
                     if (moldata->isImplicit()) {
                         state = "implicit";
                     }
-                    faunus_logger->info("inserting {0} ({1}) {2} molecules", N, state, molname);
+                    faunus_logger->info("inserting {0} ({1}) {2} molecules", num_molecules, state, molname);
                 }
                 if (moldata->atomic) {
-                    insertAtomicGroups(*moldata, spc, N);
+                    insertAtomicGroups(*moldata, spc, num_molecules);
                 } else if (moldata->isImplicit()) {
-                    insertImplicitGroups(*moldata, spc, N);
+                    insertImplicitGroups(*moldata, spc, num_molecules);
                 } else {
-                    insertMolecularGroups(*moldata, spc, N, inactive);
-                    if (auto filename = value.value("positions", ""s); !filename.empty()) {
+                    insertMolecularGroups(*moldata, spc, num_molecules, inactive);
+                    if (auto filename = properties.value("positions", ""s); !filename.empty()) {
                         bool error = true;
                         Space::Tpvec p;
                         if (loadStructure(filename, p, false)) {
                             faunus_logger->info("position file {0} found", filename);
-                            Point offset = value.value("translate", Point(0, 0, 0));
-                            error = setPositionsForTrailingGroups(N, spc, p, offset);
+                            Point offset = properties.value("translate", Point(0, 0, 0));
+                            error = setPositionsForTrailingGroups(spc, num_molecules, p, offset);
                         }
                         if (error) {
                             throw std::runtime_error("error loading positions from '" + filename + "'");

--- a/src/space.h
+++ b/src/space.h
@@ -267,27 +267,13 @@ void from_json(const json &j, Space &spc); //!< Deserialize json object to Space
  */
 class InsertMoleculesInSpace {
   private:
-    static bool insertAtomicGroups(MoleculeData &moldata, Space &spc, int N, bool inactive = false);
-    static void insertMolecularGroups(MoleculeData &moldata, Space &spc, int num_molecules, bool inactive);
-
-    /**
-     * @brief Set positions for N last groups in Space
-     * @param int N Number of groups set affect
-     * @param particles Position vector for all particles in the N groups
-     * @param offset Translate positions by this offset
-     */
-    static bool setPositionsForTrailingGroups(Space &spc, int num_molecules, const Faunus::ParticleVector &particles,
-                                              const Point &offset);
-
-    static void insertImplicitGroups(const MoleculeData &mol, Space &spc, int num_molecules);
+    static void insertAtomicGroups(MoleculeData &, Space &, int, bool = false);
+    static void insertMolecularGroups(MoleculeData &, Space &, int num_molecules, bool);
+    static void setPositionsForTrailingGroups(Space &, int, const Faunus::ParticleVector &, const Point &);
+    static void insertImplicitGroups(const MoleculeData &, Space &, int);
 
   public:
-    /**
-     * @brief Insert molecules into Space based on JSON input
-     * @param json_array JSON array
-     * @param spc Space to insert into
-     */
-    static void insertMolecules(const json &json_array, Space &spc);
+    static void insertMolecules(const json &, Space &);
 }; // end of insertMolecules class
 
 /**

--- a/src/space.h
+++ b/src/space.h
@@ -273,10 +273,10 @@ class InsertMoleculesInSpace {
     /**
      * @brief Set positions for N last groups in Space
      * @param int N Number of groups set affect
-     * @param positions Position vector for all particles in the N groups
+     * @param particles Position vector for all particles in the N groups
      * @param offset Translate positions by this offset
      */
-    static bool setPositionsForTrailingGroups(Space &spc, int num_molecules, const Faunus::ParticleVector &positions,
+    static bool setPositionsForTrailingGroups(Space &spc, int num_molecules, const Faunus::ParticleVector &particles,
                                               const Point &offset);
 
     static void insertImplicitGroups(const MoleculeData &mol, Space &spc, int num_molecules);

--- a/src/space.h
+++ b/src/space.h
@@ -260,7 +260,31 @@ void from_json(const json &j, Space &spc); //!< Deserialize json object to Space
  *     - water: { N: 1, inactive: true }
  * ~~~
  */
-void insertMolecules(const json &j, Space &spc); //!< Insert `N` molecules into space as defined in `insert`
+
+/**
+ * This takes a json array of objects where each item corresponds
+ * to a molecule. An `N` number of molecules is inserted according
+ * to user-defined rules
+ */
+class InsertMoleculesInSpace {
+  private:
+    static bool insertAtomicGroups(MoleculeData &moldata, Space &spc, int N, bool inactive = false);
+    static void insertMolecularGroups(MoleculeData &moldata, Space &spc, int N, bool inactive);
+
+    /**
+     * @brief Set positions for N last groups in Space
+     * @param int N Number of groups set affect
+     * @param positions Position vector for all particles in the N groups
+     * @param offset Translate positions by this offset
+     */
+    static bool setPositionsForTrailingGroups(int N, Space &spc, const Space::Tpvec &positions,
+                                              const Point &offset = {0, 0, 0});
+
+    static void insertImplicitGroups(const MoleculeData &mol, Space &spc, int N);
+
+  public:
+    static void insertMolecules(const json &j, Space &spc);
+}; // end of insertMolecules class
 
 /**
  * @brief Helper class for range-based for-loops over *active* particles

--- a/src/space.h
+++ b/src/space.h
@@ -262,14 +262,13 @@ void from_json(const json &j, Space &spc); //!< Deserialize json object to Space
  */
 
 /**
- * This takes a json array of objects where each item corresponds
- * to a molecule. An `N` number of molecules is inserted according
- * to user-defined rules
+ * This class helps inserting molecules into Space, based on user
+ * JSON input.
  */
 class InsertMoleculesInSpace {
   private:
     static bool insertAtomicGroups(MoleculeData &moldata, Space &spc, int N, bool inactive = false);
-    static void insertMolecularGroups(MoleculeData &moldata, Space &spc, int N, bool inactive);
+    static void insertMolecularGroups(MoleculeData &moldata, Space &spc, int num_molecules, bool inactive);
 
     /**
      * @brief Set positions for N last groups in Space
@@ -277,13 +276,18 @@ class InsertMoleculesInSpace {
      * @param positions Position vector for all particles in the N groups
      * @param offset Translate positions by this offset
      */
-    static bool setPositionsForTrailingGroups(int N, Space &spc, const Space::Tpvec &positions,
-                                              const Point &offset = {0, 0, 0});
+    static bool setPositionsForTrailingGroups(Space &spc, int num_molecules, const Faunus::ParticleVector &positions,
+                                              const Point &offset);
 
-    static void insertImplicitGroups(const MoleculeData &mol, Space &spc, int N);
+    static void insertImplicitGroups(const MoleculeData &mol, Space &spc, int num_molecules);
 
   public:
-    static void insertMolecules(const json &j, Space &spc);
+    /**
+     * @brief Insert molecules into Space based on JSON input
+     * @param json_array JSON array
+     * @param spc Space to insert into
+     */
+    static void insertMolecules(const json &json_array, Space &spc);
 }; // end of insertMolecules class
 
 /**


### PR DESCRIPTION
When inserting molecules, "molarity" can now be used as an alternative to "N". This commit also refactors the `Faunus::insertMolecules` into a separate class with where responsibilities are split among several (hidden) functions.