### PR TITLE
Enable gzip compression for reactionfile analysis

### DIFF
--- a/docs/_docs/analysis.md
+++ b/docs/_docs/analysis.md
@@ -367,15 +367,16 @@ atomic species can be saved.
 ## Reaction Coordinate
 
 This saves a given reaction coordinate (see Penalty Function in Energy) as a function of steps.
-The output file has three columns with steps; the value of the reaction coordinate; and
-the cummulative average of all preceding values.
+The output `file` has three columns with steps; the value of the reaction coordinate; and
+the cummulative average of all preceding values. Optional GZip compression can be activated by
+ending the filename with `.gz`.
 
 The folowing example prints the mass center $z$ coordinate of the first molecule
 to disk every 100th steps:
 
 ~~~ yaml
 - reactioncoordinate:
-    {nstep: 100, file: cmz.dat, type: molecule, index: 0, property: com_z}
+    {nstep: 100, file: cmz.dat.gz, type: molecule, index: 0, property: com_z}
 ~~~ 
 
 In the next example, the Angle between the principal molecular axis and the $xy$-plane
@@ -383,7 +384,7 @@ is reported by diagonalising the gyration tensor to find the principal moments:
 
 ~~~ yaml
 - reactioncoordinate:
-    {nstep: 100, file: angle.dat, type: molecule, index: 0, property: angle, dir: [0,0,1]}
+    {nstep: 100, file: angle.dat.gz, type: molecule, index: 0, property: angle, dir: [0,0,1]}
 ~~~ 
 
 ### Processing
@@ -402,7 +403,7 @@ def joinRC(xfile, yfile, bins):
     means, edges, bins = binned_statistic(x,y,'mean',bins)
     return (edges[:-1] + edges[1:]) / 2, means
 
-cmz, angle = joinRC('cmz.dat', 'angle.dat', 100)
+cmz, angle = joinRC('cmz.dat.gz', 'angle.dat.gz', 100)
 np.diff(cmz) # --> cmz resolution; control w. `bins`
 ~~~
 

--- a/docs/_docs/analysis.md
+++ b/docs/_docs/analysis.md
@@ -366,13 +366,16 @@ atomic species can be saved.
 
 ## Reaction Coordinate
 
-This saves a given reaction coordinate (see Penalty Function in Energy) as a function of steps.
-The output `file` has three columns: steps; the value of the reaction coordinate; and
-the cummulative average of all preceding values. Optional [gzip compression](https://en.wikipedia.org/wiki/Gzip)
-can be enabled by suffixing the filename with `.gz`, thereby reducing the output file size significantly.
+This saves a given [reaction coordinate](energy.html#reaction-coordinates)
+as a function of steps. The generated output `file` has three columns:
 
-The folowing example prints the mass center $z$ coordinate of the first molecule
-to disk every 100th steps:
+1. step number
+2. the value of the reaction coordinate
+3. the cummulative average of all preceding values.
+
+Optional [gzip compression](https://en.wikipedia.org/wiki/Gzip)
+can be enabled by suffixing the filename with `.gz`, thereby reducing the output file size significantly.
+The folowing example reports the mass center $z$ coordinate of the first molecule every 100th steps:
 
 ~~~ yaml
 - reactioncoordinate:
@@ -389,7 +392,7 @@ is reported by diagonalising the gyration tensor to find the principal moments:
 
 ### Processing
 
-In the above examples we saved two properties as a function of steps. To join the two
+In the above examples we stored two properties as a function of steps. To join the two
 files and calculate the _average angle_ as a function of the mass center coordinate, _z_,
 the following python code may be used:
 

--- a/docs/_docs/analysis.md
+++ b/docs/_docs/analysis.md
@@ -367,9 +367,9 @@ atomic species can be saved.
 ## Reaction Coordinate
 
 This saves a given reaction coordinate (see Penalty Function in Energy) as a function of steps.
-The output `file` has three columns with steps; the value of the reaction coordinate; and
-the cummulative average of all preceding values. Optional GZip compression can be activated by
-ending the filename with `.gz`.
+The output `file` has three columns: steps; the value of the reaction coordinate; and
+the cummulative average of all preceding values. Optional [gzip compression](https://en.wikipedia.org/wiki/Gzip)
+can be enabled by suffixing the filename with `.gz`, thereby reducing the output file size significantly.
 
 The folowing example prints the mass center $z$ coordinate of the first molecule
 to disk every 100th steps:
@@ -379,7 +379,7 @@ to disk every 100th steps:
     {nstep: 100, file: cmz.dat.gz, type: molecule, index: 0, property: com_z}
 ~~~ 
 
-In the next example, the Angle between the principal molecular axis and the $xy$-plane
+In the next example, the angle between the principal molecular axis and the $xy$-plane
 is reported by diagonalising the gyration tensor to find the principal moments:
 
 ~~~ yaml
@@ -389,23 +389,27 @@ is reported by diagonalising the gyration tensor to find the principal moments:
 
 ### Processing
 
-In the example above we saved two properties as a function of steps. To join the two
-files and generate the average angle as a function of _z_, the following python code
-may be used:
+In the above examples we saved two properties as a function of steps. To join the two
+files and calculate the _average angle_ as a function of the mass center coordinate, _z_,
+the following python code may be used:
 
 ~~~ python
 import numpy as np
 from scipy.stats import binned_statistic
 
-def joinRC(xfile, yfile, bins):
-    x = np.loadtxt(xfile, usecols=[1])
-    y = np.loadtxt(yfile, usecols=[1])
-    means, edges, bins = binned_statistic(x,y,'mean',bins)
+def joinRC(filename1, filename2, bins):
+    x = np.loadtxt(filename1, usecols=[1])
+    y = np.loadtxt(filename2, usecols=[1])
+    means, edges, bins = binned_statistic(x, y, 'mean', bins)
     return (edges[:-1] + edges[1:]) / 2, means
 
 cmz, angle = joinRC('cmz.dat.gz', 'angle.dat.gz', 100)
 np.diff(cmz) # --> cmz resolution; control w. `bins`
 ~~~
+
+Note that Numpy automatically detects and decompresses `.gz` files.
+Further, the command line tools `zcat`, `zless` etc. are useful for handling
+compressed files.
 
 
 ## System Sanity

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,7 +15,7 @@
 # sys.path.insert(0, os.path.abspath('.'))
 
 project = 'Faunus'
-copyright = '2019, Mikael Lund'
+copyright = '2020, Mikael Lund'
 author = 'Mikael Lund'
 source_suffix = ['.rst', '.md']
 master_doc = 'index'

--- a/src/analysis.h
+++ b/src/analysis.h
@@ -64,7 +64,7 @@ class FileReactionCoordinate : public Analysisbase {
   private:
     Average<double> avg;
     std::string type, filename;
-    std::ofstream file;
+    std::unique_ptr<std::ostream> stream = nullptr;
     std::shared_ptr<ReactionCoordinate::ReactionCoordinateBase> rc = nullptr;
 
     void _to_json(json &j) const override;
@@ -72,7 +72,7 @@ class FileReactionCoordinate : public Analysisbase {
     void _to_disk() override;
 
   public:
-    FileReactionCoordinate(const json &j, Space &spc);
+    FileReactionCoordinate(const json &, Space &);
 };
 
 /**


### PR DESCRIPTION
If `.gz` filename extension is specified, gzip data compression is used on the output file for `reactioncoordinate` analysis. Gzipped files can be read by `numpy.readtxt()` which is now illustrated in the manual.
