### PR TITLE
Enable Intel Threading Building Blocks

### DIFF
--- a/cmake/ExternalTools.cmake
+++ b/cmake/ExternalTools.cmake
@@ -169,6 +169,25 @@ FetchContent_Declare(
     URL_HASH MD5=1ad2c611378fb440e8550a7eb6b31b89)
 
 ############
+# INTEL TBB
+############
+
+option(ENABLE_TBB "Enable Intel TBB" off)
+if (ENABLE_TBB)
+    FetchContent_Declare(
+            tbb URL https://github.com/wjakob/tbb/archive/806df70ee69fc7b332fcf90a48651f6dbf0663ba.tar.gz
+            URL_HASH MD5=63fda89e88d34da63ddcef472e7725ef
+    )
+    if (NOT tbb_POPULATED)
+        FetchContent_Populate(tbb)
+        add_subdirectory(${tbb_SOURCE_DIR} ${tbb_BINARY_DIR})
+        set_target_properties(tbb_static PROPERTIES COMPILE_FLAGS "-w")
+        include_directories(SYSTEM ${tbb_SOURCE_DIR}/include)
+        target_link_libraries(project_options INTERFACE tbb_static)
+    endif ()
+endif ()
+
+############
 # NANOBENCH
 ############
 

--- a/docs/_docs/install.md
+++ b/docs/_docs/install.md
@@ -74,6 +74,7 @@ CMake Option                         | Description
 `-DENABLE_TESTS=ON`                  | Enable unittesting
 `-DENABLE_PYTHON=ON`                 | Build python bindings (experimental)
 `-DENABLE_FREESASA=ON`               | Enable SASA routines (external download)
+`-DENABLE_TBB=OFF`                   | Build with Intel Threading Building Blocks (experimental)
 `-DBUILD_STATIC=OFF`                 | Build statically linked binaries
 `-DCMAKE_BUILD_TYPE=RelWithDebInfo`  | Alternatives: `Debug` or `Release` (faster, adventurous)
 `-DCMAKE_CXX_FLAGS_RELEASE="..."`    | Compiler options for Release mode
@@ -82,6 +83,7 @@ CMake Option                         | Description
 `-DPYTHON_EXECUTABLE="..."`          | Full path to Python executable
 `-DPYTHON_INCLUDE_DIR="..."`         | Full path to python headers
 `-DPYTHON_LIBRARY="..."`             | Full path to python library, i.e. libpythonX.dylib/so
+
 
 ### Compiling the Manual
 

--- a/src/energy.h
+++ b/src/energy.h
@@ -13,6 +13,10 @@
 #include <freesasa.h>
 #endif
 
+#ifdef __cpp_lib_parallel_algorithm
+#include <execution>
+#endif
+
 namespace Faunus {
 
 namespace ReactionCoordinate {


### PR DESCRIPTION
If `ENABLE_TBB`, Intel's threading building blocks is downloaded and linked to all faunus targets. This enables the use of parallel `std::execution` policies currently available in GCC 9.1 and onwards. As exemplified in `src/energy.h`, a macro can be used to deternine if parallel execution is supported by the compiler. The linked TBB is a clone, currently of TBB 2020.2 with added CMake build, which enables simple download from our build system.

- [ ] Anything else we want to add at this time? Many energy functions have been converted to parallel STL in [this branch](/mlund/faunus/tree/parallel-algorithm-energy)
- [ ] Add thrust to the build system? Currently only random access iterators are supported (i.e. _not_ `ranges`): https://developer.nvidia.com/blog/accelerating-standard-c-with-gpus-using-stdpar/
