### PR TITLE
Draw from active molecular groups

### DIFF
--- a/docs/schema.yml
+++ b/docs/schema.yml
@@ -85,7 +85,7 @@ properties:
                 properties:
                     activity: {type: number, default: 0.0}
                     alphax: {type: number, default: 0.0}
-                    dp: {type: number, default: 0.0}
+                    dp: {type: number, default: 0.0, minimum: 0.0}
                     dprot: {type: number, default: 0.0, description: "Rotational displacement parameter"}
                     eps: {type: number, default: 0.0}
                     implicit: {type: boolean, default: false, description: "True if atom is implicit"}
@@ -625,8 +625,6 @@ properties:
                 transrot:
                     description: "Atomic translation and rotation"
                     properties:
-                        dp: {type: number}
-                        dprot: {type: number}
                         molecule: {type: string}
                         repeat: {type: [integer, string]}
                         dir:
@@ -635,11 +633,6 @@ properties:
                             minItems: 3
                             maxItems: 3
                             default: [1,1,1]
-                        dirrot:
-                            items: {type: number}
-                            type: array
-                            minItems: 3
-                            maxItems: 3
                     required: [molecule]
                     additionalProperties: false
                     type: object

--- a/src/move.h
+++ b/src/move.h
@@ -85,7 +85,7 @@ class AtomicTranslateRotate : public Movebase {
 
     void _to_json(json &j) const override;
     void _from_json(const json &j) override; //!< Configure via json object
-    std::vector<Particle>::iterator randomAtom();
+    ParticleVector::iterator randomAtom();
 
     /**
      * @brief translates a single particle.

--- a/src/move.h
+++ b/src/move.h
@@ -75,28 +75,28 @@ class AtomicSwapCharge : public Movebase {
  */
 class AtomicTranslateRotate : public Movebase {
   protected:
-    Space &spc; // Space to operate on
-    int molid = -1;
-    Point dir = {1, 1, 1};
-    Average<double> msqd; // mean squared displacement
-    double _sqd;          // squared displament
-    std::string molname;  // name of molecule to operate on
-    Change::data cdata;
+    Space &spc;            //!< Space to operate on
+    int molid = -1;        //!< Molecule id to move
+    Point dir = {1, 1, 1}; //!< displacement directions
+    Average<double> msqd;  //!< mean squared displacement
+    double _sqd;           //!< temporary squared displacement
+    std::string molname;   //!< name of molecule to operate on
+    Change::data cdata;    //!< Data for change object
 
-    void _to_json(json &j) const override;
-    void _from_json(const json &j) override; //!< Configure via json object
-    ParticleVector::iterator randomAtom();
+    void _to_json(json &) const override;
+    void _from_json(const json &) override; //!< Configure via json object
+    ParticleVector::iterator randomAtom();  //!< Select random particle to move
 
     /**
      * @brief translates a single particle.
      */
-    virtual void translateParticle(typename ParticleVector::iterator p, double dp);
-    void _move(Change &change) override;
+    virtual void translateParticle(typename ParticleVector::iterator, double);
+    void _move(Change &) override;
     void _accept(Change &) override;
     void _reject(Change &) override;
 
   public:
-    AtomicTranslateRotate(Space &spc);
+    AtomicTranslateRotate(Space &);
 };
 
 /**

--- a/src/move.h
+++ b/src/move.h
@@ -74,23 +74,21 @@ class AtomicSwapCharge : public Movebase {
  * @brief Translate and rotate a molecular group
  */
 class AtomicTranslateRotate : public Movebase {
+  private:
+    double _sqd; //!< temporary squared displacement
   protected:
-    Space &spc;            //!< Space to operate on
-    int molid = -1;        //!< Molecule id to move
-    Point dir = {1, 1, 1}; //!< displacement directions
-    Average<double> msqd;  //!< mean squared displacement
-    double _sqd;           //!< temporary squared displacement
-    std::string molname;   //!< name of molecule to operate on
-    Change::data cdata;    //!< Data for change object
+    Space &spc;                               //!< Space to operate on
+    int molid = -1;                           //!< Molecule id to move
+    Point directions = {1, 1, 1};             //!< displacement directions
+    Average<double> mean_square_displacement; //!< mean squared displacement
+    std::string molecule_name;                //!< name of molecule to operate on
+    Change::data cdata;                       //!< Data for change object
 
     void _to_json(json &) const override;
     void _from_json(const json &) override; //!< Configure via json object
     ParticleVector::iterator randomAtom();  //!< Select random particle to move
 
-    /**
-     * @brief translates a single particle.
-     */
-    virtual void translateParticle(typename ParticleVector::iterator, double);
+    virtual void translateParticle(ParticleVector::iterator, double); //!< translate single particle
     void _move(Change &) override;
     void _accept(Change &) override;
     void _reject(Change &) override;


### PR DESCRIPTION
For molecular groups draw only from active ones while for atomic groups, select ALL. This fixes a potential problem for grand canonical, molecular groups subject to internal changes using `AtomicTranslateRotate` is used. In the old code, the random molecule would be drawn from a distribution that contained also inactive molecules while it should include only active ones.
