### PR TITLE
Forces for bonded interactions for use with Langevin dynamics

### DIFF
--- a/src/bonds.cpp
+++ b/src/bonds.cpp
@@ -96,7 +96,7 @@ BondData::Variant HarmonicBond::type() const { return BondData::HARMONIC; }
 /**
  * @param particle Particle vector to all particles in the system
  *
- * This sets both the `energy` and `force` function objects
+ * This sets both the `energyFunc` and `forceFunc` function objects
  * for calculating the potential energy and the forces on the
  * participating atoms
  */

--- a/src/bonds.h
+++ b/src/bonds.h
@@ -18,11 +18,15 @@ namespace Potential {
  *
  * This stores data on the bond type; atom indices; json keywords;
  * and potentially also the energy function (nullptr per default).
+ *
+ * The `force` functor returns a vector of forces acting on the
+ * participating atoms
  */
 struct BondData {
     enum Variant { HARMONIC = 0, FENE, FENEWCA, HARMONIC_TORSION, GROMOS_TORSION, PERIODIC_DIHEDRAL, NONE };
     std::vector<int> index;
-    std::function<double(Geometry::DistanceFunction)> energy = nullptr; //!< potential energy (kT)
+    std::function<double(Geometry::DistanceFunction)> energy = nullptr;            //!< potential energy (kT)
+    std::function<std::vector<Point>(Geometry::DistanceFunction)> force = nullptr; //!< forces (kT/Å)
 
     virtual void from_json(const json &) = 0;
     virtual void to_json(json &) const = 0;
@@ -38,15 +42,15 @@ struct BondData {
 };
 
 struct StretchData : public BondData {
-    int numindex() const override { return 2; }
+    int numindex() const override;
     StretchData() = default;
-    StretchData(const std::vector<int> &index) : BondData(index) {};
+    StretchData(const std::vector<int> &index);
 };
 
 struct TorsionData : public BondData {
-    int numindex() const override { return 3; }
+    int numindex() const override;
     TorsionData() = default;
-    TorsionData(const std::vector<int> &index) : BondData(index) {};
+    TorsionData(const std::vector<int> &index);
 };
 
 /**
@@ -61,7 +65,7 @@ struct HarmonicBond : public StretchData {
     void from_json(const json &j) override;
     void to_json(json &j) const override;
     std::string name() const override;
-    void setEnergyFunction(const ParticleVector &p);
+    void setEnergyFunction(const ParticleVector &); //!< Set energy and force functors
     HarmonicBond() = default;
     HarmonicBond(double k, double req, const std::vector<int> &index);
 };

--- a/src/bonds.h
+++ b/src/bonds.h
@@ -24,9 +24,11 @@ namespace Potential {
  */
 struct BondData {
     enum Variant { HARMONIC = 0, FENE, FENEWCA, HARMONIC_TORSION, GROMOS_TORSION, PERIODIC_DIHEDRAL, NONE };
-    std::vector<int> index;
-    std::function<double(Geometry::DistanceFunction)> energyFunc = nullptr;            //!< potential energy (kT)
-    std::function<std::vector<Point>(Geometry::DistanceFunction)> forceFunc = nullptr; //!< forces (kT/Å)
+    std::vector<int> index; //!< Index of participating atoms
+    std::function<double(Geometry::DistanceFunction)> energyFunc =
+        nullptr; //!< calculate potential energy of bonded atoms(kT)
+    std::function<std::vector<Point>(Geometry::DistanceFunction)> forceFunc =
+        nullptr; //!< calculate forces on bonded atoms (kT/Å)
 
     virtual void from_json(const json &) = 0;
     virtual void to_json(json &) const = 0;

--- a/src/bonds.h
+++ b/src/bonds.h
@@ -35,7 +35,7 @@ struct BondData {
     virtual std::string name() const = 0;                //!< Name/key of bond type used in for json I/O
     virtual std::shared_ptr<BondData> clone() const = 0; //!< Make shared pointer *copy* of data
     bool hasEnergyFunction() const;                      //!< test if energy function has been set
-    void shift(int offset);                              //!< Shift indices
+    void shift(int offset);                              //!< Add offset to index
     BondData() = default;
     BondData(const std::vector<int> &index);
     virtual ~BondData() = default;

--- a/src/bonds.h
+++ b/src/bonds.h
@@ -17,16 +17,16 @@ namespace Potential {
  * @brief Base class for bonded potentials
  *
  * This stores data on the bond type; atom indices; json keywords;
- * and potentially also the energy function (nullptr per default).
+ * and potentially also the `energyFunc` functor (nullptr per default).
  *
- * The `force` functor returns a vector of forces acting on the
+ * The `forceFunc` functor returns a vector of forces acting on the
  * participating atoms
  */
 struct BondData {
     enum Variant { HARMONIC = 0, FENE, FENEWCA, HARMONIC_TORSION, GROMOS_TORSION, PERIODIC_DIHEDRAL, NONE };
     std::vector<int> index;
-    std::function<double(Geometry::DistanceFunction)> energy = nullptr;            //!< potential energy (kT)
-    std::function<std::vector<Point>(Geometry::DistanceFunction)> force = nullptr; //!< forces (kT/Å)
+    std::function<double(Geometry::DistanceFunction)> energyFunc = nullptr;            //!< potential energy (kT)
+    std::function<std::vector<Point>(Geometry::DistanceFunction)> forceFunc = nullptr; //!< forces (kT/Å)
 
     virtual void from_json(const json &) = 0;
     virtual void to_json(json &) const = 0;

--- a/src/bonds_test.h
+++ b/src/bonds_test.h
@@ -28,16 +28,26 @@ TEST_CASE("[Faunus] BondData") {
         SUBCASE("HarmonicBond Energy") {
             HarmonicBond bond(100.0, 5.0, {0, 1});
             bond.setEnergyFunction(p_4a);
-            CHECK_EQ(bond.energy(distance_5a), Approx(0));
-            CHECK_EQ(bond.energy(distance_3a), Approx(200));
-            CHECK_EQ(bond.energy(distance), Approx(50));
+            CHECK_EQ(bond.energyFunc(distance_5a), Approx(0));
+            CHECK_EQ(bond.energyFunc(distance_3a), Approx(200));
+            CHECK_EQ(bond.energyFunc(distance), Approx(50));
+        }
+        SUBCASE("HarmonicBond Force") {
+            HarmonicBond bond(100.0, 4, {0, 1});
+            bond.setEnergyFunction(p_4a);
+            auto forces = bond.forceFunc(distance_3a);
+            CHECK(forces.size() == 2);
+            CHECK(forces[0].x() == Approx(0));
+            CHECK(forces[0].y() == Approx(100));
+            CHECK(forces[0].y() == Approx(-forces[1].y()));
+            CHECK(forces[0].z() == Approx(0));
         }
         SUBCASE("HarmonicBond JSON") {
             json j = R"({"harmonic": {"index":[1,2], "k":10.0, "req":2.0}})"_json;
             bond_ptr = j;
             CHECK_EQ(json(bond_ptr), j);
             std::dynamic_pointer_cast<HarmonicBond>(bond_ptr)->setEnergyFunction(p_60deg_4a);
-            CHECK_EQ(bond_ptr->energy(distance), Approx(10.0_kJmol / 2 * 4));
+            CHECK_EQ(bond_ptr->energyFunc(distance), Approx(10.0_kJmol / 2 * 4));
         }
         SUBCASE("HarmonicBond JSON Invalid") {
             CHECK_NOTHROW((R"({"harmonic": {"index":[0,9], "k":0.5, "req":2.1}})"_json).get<BondDataPtr>());
@@ -52,16 +62,16 @@ TEST_CASE("[Faunus] BondData") {
         SUBCASE("FENEBond Energy") {
             FENEBond bond(100.0, 5.0, {0, 1});
             bond.setEnergyFunction(p_4a);
-            CHECK_EQ(bond.energy(distance_5a), pc::infty);
-            CHECK_EQ(bond.energy(distance_3a), Approx(557.86));
-            CHECK_EQ(bond.energy(distance), Approx(1277.06));
+            CHECK_EQ(bond.energyFunc(distance_5a), pc::infty);
+            CHECK_EQ(bond.energyFunc(distance_3a), Approx(557.86));
+            CHECK_EQ(bond.energyFunc(distance), Approx(1277.06));
         }
         SUBCASE("FENEBond JSON") {
             json j = R"({"fene": {"index":[1,2], "k":8, "rmax":6.0 }})"_json;
             bond_ptr = j;
             CHECK_EQ(json(bond_ptr), j);
             std::dynamic_pointer_cast<FENEBond>(bond_ptr)->setEnergyFunction(p_60deg_4a);
-            CHECK_EQ(bond_ptr->energy(distance), Approx(84.641_kJmol));
+            CHECK_EQ(bond_ptr->energyFunc(distance), Approx(84.641_kJmol));
         }
         SUBCASE("FENEBond JSON Invalid") {
             CHECK_NOTHROW((R"({"fene": {"index":[0,9], "k":0.5, "rmax":2.1}})"_json).get<BondDataPtr>());
@@ -76,16 +86,16 @@ TEST_CASE("[Faunus] BondData") {
         SUBCASE("FENEWCABond Energy") {
             FENEWCABond bond(100.0, 5.0, 20.0, 3.2, {0, 1});
             bond.setEnergyFunction(p_4a);
-            CHECK_EQ(bond.energy(distance_5a), pc::infty);
-            CHECK_EQ(bond.energy(distance_3a), Approx(557.86 + 18.931));
-            CHECK_EQ(bond.energy(distance), Approx(1277.06));
+            CHECK_EQ(bond.energyFunc(distance_5a), pc::infty);
+            CHECK_EQ(bond.energyFunc(distance_3a), Approx(557.86 + 18.931));
+            CHECK_EQ(bond.energyFunc(distance), Approx(1277.06));
         }
         SUBCASE("FENEWCABond JSON") {
             json j = R"({"fene+wca": {"index":[1,2], "k":8, "rmax":6.0, "eps":3.5, "sigma":4.5}})"_json;
             bond_ptr = j;
             CHECK_EQ(json(bond_ptr), j);
             std::dynamic_pointer_cast<FENEWCABond>(bond_ptr)->setEnergyFunction(p_60deg_4a);
-            CHECK_EQ(bond_ptr->energy(distance), Approx(92.805_kJmol));
+            CHECK_EQ(bond_ptr->energyFunc(distance), Approx(92.805_kJmol));
         }
         SUBCASE("FENEWCABond JSON Invalid") {
             CHECK_NOTHROW((R"({"fene+wca": {"index":[0,9], "k":1, "rmax":2.1, "eps":2.48, "sigma":2}})"_json).get<BondDataPtr>());
@@ -101,14 +111,14 @@ TEST_CASE("[Faunus] BondData") {
         SUBCASE("HarmonicTorsion Energy") {
             HarmonicTorsion bond(100.0, 45.0_deg, {0, 1, 2});
             bond.setEnergyFunction(p_60deg_4a);
-            CHECK_EQ(bond.energy(distance), Approx(100.0 / 2 * std::pow(15.0_deg, 2)));
+            CHECK_EQ(bond.energyFunc(distance), Approx(100.0 / 2 * std::pow(15.0_deg, 2)));
         }
         SUBCASE("HarmonicTorsion JSON") {
             json j = R"({"harmonic_torsion": {"index":[0,1,2], "k":0.5, "aeq":65}})"_json;
             bond_ptr = j;
             CHECK_EQ(json(bond_ptr), j);
             std::dynamic_pointer_cast<HarmonicTorsion>(bond_ptr)->setEnergyFunction(p_60deg_4a);
-            CHECK_EQ(bond_ptr->energy(distance), Approx(0.5_kJmol / 2 * std::pow(5.0_deg, 2)));
+            CHECK_EQ(bond_ptr->energyFunc(distance), Approx(0.5_kJmol / 2 * std::pow(5.0_deg, 2)));
         }
         SUBCASE("HarmonicTorsion JSON Invalid") {
             CHECK_NOTHROW((R"({"harmonic_torsion": {"index":[0,1,9], "k":0.5, "aeq":30.5}})"_json).get<BondDataPtr>());
@@ -122,14 +132,15 @@ TEST_CASE("[Faunus] BondData") {
         SUBCASE("GromosTorsion Energy") {
             GromosTorsion bond(100.0, cos(45.0_deg), {0, 1, 2});
             bond.setEnergyFunction(p_60deg_4a);
-            CHECK_EQ(bond.energy(distance), Approx(100.0 / 2 * std::pow(cos(60.0_deg) - cos(45.0_deg), 2)));
+            CHECK_EQ(bond.energyFunc(distance), Approx(100.0 / 2 * std::pow(cos(60.0_deg) - cos(45.0_deg), 2)));
         }
         SUBCASE("GromosTorsion JSON") {
             json j = R"({"gromos_torsion": {"index":[0,1,2], "k":0.5, "aeq":65}})"_json;
             bond_ptr = j;
             CHECK_EQ(json(bond_ptr), j);
             std::dynamic_pointer_cast<GromosTorsion>(bond_ptr)->setEnergyFunction(p_60deg_4a);
-            CHECK_EQ(bond_ptr->energy(distance), Approx(0.5_kJmol / 2 * std::pow(cos(60.0_deg) - cos(65.0_deg), 2)));
+            CHECK_EQ(bond_ptr->energyFunc(distance),
+                     Approx(0.5_kJmol / 2 * std::pow(cos(60.0_deg) - cos(65.0_deg), 2)));
         }
         SUBCASE("GromosTorsion JSON Invalid") {
             CHECK_NOTHROW((R"({"gromos_torsion": {"index":[0,1,9], "k":0.5, "aeq":30.5}})"_json).get<BondDataPtr>());
@@ -156,18 +167,18 @@ TEST_CASE("[Faunus] BondData") {
         SUBCASE("PeriodicDihedral Energy") {
             PeriodicDihedral bond(100.0, 0.0_deg, 3, {0, 1, 2, 3});
             bond.setEnergyFunction(p_120deg);
-            CHECK_EQ(bond.energy(distance), Approx(200.0));
+            CHECK_EQ(bond.energyFunc(distance), Approx(200.0));
             bond.setEnergyFunction(p_60deg);
-            CHECK_EQ(bond.energy(distance), Approx(0.0));
+            CHECK_EQ(bond.energyFunc(distance), Approx(0.0));
             bond.setEnergyFunction(p_90deg);
-            CHECK_EQ(bond.energy(distance), Approx(100.0));
+            CHECK_EQ(bond.energyFunc(distance), Approx(100.0));
         }
         SUBCASE("PeriodicDihedral JSON") {
             json j = R"({"periodic_dihedral": {"index":[0,1,2,3], "k":10, "phi":0.0, "n": 3}})"_json;
             bond_ptr = j;
             CHECK_EQ(json(bond_ptr), j);
             std::dynamic_pointer_cast<PeriodicDihedral>(bond_ptr)->setEnergyFunction(p_90deg);
-            CHECK_EQ(bond_ptr->energy(distance), Approx(10.0_kJmol));
+            CHECK_EQ(bond_ptr->energyFunc(distance), Approx(10.0_kJmol));
         }
         SUBCASE("PeriodicDihedral JSON Invalid") {
             CHECK_NOTHROW((R"({"periodic_dihedral": {"index":[0,1,2,9], "k":0.5, "phi":2.1, "n": 2}})"_json).get<BondDataPtr>());

--- a/src/energy.cpp
+++ b/src/energy.cpp
@@ -610,10 +610,11 @@ void Bonded::force(std::vector<Point> &forces) {
             assert(bond->forceFunc != nullptr);                    // the force function must be implemented
             auto bond_forces = bond->forceFunc(distance_function); // get forces on each atom in bond
             assert(bond->index.size() == bond_forces.size());
+            int j = 0;
             for (int index : bond->index) { // loop over atom index in bond (relative to group begin)
                 auto absolute_index = std::distance(spc.p.begin(), group.begin()) + index;
                 assert(absolute_index < forces.size());
-                forces[absolute_index] += bond_forces[index]; // add to overall force
+                forces[absolute_index] += bond_forces[j++]; // add to overall force
             }
         }
     }

--- a/src/energy.cpp
+++ b/src/energy.cpp
@@ -599,13 +599,15 @@ double Bonded::energy(Change &change) {
  * - loop over inter-molecular bonds and _add_ force
  *
  * Force unit: kT/Å
+ *
+ * @warning Untested
  */
 void Bonded::force(std::vector<Point> &forces) {
     auto distance_function = spc.geo.getDistanceFunc();
-    for (auto [molid, bonds] : intra) {                        // loop over all intra-molecular bonds
-        auto &group = spc.groups[molid];                       // this is the group we're currently working on
-        for (auto bond : bonds) {                              // loop over all bonds in group
-            assert(bond->forceFunc != nullptr);                // the force function must be implemented
+    for (auto [group_index, bonds] : intra) {                      // loop over all intra-molecular bonds
+        auto &group = spc.groups[group_index];                     // this is the group we're currently working on
+        for (auto bond : bonds) {                                  // loop over all bonds in group
+            assert(bond->forceFunc != nullptr);                    // the force function must be implemented
             auto bond_forces = bond->forceFunc(distance_function); // get forces on each atom in bond
             assert(bond->index.size() == bond_forces.size());
             for (int index : bond->index) { // loop over atom index in bond (relative to group begin)

--- a/src/energy.cpp
+++ b/src/energy.cpp
@@ -610,22 +610,20 @@ void Bonded::force(std::vector<Point> &forces) {
             assert(bond->forceFunc != nullptr);                    // the force function must be implemented
             auto bond_forces = bond->forceFunc(distance_function); // get forces on each atom in bond
             assert(bond->index.size() == bond_forces.size());
-            int j = 0;
-            for (int index : bond->index) { // loop over atom index in bond (relative to group begin)
-                auto absolute_index = std::distance(spc.p.begin(), group.begin()) + index;
+            for (int i = 0; i < bond->index.size(); i++) { // loop over atom index in bond (relative to group begin)
+                auto absolute_index = std::distance(spc.p.begin(), group.begin()) + bond->index[i];
                 assert(absolute_index < forces.size());
-                forces[absolute_index] += bond_forces[j++]; // add to overall force
+                forces[absolute_index] += bond_forces[i]; // add to overall force
             }
         }
     }
 
-    for (auto bond : inter) {                              // loop over inter-molecular bonds
-        assert(bond->forceFunc != nullptr);                // the force function must be implemented
+    for (auto bond : inter) {                                  // loop over inter-molecular bonds
+        assert(bond->forceFunc != nullptr);                    // the force function must be implemented
         auto bond_forces = bond->forceFunc(distance_function); // get forces on each atom in bond
         assert(bond_forces.size() == bond->index.size());
-        int j = 0;
-        for (int absolute_index : bond->index) {        // loop over atom index in bond (absolute index)
-            forces[absolute_index] += bond_forces[j++]; // add to overall force
+        for (int i = 0; i < bond->index.size(); i++) { // loop over atom index in bond (absolute index)
+            forces[bond->index[i]] += bond_forces[i];  // add to overall force
         }
     }
 }

--- a/src/energy.cpp
+++ b/src/energy.cpp
@@ -517,7 +517,7 @@ double Bonded::sum_energy(const Bonded::BondVector &bonds) const {
     double energy = 0;
     for (auto &bond : bonds) {
         assert(bond->hasEnergyFunction());
-        energy += bond->energy(spc.geo.getDistanceFunc());
+        energy += bond->energyFunc(spc.geo.getDistanceFunc());
     }
     return energy;
 }
@@ -528,7 +528,7 @@ double Bonded::sum_energy(const Bonded::BondVector &bonds, const std::vector<int
         for (auto particle_ndx : particles_ndx) {
             if (std::find(bond->index.begin(), bond->index.end(), particle_ndx) != bond->index.end()) {
                 assert(bond->hasEnergyFunction());
-                energy += bond->energy(spc.geo.getDistanceFunc());
+                energy += bond->energyFunc(spc.geo.getDistanceFunc());
                 break; // count each interaction at most once
             }
         }
@@ -605,8 +605,8 @@ void Bonded::force(std::vector<Point> &forces) {
     for (auto [molid, bonds] : intra) {                        // loop over all intra-molecular bonds
         auto &group = spc.groups[molid];                       // this is the group we're currently working on
         for (auto bond : bonds) {                              // loop over all bonds in group
-            assert(bond->force != nullptr);                    // the force function must be implemented
-            auto bond_forces = bond->force(distance_function); // get forces on each atom in bond
+            assert(bond->forceFunc != nullptr);                // the force function must be implemented
+            auto bond_forces = bond->forceFunc(distance_function); // get forces on each atom in bond
             assert(bond->index.size() == bond_forces.size());
             for (int index : bond->index) { // loop over atom index in bond (relative to group begin)
                 auto absolute_index = std::distance(spc.p.begin(), group.begin()) + index;
@@ -617,8 +617,8 @@ void Bonded::force(std::vector<Point> &forces) {
     }
 
     for (auto bond : inter) {                              // loop over inter-molecular bonds
-        assert(bond->force != nullptr);                    // the force function must be implemented
-        auto bond_forces = bond->force(distance_function); // get forces on each atom in bond
+        assert(bond->forceFunc != nullptr);                // the force function must be implemented
+        auto bond_forces = bond->forceFunc(distance_function); // get forces on each atom in bond
         assert(bond_forces.size() == bond->index.size());
         int j = 0;
         for (int absolute_index : bond->index) {        // loop over atom index in bond (absolute index)

--- a/src/energy.h
+++ b/src/energy.h
@@ -246,7 +246,7 @@ class Bonded : public Energybase {
     Space &spc;
     typedef BasePointerVector<Potential::BondData> BondVector;
     BondVector inter;                // inter-molecular bonds
-    std::map<int, BondVector> intra; // intra-molecular bonds
+    std::map<int, BondVector> intra; // intra-molecular bonds; key is molecule id
 
   private:
     void update_intra();                              // finds and adds all intra-molecular bonds of active molecules
@@ -257,7 +257,8 @@ class Bonded : public Energybase {
   public:
     Bonded(const json &, Space &);
     void to_json(json &) const override;
-    double energy(Change &) override; // brute force -- refine this!
+    double energy(Change &) override;          //!< brute force -- refine this!
+    void force(std::vector<Point> &) override; //!< Calculates the forces on all particles
 };
 
 /**

--- a/src/energy.h
+++ b/src/energy.h
@@ -246,7 +246,7 @@ class Bonded : public Energybase {
     Space &spc;
     typedef BasePointerVector<Potential::BondData> BondVector;
     BondVector inter;                // inter-molecular bonds
-    std::map<int, BondVector> intra; // intra-molecular bonds; key is molecule id
+    std::map<int, BondVector> intra; // intra-molecular bonds; key is group index
 
   private:
     void update_intra();                              // finds and adds all intra-molecular bonds of active molecules

--- a/src/speciation.cpp
+++ b/src/speciation.cpp
@@ -154,7 +154,7 @@ Change::data SpeciationMove::deactivateMolecularGroup(Space::Tgroup &target) {
         auto bond_clone = bond->clone();
         bond_clone->shift(std::distance(spc.p.begin(), target.begin()));
         Potential::setBondEnergyFunction(bond_clone, spc.p);
-        bond_energy += bond_clone->energy(spc.geo.getDistanceFunc());
+        bond_energy += bond_clone->energyFunc(spc.geo.getDistanceFunc());
     }
 
     target.deactivate(target.begin(), target.end()); // deactivate whole group
@@ -225,7 +225,7 @@ Change::data SpeciationMove::activateMolecularGroup(Space::Tgroup &target) {
         auto bondclone = bond->clone();
         bondclone->shift(std::distance(spc.p.begin(), target.begin()));
         Potential::setBondEnergyFunction(bondclone, spc.p);
-        bond_energy -= bondclone->energy(spc.geo.getDistanceFunc());
+        bond_energy -= bondclone->energyFunc(spc.geo.getDistanceFunc());
     }
 
     Change::data d;                          // describes the changed - used for energy evaluation


### PR DESCRIPTION
This adds force calculations to bonded interactions and, with harmonic as an example, shows how forces can be implemented for arbitrary bond types. These implementations should/could be done in a separate PR.

- [x] add `force` functor to `BondData`
- [x] add `Bonded::force()`
- [x] implement force calculation in `Harmonic` incl. unittest
- [ ] double-check correctness of `Harmonic::forceFunc`. Sign on force OK?

Contributes to #283