### PR TITLE
Fix Group::contains for inactive groups

### DIFF
--- a/src/group.cpp
+++ b/src/group.cpp
@@ -35,11 +35,12 @@ template <class T> Group<T> &Group<T>::shallowcopy(const Group<T> &o) {
 }
 
 template <class T> bool Group<T>::contains(const T &a, bool include_inactive) const {
-    if (not this->empty()) {
-        int size = (include_inactive ? this->capacity() : this->size());
+    int size = (include_inactive ? this->capacity() : this->size());
+    if (size > 0) {
         int d = &a - &(*(this->begin()));
-        if (d>=0 and d<size)
+        if (d >= 0 and d < size) {
             return true;
+        }
     }
     return false;
 }

--- a/src/group_test.h
+++ b/src/group_test.h
@@ -76,10 +76,16 @@ TEST_CASE("[Faunus] Group") {
         Group<Particle> g(p.begin(), p.end());
 
         SUBCASE("contains()") {
-            CHECK( g.contains(p[0]) );
-            CHECK( g.contains(p[1]) );
-            CHECK( g.contains(p[2]) );
-            CHECK( g.contains(p[3]) == false );
+            CHECK(g.contains(p[0]));
+            CHECK(g.contains(p[1]));
+            CHECK(g.contains(p[2]));
+            CHECK(g.size() == 3);
+            g.deactivate(g.end() - 1, g.end());
+            CHECK(g.size() == 2);
+            CHECK(g.contains(p[2]) == false);
+            CHECK(g.contains(p[2], true) == true);
+            g.activate(g.end(), g.end() + 1);
+            CHECK(g.size() == 3);
         }
 
         SUBCASE("getGroupFilter(): complete group") {

--- a/src/speciation.cpp
+++ b/src/speciation.cpp
@@ -47,6 +47,13 @@ bool SpeciationMove::atomicSwap(Change &change) {
                 return false;
             }
         }
+        if (!molecular_products.empty()) {          // ensure that we have inactive molecular products
+            assert(molecular_products.size() == 1); // only one allowed this far
+            auto mollist = spc.findMolecules(molecular_products.begin()->first, Tspace::INACTIVE);
+            if (ranges::cpp20::empty(mollist)) {
+                return false;
+            }
+        }
         auto random_particle = slump.sample(atomlist.begin(), atomlist.end()); // target particle to swap
         auto group = spc.findGroupContaining(*random_particle);                // find enclosing group
 

--- a/src/speciation.cpp
+++ b/src/speciation.cpp
@@ -40,6 +40,13 @@ bool SpeciationMove::atomicSwap(Change &change) {
         if (ranges::cpp20::empty(atomlist)) { // Make sure that there are any active atoms to swap
             return false;                     // Slip out the back door
         }
+        if (!molecular_reactants.empty()) {          // ensure that we have molecular reactants
+            assert(molecular_reactants.size() == 1); // only one allowed this far
+            auto mollist = spc.findMolecules(molecular_reactants.begin()->first);
+            if (ranges::cpp20::empty(mollist)) {
+                return false;
+            }
+        }
         auto random_particle = slump.sample(atomlist.begin(), atomlist.end()); // target particle to swap
         auto group = spc.findGroupContaining(*random_particle);                // find enclosing group
 


### PR DESCRIPTION
This is a bug fix for speciation moves using the `neutral` keyword in the reaction list.
- `Group::contains()` respects inactive groups
- Unittest of `contains()` covers in inactive groups
- Fix swap move logic involving atomic groups

Squash commit intended.