### PR TITLE
Clarify keyword `inactive` in manual

### DIFF
--- a/docs/_docs/topology.md
+++ b/docs/_docs/topology.md
@@ -188,7 +188,9 @@ making a union.
 
 Upon starting a simulation, an initial configuration is required and must be
 specified in the section `insertmolecules` as a list of valid molecule names.
-Molecules are inserted in the given order and may be `inactive`.
+Molecules are inserted in the given order and may be `inactive`, meaning that
+they are not present in the simulation cell, but available as a reservoir for
+e.g. grand canonical moves.
 If a group is marked `atomic`, its `atoms` are inserted `N` times.
 
 Example:
@@ -206,7 +208,7 @@ The following keywords for each molecule type are available:
 -------------------- | ---------------------------------------
 `N`                  | Number of molecules to insert
 `molarity`           | Insert molecules to reach molarity
-`inactive=false`     | Deactivates inserted molecules
+`inactive=false`     | Set to true if the particles should be inactive
 `positions`          | Load positions from file (`aam`, `pqr`, `xyz`)
 `translate=[0,0,0]`  | Displace loaded `positions` with vector
 


### PR DESCRIPTION
Clarify inactive keyword

# Description

Please edit this text to include a summary of the change and which issue is fixed.

## Checklist

- [ ] `make test` passes with no errors
- [ ] the source code is well documented
- [ ] new functionality includes unittests
- [ ] the user-manual has been updated to reflect the changes
- [ ] I have installed the provided commit hook to auto-format commits (requires `clang-format`):

  ``` bash
  ./scripts/git-pre-commit-format install
  ```

- [ ] code naming scheme follows the convention:

  Style        | Elements
  ------------ | ---------------------
  `PascalCase` | classes, namespaces
  `camelCase`  | functions
  `snake_case` | variables
