### PR TITLE
Enable integer selection for inactive molecules

### DIFF
--- a/docs/_docs/topology.md
+++ b/docs/_docs/topology.md
@@ -198,8 +198,7 @@ Example:
 ~~~ yaml
 insertmolecules:
   - salt:  { molarity: 0.1 }
-  - water: { N: 256 }
-  - water: { N: 1, inactive: true }
+  - water: { N: 256, inactive: 2 }
 ~~~
 
 The following keywords for each molecule type are available:
@@ -208,7 +207,7 @@ The following keywords for each molecule type are available:
 -------------------- | ---------------------------------------
 `N`                  | Number of molecules to insert
 `molarity`           | Insert molecules to reach molarity
-`inactive=false`     | Set to true if the particles should be inactive
+`inactive`           | Number of inserted molecules to deactivate; set to `true` for all
 `positions`          | Load positions from file (`aam`, `pqr`, `xyz`)
 `translate=[0,0,0]`  | Displace loaded `positions` with vector
 

--- a/docs/schema.yml
+++ b/docs/schema.yml
@@ -69,7 +69,7 @@ properties:
                 properties:
                     N: {type: integer, description: Number of molecules to insert}
                     molarity: {type: number, description: Insert molecules to reach this molarity}
-                    inactive: {type: boolean, default: false, description: Should molecules be inactive?}
+                    inactive: {type: [boolean, integer], description: Deactive (all) inserted molecules}
                     positions: {type: string, description: Load positions from file}
                 oneOf:
                     - required: [N]

--- a/docs/schema.yml
+++ b/docs/schema.yml
@@ -69,7 +69,7 @@ properties:
                 properties:
                     N: {type: integer, description: Number of molecules to insert}
                     molarity: {type: number, description: Insert molecules to reach this molarity}
-                    inactive: {type: [boolean, integer], description: Deactive (all) inserted molecules}
+                    inactive: {type: [boolean, integer], description: Number of inserted molecules to deactivate}
                     positions: {type: string, description: Load positions from file}
                 oneOf:
                     - required: [N]

