### PR TITLE
Introduced overwrite option to savestate

### DIFF
--- a/docs/schema.yml
+++ b/docs/schema.yml
@@ -869,6 +869,7 @@ properties:
                         nstep: {type: integer, default: -1, description: "Sample interval; -1 = end of simulation only"}
                         nskip: {type: integer, default: 0, description: Initial steps to skip}
                         savestate: {type: boolean, default: false, description: Include random number state}
+                        overwrite: {type: boolean, default: false, description: "Remove numbering of file every nstep"}
                     required: [file]
                     additionalProperties: false
                     type: object

--- a/docs/schema.yml
+++ b/docs/schema.yml
@@ -865,11 +865,11 @@ properties:
                 savestate:
                     description: "Save particle positions to file"
                     properties:
-                        file: {type: string, pattern: "(.*?)\\.(aam|pqr|state|ubj|gro|xyz|json)$"}
+                        file: {type: string, description: "Output filename", pattern: "(.*?)\\.(aam|pqr|state|ubj|gro|xyz|json)$"}
                         nstep: {type: integer, default: -1, description: "Sample interval; -1 = end of simulation only"}
-                        nskip: {type: integer, default: 0, description: Initial steps to skip}
-                        savestate: {type: boolean, default: false, description: Include random number state}
-                        overwrite: {type: boolean, default: false, description: "Remove numbering of file every nstep"}
+                        nskip: {type: integer, default: 0, description: "Initial steps to skip"}
+                        saverandom: {type: boolean, default: false, description: "Include random number state"}
+                        overwrite: {type: boolean, default: false, description: "Overwrite file for step, i.e. no file numbering"}
                     required: [file]
                     additionalProperties: false
                     type: object

--- a/src/analysis.cpp
+++ b/src/analysis.cpp
@@ -164,9 +164,13 @@ void SaveState::_to_json(json &j) const { j["file"] = filename; }
 void SaveState::_sample() {
     assert(sample_interval >= 0);
     // tag filename with step number:
-    auto numbered_filename = filename;
-    numbered_filename.insert(filename.find_last_of("."), "_"s + std::to_string(getNumberOfSteps()));
-    writeFunc(numbered_filename);
+    if (use_numbered_files) {
+        auto numbered_filename = filename;
+        numbered_filename.insert(filename.find_last_of("."), "_"s + std::to_string(getNumberOfSteps()));
+        writeFunc(numbered_filename);
+    } else {
+        writeFunc(filename);
+    }
 }
 
 SaveState::~SaveState() {
@@ -185,6 +189,7 @@ SaveState::SaveState(json j, Space &spc) {
 
     save_random_number_generator_state = j.value("saverandom", false);
     filename = MPI::prefix + j.at("file").get<std::string>();
+    use_numbered_files = !j.value("overwrite", false);
 
     if (auto suffix = filename.substr(filename.find_last_of(".") + 1); suffix == "aam") {
         writeFunc = [&](auto &file) { FormatAAM::save(file, spc.p); };

--- a/src/analysis.h
+++ b/src/analysis.h
@@ -253,12 +253,14 @@ class SanityCheck : public Analysisbase {
  * If the sample interval is set to the special value -1, the
  * analysis is called exclusively at the very end of the simulation.
  * If sample interval >= 0 the analysis is performed as per usual and
- * each saved configuration file is named with the step count.
+ * each saved configuration file is named with the step count. This can
+ * be disbled by setting `use_numbered_files` to false.
  */
 class SaveState : public Analysisbase {
   private:
     std::function<void(const std::string &)> writeFunc = nullptr;
     bool save_random_number_generator_state = false;
+    bool use_numbered_files = true;
     std::string filename;
     void _to_json(json &) const override;
     void _sample() override;

--- a/src/analysis.h
+++ b/src/analysis.h
@@ -250,11 +250,9 @@ class SanityCheck : public Analysisbase {
  * is `.state` which stores information about groups, particle
  * positions, random number state etc.
  *
- * If the sample interval is set to the special value -1, the
- * analysis is called exclusively at the very end of the simulation.
- * If sample interval >= 0 the analysis is performed as per usual and
- * each saved configuration file is named with the step count. This can
- * be disbled by setting `use_numbered_files` to false.
+ * - if sample interval = -1, analysis is run only once at the simulation end.
+ * - if sample interval >= 0, analysis is performed as every nstep.
+ * - if `use_numbered_files` = true (default) files are labelled with the step count
  */
 class SaveState : public Analysisbase {
   private:


### PR DESCRIPTION
# Description

The option to overwrite your savestate file has been introduced in order to easier make restart files every nstep.
## Checklist

- [ ] `make test` passes with no errors
- [ ] the source code is well documented
- [ ] new functionality includes unittests
- [ ] the user-manual has been updated to reflect the changes
- [ ] I have installed the provided commit hook to auto-format commits (requires `clang-format`):

  ``` bash
  ./scripts/git-pre-commit-format install
  ```

- [ ] code naming scheme follows the convention:

  Style        | Elements
  ------------ | ---------------------
  `PascalCase` | classes, namespaces
  `camelCase`  | functions
  `snake_case` | variables
