### PR TITLE
Allow gzip for qrtraj and minor refactoring

### DIFF
--- a/docs/_docs/analysis.md
+++ b/docs/_docs/analysis.md
@@ -600,7 +600,6 @@ vmd confout.pqr traj.xtc -e scripts/vmd-qrtraj.tcl
 ~~~
 
 `qrfile`          |  Description
------------------ | ---------------------------------------------------------
-`file=qrtraj.dat` |  Filename of output file
-`nstep`           |  Interval between samples.
-
+----------------- | -----------------------------------
+`file=qrtraj.dat` |  Output filename (.dat, .gz)
+`nstep`           |  Interval between samples

--- a/docs/schema.yml
+++ b/docs/schema.yml
@@ -984,6 +984,16 @@ properties:
                     required: [ninsert, molecule, nstep]
                     additionalProperties: false
 
+                qrfile:
+                    description: "Write trajectory with charges and radii"
+                    properties:
+                        file: {type: string, pattern: "(.*?)\\.(dat|gz)$", default: "qrtraj.dat", description: "Output file (.dat, .gz)"}
+                        nstep: {type: integer, description: "Interval between samples"}
+                        nskip: {type: integer, default: 0, description: "Initial steps to skip"}
+                    required: [nstep]
+                    additionalProperties: false
+                    type: object
+
                 xtcfile:
                     description: "Write Gromacs XTC trajectory"
                     properties:

--- a/src/analysis.cpp
+++ b/src/analysis.cpp
@@ -388,28 +388,32 @@ void VirtualVolume::_to_disk() {
 
 void QRtraj::_sample() { write_to_file(); }
 
-void QRtraj::_to_json(json &j) const { j = {{"file", file}}; }
+void QRtraj::_to_json(json &j) const { j = {{"file", filename}}; }
+
 QRtraj::QRtraj(const json &j, Space &spc) {
     from_json(j);
     name = "qrfile";
-    file = j.value("file", "qrtraj.dat"s);
-    f.open(MPI::prefix + file);
-    if (not f)
-        throw std::runtime_error("error opening "s + file);
-    write_to_file = [&groups = spc.groups, &f = f]() {
+    filename = MPI::prefix + j.value("file", "qrtraj.dat"s);
+    if (stream = IO::openCompressedOutputStream(filename); !*stream) { // may be gzip compressed
+        throw std::runtime_error("could not open create "s + filename);
+    }
+    write_to_file = [&groups = spc.groups, &stream = stream]() {
         for (auto &g : groups) {
             for (auto it = g.begin(); it != g.trueend(); ++it) { // loop over *all* particles
-              f << ((it < g.end()) ? fmt::format("{:.6f} {:.6f} ", it->charge,
-                                                 atoms[it->id].sigma * 0.5)
-                                   : "0 0 ");
+                if (it < g.end()) {                              // active particles...
+                    *stream << fmt::format("{} {} ", it->charge, atoms[it->id].sigma * 0.5);
+                } else {               // inactive particles...
+                    *stream << "0 0 "; // ... have zero charge and size
+                }
             }
         }
-        f << "\n";               // newline for every frame
+        *stream << "\n"; // newline for every frame
     };
 }
 void QRtraj::_to_disk() {
-    if (f)
-        f.flush(); // empty buffer
+    if (*stream) {
+        stream->flush(); // empty buffer
+    }
 }
 
 void CombinedAnalysis::sample() {
@@ -516,13 +520,7 @@ FileReactionCoordinate::FileReactionCoordinate(const json &j, Space &spc) {
     from_json(j);
     name = "reactioncoordinate";
     filename = MPI::prefix + j.at("file").get<std::string>();
-    if (auto suffix = filename.substr(filename.find_last_of(".") + 1); suffix == "gz") {
-        faunus_logger->trace("{}: GZip compression enabled for {}", name, filename);
-        stream = std::make_unique<zstr::ofstream>(filename);
-    } else {
-        stream = std::make_unique<std::ofstream>(filename);
-    }
-    if (not*stream) {
+    if (stream = IO::openCompressedOutputStream(filename); not*stream) {
         throw std::runtime_error("could not open create "s + filename);
     }
     type = j.at("type").get<std::string>();

--- a/src/analysis.h
+++ b/src/analysis.h
@@ -548,21 +548,23 @@ class PolymerShape : public Analysisbase {
 };
 
 /**
- * @brief "Trajectory" with charge and radius, only, for all (active, inactive) particles
+ * @brief Trajectory with charge and radius, only, for all (active, inactive) particles
  *
- * For use w. VMD to visualize charge fluctuations and grand canonical ensembles
+ * For use with VMD to visualize charge fluctuations and grand canonical ensembles. Inactive
+ * particles have zero charge and radius. If the `filename` ends with `.gz` a GZip compressed
+ * file is created.
  */
 class QRtraj : public Analysisbase {
   private:
-    std::string file;
-    std::ofstream f;
-    std::function<void()> write_to_file;
-    void _sample() override;
+    std::string filename;                           //!< Output filename
+    std::unique_ptr<std::ostream> stream = nullptr; //!< Output stream
+    std::function<void()> write_to_file;            //!< Write a single frame to stream
+    void _sample() override;                        //!< Samples one frame and outputs to stream
     void _to_json(json &j) const override;
     void _to_disk() override;
 
   public:
-    QRtraj(const json &j, Space &spc);
+    QRtraj(const json &, Space &spc);
 };
 
 /**

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -61,10 +61,8 @@ std::unique_ptr<std::ostream> IO::openCompressedOutputStream(const std::string &
     if (filename.substr(filename.find_last_of(".") + 1) == "gz") {
         faunus_logger->trace("enabling gzip compression for {}", filename);
         return std::make_unique<zstr::ofstream>(filename);
-    } else {
-        return std::make_unique<std::ofstream>(filename);
     }
-    return nullptr;
+    return std::make_unique<std::ofstream>(filename);
 }
 
 int FormatXTC::getNumAtoms() { return natoms_xtc; }


### PR DESCRIPTION
- Allow .gz filenames in qrtraj for much reduced file sizes.

- Simpler gzip code in `reactioncoordinate`

- Update manual accordingly

- Less digits in qrfile.dat to reduce files size further