--- a/src/group.h
+++ b/src/group.h
@@ -239,12 +239,20 @@ namespace Faunus {
 
             std::vector<std::reference_wrapper<Point>> positions() const; //!< Iterable range with positions of active particles
 
-            // warning! this should be tested -- do not use yet.
-            template<typename TdistanceFunc>
-                void unwrap(const TdistanceFunc &vdist) {
-                    for (auto &i : *this)
-                        i.pos = cm + vdist( i.pos, cm );
-                } //!< Remove periodic boundaries with respect to mass center (Order N complexity).
+            /**
+             * @brief Remove PBC for molecular groups w. respect to mass center
+             * @tparam TdistanceFunc
+             * @param vdist Distance calculation function
+             * @remarks Atomic groups are not touched
+             * @warning Is this fit for use?
+             */
+            template <typename TdistanceFunc> void unwrap(const TdistanceFunc &vdist) {
+                if (isMolecular()) {
+                    for (auto &i : *this) {
+                        i.pos = cm + vdist(i.pos, cm);
+                    }
+                }
+            } //!<
 
             void wrap(Geometry::BoundaryFunction); //!< Apply periodic boundaries (Order N complexity).
 

--- a/src/group.h
+++ b/src/group.h
@@ -28,7 +28,7 @@ namespace Faunus {
             void clear() { this->second = this->first; assert(empty()); }
             std::pair<int,int> to_index(T reference) const {
                 return {std::distance(reference, begin()), std::distance(reference, end()-1)};
-            } //!< Returns index pair relative to reference
+            } //!< Returns particle index pair relative to given reference
         }; //!< Turns a pair of iterators into a range
 
     /**

--- a/src/group.h
+++ b/src/group.h
@@ -118,6 +118,10 @@ namespace Faunus {
             bool compressible=false;   //!< Is it a compressible group?
             bool atomic=false;   //!< Is it an atomic group?
 
+            inline bool isAtomic() const { return traits().atomic; } //!< Is it an atomic group?
+
+            inline bool isMolecular() const { return !traits().atomic; } //!< is it a molecular group?
+
             //! Selections to filter groups using `getSelectionFilter()`
             enum Selectors : unsigned int {
                 ANY = (1u << 1),       //!< Match any group (disregards all other flags)
@@ -183,6 +187,7 @@ namespace Faunus {
 #pragma clang diagnostic pop
 
             inline const MoleculeData &traits() const {
+                assert(id >= 0 && id < Faunus::molecules.size());
                 return Faunus::molecules[id];
             } //!< Convenient access to molecule properties
 

--- a/src/montecarlo.cpp
+++ b/src/montecarlo.cpp
@@ -142,9 +142,10 @@ void MetropolisMonteCarlo::move() {
             auto move = *move_it;                                      // more readable like this
             move->move(change);
 #ifndef NDEBUG
-            // check if atom index indeed belong to the group (index)
-            if (not change.sanityCheck(*state->spc)) {
-                throw std::runtime_error("insane change object\n" + json(change).dump(4));
+            try {
+                change.sanityCheck(state->spc->groups);
+            } catch (std::exception &e) {
+                throw std::runtime_error(e.what());
             }
 #endif
             if (change) {

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -18,21 +18,25 @@ void Change::clear() {
     assert(empty());
 }
 bool Change::empty() const {
-    if (dV == false)
-        if (all == false)
-            if (groups.empty())
-                if (dN == false)
-                    return true;
-    return false;
+    if (dV || all || dN || !groups.empty()) {
+        return false;
+    } else {
+        return true;
+    }
 }
 Change::operator bool() const { return not empty(); }
 
 std::vector<int> Change::touchedParticleIndex(const std::vector<Group<Particle>> &group_vector) {
-    std::vector<int> atom_indexes; // atom index rel. to first particle in system
-    auto begin = group_vector.front().begin();
-    for (auto &d : groups)     // loop over changes groups
-        for (auto i : d.atoms) // atom index rel. to group
-            atom_indexes.push_back(i + std::distance(begin, group_vector.at(d.index).begin()));
+    std::vector<int> atom_indexes;                                   // atom index rel. to first particle in system
+    for (const auto &changed : groups) {                             // loop over changed groups
+        auto begin_first = group_vector.front().begin();             // first particle, first group
+        auto begin_current = group_vector.at(changed.index).begin(); // first particle, current group
+        auto offset = std::distance(begin_first, begin_current);     // abs. distance from first particle
+        atom_indexes.reserve(atom_indexes.size() + changed.atoms.size());
+        for (auto index : changed.atoms) {          // atom index relative to group
+            atom_indexes.push_back(index + offset); // atom index relative to first
+        }
+    }
     return atom_indexes;
 }
 

--- a/src/space.h
+++ b/src/space.h
@@ -272,19 +272,8 @@ class InsertMoleculesInSpace {
     static void setPositionsForTrailingGroups(Space &, int, const Faunus::ParticleVector &, const Point &);
     static void insertImplicitGroups(const MoleculeData &, Space &, int);
 
-    /**
-     * @brief Get number of inactive molecules from json objest
-     * @param j Input json object
-     * @param number_of_molecules Total number of molecules
-     * @return Number of molecules to be inactive (always smaller than `number_of_molecules`)
-     * @throws If Inactive molecules is higher than `number_of_molecules`
-     *
-     * Looks for key "inactive" and if:
-     * - boolean true: all molecules are inactive
-     * - number: number of molecules to declare inactive
-     * - no `inactive` key found, return zero
-     */
-    static int getNumberOfInactiveParticles(const json &j, int number_of_molecules);
+    //! @brief Get number of inactive molecules from json object
+    static int getNumberOfInactiveMolecules(const json &j, int number_of_molecules);
 
   public:
     static void insertMolecules(const json &, Space &);

