### PR TITLE
Make PQR output respect inactive particles

### DIFF
--- a/docs/_docs/analysis.md
+++ b/docs/_docs/analysis.md
@@ -335,7 +335,7 @@ $$
 
 
 During simulation, the above terms are thermally averaged over angles, co-solute degrees of freedom etc.
-Note also that the moments are defined with respect to the *mass* center, not *charge* center.
+Note also that the moments are defined with respect to the _mass_ center, not _charge_ center.
 While for globular macromolecules the difference between the two is often small,
 the latter is more appropriate and is planned for a future update.
 
@@ -517,7 +517,9 @@ keyword when inserting the initial molecules in the [topology](topology).
 `saverandom=false` |  Save the state of the random number generator
 `nstep=-1`         |  Interval between samples. If -1, save at end of simulation
 
-Saves the current configuration or the system state to file.
+Saves the current configuration or the system state to file. For grand canonical
+simulations, the PQR file format sets charges and radii of inactive particles to zero
+and positions them in one corner of the box.
 
 If the suffix is `json` (text) or `ubj` ([binary](http://ubjson.org)), a single 
 state file that can be used to restart the simulation is saved

--- a/src/analysis.cpp
+++ b/src/analysis.cpp
@@ -169,8 +169,8 @@ SaveState::SaveState(const json &j, Space &spc) {
         writeFunc = std::bind([](std::string file, Space &s) { FormatGRO::save(file, s); }, _1, std::ref(spc));
 
     else if (suffix == "pqr")
-        writeFunc = std::bind([](std::string file, Space &s) { FormatPQR::save(file, s.p, s.geo.getLength()); }, _1,
-                              std::ref(spc));
+        writeFunc = std::bind([](std::string file, Space &s) { FormatPQR::save(file, s.groups, s.geo.getLength()); },
+                              _1, std::ref(spc));
 
     else if (suffix == "xyz")
         writeFunc = std::bind([](std::string file, Space &s) { FormatXYZ::save(file, s.p, s.geo.getLength()); }, _1,

--- a/src/io.h
+++ b/src/io.h
@@ -9,6 +9,8 @@
 
 namespace Faunus {
 
+template <typename T = Particle> class Group;
+
 #ifndef __cplusplus
 #define __cplusplus
 #endif
@@ -103,11 +105,15 @@ class FormatPQR {
     static bool readAtomRecord(const std::string &, Particle &, double &);       //!< Read ATOM or HETATOM record
 
   public:
+    typedef std::vector<Group<Particle>> Tgroup_vector;
     static Point load(std::istream &, ParticleVector &, bool);                      //!< Load PQR from stream
     static Point load(const std::string &, ParticleVector &, bool);                 //!< Load PQR from file
     static void loadTrajectory(const std::string &, std::vector<ParticleVector> &); //!< Load trajectory
     static bool save(std::ostream &, const ParticleVector &, Point = Point(0, 0, 0), int = 1e9);      //!< Save PQR file
     static bool save(const std::string &, const ParticleVector &, Point = Point(0, 0, 0), int = 1e9); //!< Save PQR file
+
+    static bool save(std::ostream &, const Tgroup_vector &, Point = Point(0, 0, 0));      //!< Save PQR file
+    static bool save(const std::string &, const Tgroup_vector &, Point = Point(0, 0, 0)); //!< Save PQR file
 };
 
 /**


### PR DESCRIPTION
PQR files now set zero charge and radius
to inactive particles. Also, the molecule
index is used to increment the residue id.