### PR TITLE
Respect active particles in Langevin Dynamics

### DIFF
--- a/docs/_docs/langevin.md
+++ b/docs/_docs/langevin.md
@@ -20,22 +20,28 @@ moves:
 
 `langevin`      | Description
 --------------- | --------------------------------------------
-`splitting`     | Method for numerically solving the Langevin equation
-`nstep`         | Number of random MC steps to be conducted before continuing Langevin dynamics
-`mdsteps`       | Number of iterations for each Langevin dynamics event
+`nsteps`        | Number of time iterations for each Langevin dynamics event
+`integrator`    | Object with the following two keywords:
 `time_step`     | Time step for integration <!--∆𝑡--> $\Delta t$ (ps)
 `friction`      | Friction coefficient <!--𝛾--> $\gamma$ (1/ps)
 
 This move will solve the Langevin equation for the particles in the system on the form
-\begin{equation*}
-d\begin{bmatrix} \mathbf{q} \\ \mathbf{p} \end{bmatrix} = \underbrace{\begin{bmatrix} M^{-1}\mathbf{q} \\ 0 \end{bmatrix} \mathrm{d}t}_{\text{A}} + \underbrace{\begin{bmatrix} 0 \\ -\nabla U(\mathbf{q}) \end{bmatrix}\mathrm{d}t}_{\text{B}} + \underbrace{\begin{bmatrix} 0 \\-\gamma \mathbf{p} + \sqrt{2k\text{k}_{\mathrm{b}}T\gamma} \sqrt{M} ~\mathrm{d}\mathbf{W} \end{bmatrix}}_{\text{O}}
-\end{equation*}
-Where A, B, and O makes up the individual terms for solving the Langevin equation, which can individually be solved exactly to obtain a trajectory given by
-\begin{align*}
-\varphi^{\mathrm{A}}(\mathbf{q}, \mathbf{p}) &= \left(\mathbf{q} + \Delta t \sqrt{M}~ \mathbf{p}, \mathbf{p}\right) \\
-\varphi^{\mathrm{B}}(\mathbf{q}, \mathbf{p}) &= \left(\mathbf{q}, \mathbf{p} - \Delta t \nabla U(\mathbf{q})\right) \\
-\varphi^{\mathrm{O}}(\mathbf{q}, \mathbf{p}) &= \left(\mathbf{q}, e^{-\gamma \Delta t}\mathbf{p} + \sqrt{\mathrm{k}_{\mathrm{B}}T (1 - e^{-2\gamma \Delta t})} \sqrt{M} \mathbf{R} \right)
-\end{align*}
+$$
+d\begin{bmatrix} \mathbf{q} \\ \mathbf{p} \end{bmatrix} = \underbrace{\begin{bmatrix} M^{-1}\mathbf{q} \\ 0 \end{bmatrix} \mathrm{d}t}\_{\text{A}} + \underbrace{\begin{bmatrix} 0 \\ -\nabla U(\mathbf{q}) \end{bmatrix}\mathrm{d}t}\_{\text{B}} + \underbrace{\begin{bmatrix} 0 \\-\gamma \mathbf{p} + \sqrt{2k\text{k}\_{\mathrm{b}}T\gamma} \sqrt{M} ~\mathrm{d}\mathbf{W} \end{bmatrix}}\_{\text{O}}
+$$
+
+Where A, B, and O makes up the terms for solving the Langevin equation, which can be individually solved to obtain a trajectory given by
+$$
+\varphi^{\mathrm{A}}(\mathbf{q}, \mathbf{p}) = \left(\mathbf{q} + \Delta t \sqrt{M}~ \mathbf{p}, \mathbf{p}\right) \\
+\varphi^{\mathrm{B}}(\mathbf{q}, \mathbf{p}) = \left(\mathbf{q}, \mathbf{p} - \Delta t \nabla U(\mathbf{q})\right) \\
+\varphi^{\mathrm{O}}(\mathbf{q}, \mathbf{p}) = \left(\mathbf{q}, e^{-\gamma \Delta t}\mathbf{p} + \sqrt{\mathrm{k}\_{\mathrm{B}}T (1 - e^{-2\gamma \Delta t})} \sqrt{M} \mathbf{R} \right)
+$$
+
+We currently use the splitting scheme "BAOAB" ([Symmetric Langevin Velocity-Verlet](http://doi.org/ggrnfs)) since it is less errorprone with increasing timestep [Leimkuhler & Matthews, pp. 279-281](http://doi.org/dx7v).
+
+
+<!--
+
 The keyword `splitting` thus refers to the string constructed from the labels A, B and O. In the current implementation a selection of splitting schemes are available
 
 `splitting`     | Description
@@ -49,7 +55,6 @@ OBABO           | [Bussi-Parrinello Langevin Velocity-Verlet](http://doi.org/cjp
 
 We recommend the usage of the splitting scheme "BAOAB" (Symmetric Langevin Velocity-Verlet) due to it being less errorprone with increasing timestep [Leimkuhler & Matthews, pp. 279-281](http://doi.org/dx7v).
 
-<!--
 ## Molecular dynamics
 To be implemented. It is currently possible to sample the NVE ensemble using the Langevin move by setting `friction = 0`.
 

--- a/docs/schema.yml
+++ b/docs/schema.yml
@@ -784,6 +784,21 @@ properties:
                     required: [file, name1, name2, nstep]
                     additionalProperties: false
 
+                langevin_dynamics:
+                    description: "Run Langevin Dynamics (LD) with BAOAB splitting"
+                    type: object
+                    properties:
+                        nsteps: {type: integer, description: "Number of LD steps to perform"}
+                        integrator:
+                            type: object
+                            properties:
+                                time_step: {type: number, description: "Time interval between steps (ps)"}
+                                friction: {type: number, description: "Friction coefficient"}
+                            required: [time_step, friction]
+                            additionalProperties: false
+                    required: [nsteps, integrator]
+                    additionalProperties: false
+
                 atomprofile:
                     description: Summed density of atoms in spherical, cylindrical or planar shells
                     type: object

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,7 +16,7 @@ if (ENABLE_PCH)
             project_options INTERFACE <vector> <string> <map> <set> <algorithm> <utility> <random> <iostream>
             <limits> <memory>
             <Eigen/Core> <Eigen/Geometry>
-            <range/v3/view/filter.hpp> <range/v3/view/transform.hpp>
+            <range/v3/view/filter.hpp> <range/v3/view/transform.hpp> <range/v3/view/join.hpp>
             <cereal/cereal.hpp> <cereal/types/base_class.hpp> <cereal/types/memory.hpp>
             <nlohmann/json.hpp> <nlohmann/json_fwd.hpp>
             <spdlog/fmt/fmt.h> <spdlog/spdlog.h>)

--- a/src/aux/pow_function.h
+++ b/src/aux/pow_function.h
@@ -1,3 +1,4 @@
+#pragma once
 #include <doctest/doctest.h>
 
 namespace Faunus {

--- a/src/average.h
+++ b/src/average.h
@@ -87,4 +87,3 @@ namespace Faunus
 
   } // namespace Faunus
 
-

--- a/src/forcemove.cpp
+++ b/src/forcemove.cpp
@@ -78,7 +78,7 @@ inline Point LangevinVelocityVerlet::velocityFluctuationDissipation(const Point 
  */
 void LangevinVelocityVerlet::step(PointVector &velocities, PointVector &forces) {
     assert(spc.numParticles(Space::ACTIVE) == forces.size());
-    assert(spc.numParticles(Space::ACTIVE) == velocities.size());
+    assert(forces.size() == velocities.size());
 
     auto zipped = ranges::views::zip(spc.activeParticles(), forces, velocities);
 

--- a/src/forcemove.cpp
+++ b/src/forcemove.cpp
@@ -1,5 +1,6 @@
 #include "forcemove.h"
 #include "random.h"
+#include "energy.h"
 
 namespace Faunus::Move {
 
@@ -50,34 +51,50 @@ inline Point LangevinVelocityVerlet::velocityIncrement(const Point& force, const
     return 0.5 * time_step * force * meanSquareSpeedComponent(mass);
 }
 
-inline Point LangevinVelocityVerlet::velocityFluctuationDissipation(const Point& velocity, const double mass) {
-    const double prefactor = exp(-friction_coefficient * time_step); // Ornstein-Uhlenbeck process prefactor
+/**
+ * @param velocity Initial velocity
+ * @param mass Particle Mass in g/mol
+ * @return Updated velocity
+ */
+inline Point LangevinVelocityVerlet::velocityFluctuationDissipation(const Point &velocity, const double mass) {
+    const double prefactor = std::exp(-friction_coefficient * time_step); // Ornstein-Uhlenbeck process prefactor
     return (prefactor * velocity) +
-                    std::sqrt((1 - std::pow(prefactor, 2)) * meanSquareSpeedComponent(mass)) * noise();
+           random_vector(random.engine) * std::sqrt((1.0 - prefactor * prefactor) * meanSquareSpeedComponent(mass));
 }
 
+/**
+ * @param velocities Vector of velocities
+ * @param forces Vector of forces
+ * @note
+ * Using rangesv3, raw loops can be avoided and allow for future c++17 execution policies:
+ *
+ *     auto rng = zip(spc.p, velocities, forces);
+ *     for (auto&& [particle, velicity, force] : rng) { ... };
+ *     std::for_each(rng.begin(), rng.end(), [](auto &&tuple){
+ *         auto&& [particle, velicity, force] = tuple;
+ *         ...
+ *     }};
+ * @todo Splitting scheme still hard-coded to 'BAOAB'
+ */
 void LangevinVelocityVerlet::step(PointVector &velocities, PointVector &forces) {
-    assert(spc.p.size() == forces.size());     // Check that the position and force vectors are of the same size.
-    assert(spc.p.size() == velocities.size()); // Check that the position and velocity vectors are of the same size.
+    assert(spc.numParticles(Space::ACTIVE) == forces.size());
+    assert(spc.numParticles(Space::ACTIVE) == velocities.size());
 
-    for (std::size_t i = 0; i < spc.p.size(); ++i) {
-        const auto mass = atoms[spc.p[i].id].mw;
-        auto &position = spc.p[i].pos;
-        auto &velocity = velocities[i];
-        velocity += velocityIncrement(forces[i], mass);            // B step
-        position += positionIncrement(velocity);                   // A step
+    auto zipped = ranges::views::zip(spc.activeParticles(), forces, velocities);
+
+    for (auto &&[particle, force, velocity] : zipped) {
+        const auto mass = particle.traits().mw;
+        velocity += velocityIncrement(force, mass);                // B step
+        particle.pos += positionIncrement(velocity);               // A step
         velocity = velocityFluctuationDissipation(velocity, mass); // O step
-        position += positionIncrement(velocity);                   // A step
-        spc.geo.boundary(position);
+        particle.pos += positionIncrement(velocity);               // A step
+        spc.geo.boundary(particle.pos);
     }
-    // Update forces. The force vector must be initialized with zeros as the resulting force is computed
-    // additively (+=).
-    std::fill(forces.begin(), forces.end(), Point(0.0, 0.0, 0.0));
-    energy.force(forces);
+    std::fill(forces.begin(), forces.end(), Point::Zero()); // forces must be updated ...
+    energy.force(forces);                                   // ... before each B step
 
-    for (std::size_t i = 0; i < spc.p.size(); ++i) {
-        const auto mass = atoms[spc.p[i].id].mw;
-        velocities[i] += velocityIncrement(forces[i], mass);       // B step
+    for (auto &&[particle, force, velocity] : zipped) {
+        velocity += velocityIncrement(force, particle.traits().mw); // B step
     }
 }
 
@@ -106,16 +123,30 @@ TEST_CASE("[Faunus] Integrator") {
 // =============== ForceMoveBase ===============
 
 ForceMoveBase::ForceMoveBase(Space &spc, std::shared_ptr<IntegratorBase> integrator, unsigned int nsteps)
-    : nsteps(nsteps), spc(spc), integrator(integrator) {
-    forces.resize(spc.p.size());
-    velocities.resize(spc.p.size());
+    : integrator(integrator), number_of_steps(nsteps), spc(spc) {
+    forces.reserve(spc.p.size());
+    velocities.reserve(spc.p.size());
+    resizeForcesAndVelocities();
     repeat = 1;
+}
+
+/**
+ * @return Number of activate particles
+ *
+ * Upon resizing, new elements in `forces` and `velocities` are zeroed.
+ */
+size_t ForceMoveBase::resizeForcesAndVelocities() {
+    const auto num_active_particles = spc.numParticles(Space::ACTIVE);
+    forces.resize(num_active_particles, Point::Zero());
+    velocities.resize(num_active_particles, Point::Zero());
+    return num_active_particles;
 }
 
 void ForceMoveBase::_move(Change &change) {
     change.clear();
     change.all = true;
-    for (unsigned int step = 0; step < nsteps; ++step) {
+    resizeForcesAndVelocities();
+    for (unsigned int step = 0; step < number_of_steps; ++step) {
         integrator->step(velocities, forces);
     }
     for (auto &group : spc.groups) { // update mass centers before returning to Monte Carlo
@@ -124,12 +155,12 @@ void ForceMoveBase::_move(Change &change) {
 }
 
 void ForceMoveBase::_to_json(json &j) const {
-    j = {{"nsteps", nsteps}};
+    j = {{"nsteps", number_of_steps}};
     j["integrator"] = *integrator;
 }
 
 void ForceMoveBase::_from_json(const json &j) {
-    nsteps = j.at("nsteps").get<unsigned int>();
+    number_of_steps = j.at("nsteps").get<unsigned int>();
     integrator->from_json(j["integrator"]);
     generateVelocities();
 }
@@ -138,18 +169,18 @@ double ForceMoveBase::bias(Change &, double, double) {
     return pc::neg_infty; // always accept the move
 }
 
-void ForceMoveBase::setVelocities(const PointVector &velocities) {
-    assert(spc.p.size() == velocities.size()); // Check that the position and velocity vectors are of the same size.
-    this->velocities = velocities;
+void ForceMoveBase::generateVelocities() {
+    NormalRandomVector random_vector; // generator of random 3d vector from a normal distribution
+    const auto particles = spc.activeParticles();
+    resizeForcesAndVelocities();
+    std::transform(particles.begin(), particles.end(), velocities.begin(), [&](auto &particle) {
+        return random_vector(random.engine) * std::sqrt(meanSquareSpeedComponent(particle.traits().mw));
+    });
+    std::fill(forces.begin(), forces.end(), Point::Zero());
 }
 
-void ForceMoveBase::generateVelocities() {
-    for (std::size_t i = 0; i < spc.p.size(); ++i) {
-        const auto mass = atoms[spc.p[i].id].mw;
-        velocities[i] = random_vector() * std::sqrt(meanSquareSpeedComponent(mass));
-        forces[i] = {0, 0, 0};
-    }
-}
+const PointVector &ForceMoveBase::getForces() const { return forces; }
+const PointVector &ForceMoveBase::getVelocities() const { return velocities; }
 
 // =============== LangevinMove ===============
 
@@ -181,7 +212,17 @@ TEST_CASE("[Faunus] LangevinDynamics") {
     Space spc;
     DummyEnergy energy;
 
-    SUBCASE("[Faunus] JSON init") {
+    SUBCASE("Velocity and force initialization") {
+        spc.p.resize(10);                                        // 10 particles in total
+        spc.groups.emplace_back(spc.p.begin(), spc.p.end() - 1); // 9 active particles
+        LangevinDynamics ld(spc, energy);
+        CHECK(ld.getForces().capacity() >= 10);
+        CHECK(ld.getVelocities().capacity() >= 10);
+        CHECK_EQ(ld.getForces().size(), 9);
+        CHECK_EQ(ld.getVelocities().size(), 9);
+    }
+
+    SUBCASE("JSON init") {
         json j_in = R"({"nsteps": 100, "integrator": {"time_step": 0.001, "friction": 2.0}})"_json;
         LangevinDynamics ld(spc, energy);
         ld.from_json(j_in);

--- a/src/move.h
+++ b/src/move.h
@@ -40,8 +40,8 @@ class Movebase {
     void move(Change &);        //!< Perform move and modify given change object
     void accept(Change &);
     void reject(Change &);
-    virtual double bias(Change &, double,
-                        double); //!< adds extra energy change not captured by the Hamiltonian
+    virtual double bias(Change &, double old_energy,
+                        double new_energy); //!< adds extra energy change not captured by the Hamiltonian
     inline virtual ~Movebase() = default;
 };
 

--- a/src/space.h
+++ b/src/space.h
@@ -94,7 +94,7 @@ class Space {
     void push_back(int, const ParticleVector &);            //!< Safely add particles and corresponding group to back
     Tgvec::iterator findGroupContaining(const Particle &i); //!< Finds the group containing the given atom
     Tgvec::iterator findGroupContaining(size_t atom_index); //!< Finds the group containing given atom index
-    size_t numParticles(Selection sel = ACTIVE) const;      //!< Number of particles, all or active (default)
+    size_t numParticles(Selection selection = ACTIVE) const; //!< Number of particles, all or active (default)
     Point scaleVolume(double, Geometry::VolumeMethod = Geometry::ISOTROPIC); //!< Scales atoms, molecules, container
     Tgvec::iterator randomMolecule(int, Random &, Selection = ACTIVE);       //!< Random group matching molid
     json info();

--- a/src/space.h
+++ b/src/space.h
@@ -3,6 +3,7 @@
 #include "geometry.h"
 #include "group.h"
 #include "molecule.h"
+#include <range/v3/view/join.hpp>
 
 namespace Faunus {
 
@@ -173,13 +174,7 @@ class Space {
     } //!< Range with all active atoms of type `atomid` (complexity: order N)
 
     auto activeParticles() {
-        auto f = [&groups = groups](Particle &i) {
-            for (auto &g : groups)
-                if (g.contains(i)) // true if particle is within active part
-                    return true;
-            return false;
-        };
-        return p | ranges::cpp20::views::filter(f);
+        return groups | ranges::cpp20::views::join;
     } //!< Returns range with all *active* particles in space
 
     /**


### PR DESCRIPTION
Ensure that the Langevin move operates only on active particles.

- Filter to update only active particles.
- Uncomment `splitting` from manual as it's not available.