--- a/src/space.h
+++ b/src/space.h
@@ -217,11 +217,7 @@ class Space {
     void sync(const Space &other,
               const Tchange &change); //!< Copy differing data from other (o) Space using Change object
 
-    /**
-     * @brief Scales atoms, molecules, and simulation container
-     * @returns Scaling factors in each dimension
-     */
-    Point scaleVolume(double, Geometry::VolumeMethod = Geometry::ISOTROPIC);
+    Point scaleVolume(double, Geometry::VolumeMethod = Geometry::ISOTROPIC); //!< Scales atoms, molecules, container
 
     json info();
 

--- a/src/space.h
+++ b/src/space.h
@@ -6,12 +6,6 @@
 
 namespace Faunus {
 
-struct reservoir {
-    std::string name;
-    int N_reservoir;
-    bool canonic;
-};
-
 class Space;
 
 /**
@@ -25,7 +19,6 @@ struct Change {
     bool all = false;        //!< Set to true if *everything* has changed
     bool dN = false;         //!< True if the number of atomic or molecular species has changed
     bool moved2moved = true; //!< If several groups are moved, should they interact with each other?
-    // bool chargeMove = false; //!< Not in use...
 
     struct data {
         bool dNatomic = false;  //!< True if the number of atomic molecules has changed
@@ -58,17 +51,13 @@ void to_json(json &, const Change &);       //!< Serialise Change object to json
 
 /**
  * @brief Placeholder for atoms and molecules
- * @tparam Tparticletype Particle type for the space
- *
- * @todo
- * Split definitions into cpp file and forward instatiate
- * an instance of `Space<Tparticle>` where `Tparticle` has
- * been defined as `typedef Particle<Charge> Tparticle`.
  */
 class Space {
   private:
     /**
-     * Storage for the reservoir size (map value) of each implicit
+     * @brief Stores implicit molecules
+     *
+     * This stores the number (map value) of each implicit
      * molecule in the system, identified by the molecular id (map key)
      * The reservoir is used to emulate a canonical system where a finite
      * number of implicit molecules can participate in equilibrium reactions.
@@ -91,9 +80,9 @@ class Space {
     std::vector<ChangeTrigger> changeTriggers;           //!< Call when a Change object is applied
     std::vector<SyncTrigger> onSyncTriggers;             //!< Call when two Space objects are synched
 
-    Tpvec p;       //!< Particle vector
-    Tgvec groups;  //!< Group vector
-    Tgeometry geo; //!< Container geometry // TODO as a dependency injection in the constructor
+    ParticleVector p; //!< Particle vector
+    Tgvec groups;     //!< Group vector
+    Tgeometry geo;    //!< Container geometry // TODO as a dependency injection in the constructor
 
     const std::map<int, int> &getImplicitReservoir() const; //!< Map of implicit molecule reservoirs
     std::map<int, int> &getImplicitReservoir();             //!< Map of implicit molecule reservoirs
@@ -186,10 +175,10 @@ class Space {
         return std::find_if(groups.begin(), groups.end(), [&i](auto &g) { return g.contains(i); });
     } //!< Finds the groups containing the given atom
 
-    auto findGroupContaining(size_t index) {
-        assert(index < p.size());
+    auto findGroupContaining(size_t atom_index) {
+        assert(atom_index < p.size());
         return std::find_if(groups.begin(), groups.end(),
-                            [&](auto &g) { return index < std::distance(p.begin(), g.end()); });
+                            [&](auto &g) { return atom_index < std::distance(p.begin(), g.end()); });
     } //!< Finds group containing given atom index
 
     auto activeParticles() {

--- a/src/space.h
+++ b/src/space.h
@@ -267,10 +267,24 @@ void from_json(const json &j, Space &spc); //!< Deserialize json object to Space
  */
 class InsertMoleculesInSpace {
   private:
-    static void insertAtomicGroups(MoleculeData &, Space &, int, bool);
-    static void insertMolecularGroups(MoleculeData &, Space &, int num_molecules, bool);
+    static void insertAtomicGroups(MoleculeData &, Space &, int number, int num_inactive);
+    static void insertMolecularGroups(MoleculeData &, Space &, int num_molecules, int num_inactive);
     static void setPositionsForTrailingGroups(Space &, int, const Faunus::ParticleVector &, const Point &);
     static void insertImplicitGroups(const MoleculeData &, Space &, int);
+
+    /**
+     * @brief Get number of inactive molecules from json objest
+     * @param j Input json object
+     * @param number_of_molecules Total number of molecules
+     * @return Number of molecules to be inactive (always smaller than `number_of_molecules`)
+     * @throws If Inactive molecules is higher than `number_of_molecules`
+     *
+     * Looks for key "inactive" and if:
+     * - boolean true: all molecules are inactive
+     * - number: number of molecules to declare inactive
+     * - no `inactive` key found, return zero
+     */
+    static int getNumberOfInactiveParticles(const json &j, int number_of_molecules);
 
   public:
     static void insertMolecules(const json &, Space &);

--- a/src/space.h
+++ b/src/space.h
@@ -107,14 +107,7 @@ class Space {
 
     void clear(); //!< Clears particle and molecule list
 
-    /*
-     * The following is considered:
-     *
-     * - `groups` vector is expanded with a new group at the end
-     * - if the particle vector is relocated, all existing group
-     *   iterators are updated to reflect the new memory positions
-     */
-    void push_back(int molid, const Tpvec &in); //!< Safely add particles and corresponding group to back
+    void push_back(int, const ParticleVector &); //!< Safely add particles and corresponding group to back
 
     /**
      * @brief Find all groups of type `molid` (complexity: order N)
@@ -267,7 +260,7 @@ void from_json(const json &j, Space &spc); //!< Deserialize json object to Space
  */
 class InsertMoleculesInSpace {
   private:
-    static void insertAtomicGroups(MoleculeData &, Space &, int number, int num_inactive);
+    static void insertAtomicGroups(MoleculeData &, Space &, int num_molecules, int num_inactive_molecules);
     static void insertMolecularGroups(MoleculeData &, Space &, int num_molecules, int num_inactive);
     static void setPositionsForTrailingGroups(Space &, int, const Faunus::ParticleVector &, const Point &);
     static void insertImplicitGroups(const MoleculeData &, Space &, int);

--- a/src/space_test.h
+++ b/src/space_test.h
@@ -11,6 +11,8 @@ TEST_CASE("[Faunus] Change") {
     change.dV = true;
     CHECK(not change.empty());
     CHECK(change);
+    change.clear();
+    CHECK(change.empty());
 }
 
 TEST_CASE("[Faunus] Space") {
@@ -42,33 +44,6 @@ TEST_CASE("[Faunus] Space") {
 
     // check `positions()`
     CHECK(&spc1.positions()[0] == &spc1.p[0].pos);
-
-    // sync groups
-    Change c;
-    c.all = true;
-    c.dV = true;
-    c.groups.resize(1);
-    c.groups[0].index = 0;
-    c.groups[0].all = true;
-    Tspace spc2;
-    spc2.sync(spc1, c);
-    CHECK(spc2.p.size() == 2);
-    CHECK(spc2.groups.size() == 1);
-    CHECK(spc2.groups.front().id == 0);
-    CHECK(spc2.groups.front().begin() != spc1.groups.front().begin());
-    CHECK(spc2.p.front().pos.x() == doctest::Approx(2));
-
-    // nothing should be synched (all==false)
-    spc2.p.back().pos.z() = -0.1;
-    c.all = false;
-    c.groups[0].all = false;
-    spc1.sync(spc2, c);
-    CHECK(spc1.p.back().pos.z() != -0.1);
-
-    // everything should be synched (all==true)
-    c.groups[0].all = true;
-    spc1.sync(spc2, c);
-    CHECK(spc1.p.back().pos.z() == doctest::Approx(-0.1));
 
     SUBCASE("getActiveParticles") {
         // add three groups to space

--- a/src/space_test.h
+++ b/src/space_test.h
@@ -14,24 +14,29 @@ TEST_CASE("[Faunus] Change") {
 }
 
 TEST_CASE("[Faunus] Space") {
-    Tspace spc1;
+    Space spc1;
     spc1.geo = R"( {"type": "sphere", "radius": 1e9} )"_json;
 
     // check molecule insertion
-    molecules.at(0).atomic = false;
-    REQUIRE_EQ(molecules.at(0).atomic, false);
-    atoms.resize(2);
-    CHECK(atoms.at(0).mw == 1);
+    Faunus::molecules.at(0).atomic = false;
+    REQUIRE_EQ(Faunus::molecules.at(0).atomic, false);
+    Faunus::molecules.at(0).atoms.resize(2);
+    CHECK(Faunus::molecules.at(0).atoms.size() == 2);
+
+    Faunus::atoms.resize(2);
+    CHECK(Faunus::atoms.at(0).mw == 1);
+
     Particle a;
     a.id = 0;
     a.pos.setZero();
-    Tspace::Tpvec p(2, a);
+    ParticleVector p(2, a);
     CHECK(p[0].traits().mw == 1);
     p[0].pos.x() = 2;
     p[1].pos.x() = 3;
-    spc1.push_back(0, p);
+    spc1.push_back(0, p); // insert molecular group
     CHECK(spc1.p.size() == 2);
     CHECK(spc1.groups.size() == 1);
+    CHECK(spc1.groups.back().isMolecular());
     CHECK(spc1.groups.front().id == 0);
     CHECK(spc1.groups.front().cm.x() == doctest::Approx(2.5));
 
@@ -67,12 +72,14 @@ TEST_CASE("[Faunus] Space") {
 
     SUBCASE("getActiveParticles") {
         // add three groups to space
-        Tspace spc;
+        Space spc;
         spc.geo = R"( {"type": "sphere", "radius": 1e9} )"_json;
         Particle a;
         a.pos.setZero();
         a.id = 0;
-        typename Tspace::Tpvec pvec({a, a, a});
+        ParticleVector pvec({a, a, a});
+
+        Faunus::molecules.at(0).atoms.resize(3);
 
         spc.push_back(0, pvec);
         spc.push_back(0, pvec);


### PR DESCRIPTION
In the topology, enable integer number of particles to deactivate (in addition to the boolean).
Independently requested by @SHervoe-Hansen and @MarcoPolimeni.

This has turned out to be a refactoring commit for `Space` with updated insertion methods to better accommodate changes like this one.