### PR TITLE
Allow cuboids in scattering analysis

### DIFF
--- a/docs/_docs/analysis.md
+++ b/docs/_docs/analysis.md
@@ -191,7 +191,7 @@ S(q) = \frac{1}{N} \left <
 $$
 
 The sampled $q$-interval is always $\left [ 2\pi/L,\, 2\pi p\_{max} \sqrt{3} / L \right ]$,
-$L$ being the box side length. Currently only cubic boxes are supported.
+$L$ being the box side length. Only cubic boxes have been tested, but the implementation respects cuboidal systems (untested).
 For more information, see [doi:10.1063/1.449987](http://dx.doi.org/10.1063/1.449987).
 
 

--- a/src/analysis.cpp
+++ b/src/analysis.cpp
@@ -1448,12 +1448,12 @@ void ScatteringFunction::_sample() {
             IO::write(filename + "." + suffix, debye->getIntensity());
         break;
     case EXPLICIT_PBC:
-        explicit_average_pbc->sample(p, spc.geo.getLength().x());
+        explicit_average_pbc->sample(p, spc.geo.getLength());
         if (save_after_sample)
             IO::write(filename + "." + suffix, explicit_average_pbc->getSampling());
         break;
     case EXPLICIT_IPBC:
-        explicit_average_ipbc->sample(p, spc.geo.getLength().x());
+        explicit_average_ipbc->sample(p, spc.geo.getLength());
         if (save_after_sample)
             IO::write(filename + "." + suffix, explicit_average_ipbc->getSampling());
         break;

--- a/src/scatter.cpp
+++ b/src/scatter.cpp
@@ -12,7 +12,7 @@ using doctest::Approx;
 TEST_CASE_TEMPLATE("[Faunus] StructureFactorPBC", T, StructureFactorPBC<float, SIMD>, StructureFactorPBC<float, EIGEN>,
                    StructureFactorPBC<float, GENERIC>) {
     size_t cnt = 0;
-    double box = 80;
+    Point box = {80.0, 80.0, 80.0};
     const std::vector<Point> positions = {
         {10, 20, 30},  {-32, 19, 1},  {34, -2, 23}, {0, 0, 1},     {25, 0, -12},
         {-6, -4, -29}, {-12, 23, -3}, {3, 1, -4},   {-31, 29, -20}}; // random position vector
@@ -30,10 +30,10 @@ TEST_CASE_TEMPLATE("[Faunus] StructureFactorPBC", T, StructureFactorPBC<float, S
 
 #ifdef ANKERL_NANOBENCH_H_INCLUDED
 TEST_CASE("Benchmark") {
-    double box = 80;
+    Point box = {80.0, 80.0, 80.0};
     std::vector<Point> pos(1000);
     for (auto &p : pos)
-        p = Eigen::Vector3d::Random() * box;
+        p = Eigen::Vector3d::Random() * box.x();
     ankerl::nanobench::Config bench;
     bench.minEpochIterations(100);
     bench.run("SIMD", [&] { StructureFactorPBC<double, SIMD>(10).sample(pos, box); }).doNotOptimizeAway();
@@ -44,7 +44,7 @@ TEST_CASE("Benchmark") {
 
 TEST_CASE("[Faunus] StructureFactorIPBC") {
     size_t cnt = 0;
-    double box = 80;
+    Point box = {80.0, 80.0, 80.0};
     const std::vector<Point> positions = {
         {10, 20, 30},  {-32, 19, 1},  {34, -2, 23}, {0, 0, 1},     {25, 0, -12},
         {-6, -4, -29}, {-12, 23, -3}, {3, 1, -4},   {-31, 29, -20}}; // random position vector

--- a/src/scatter.h
+++ b/src/scatter.h
@@ -270,13 +270,13 @@ class StructureFactorPBC : private TSamplingPolicy {
   public:
     StructureFactorPBC(int q_multiplier) : p_max(q_multiplier){}
 
-    template <class Tpositions> void sample(const Tpositions &positions, const double boxlength) {
+    template <class Tpositions> void sample(const Tpositions &positions, const Point &boxlength) {
         // https://gcc.gnu.org/gcc-9/porting_to.html#ompdatasharing
         // #pragma omp parallel for collapse(2) default(none) shared(directions, p_max, boxlength) shared(positions)
         #pragma omp parallel for collapse(2) default(shared)
         for (int i = 0; i < directions.size(); ++i) {
-            for (int p = 1; p <= p_max; ++p) {                                // loop over multiples of q
-                const Point q = (2 * pc::pi * p / boxlength) * directions[i]; // scattering vector
+            for (int p = 1; p <= p_max; ++p) {                                         // loop over multiples of q
+                const Point q = 2.0 * pc::pi * directions[i].cwiseQuotient(boxlength); // scattering vector
                 T sum_sin = 0.0;
                 T sum_cos = 0.0;
                 if constexpr (method == SIMD) {
@@ -343,13 +343,13 @@ template <typename T = float, typename TSamplingPolicy = SamplingPolicy<T>> clas
   public:
     explicit StructureFactorIPBC(int q_multiplier) : p_max(q_multiplier) {}
 
-    template <class Tpositions> void sample(const Tpositions &positions, const double boxlength) {
+    template <class Tpositions> void sample(const Tpositions &positions, const Point &boxlength) {
         // https://gcc.gnu.org/gcc-9/porting_to.html#ompdatasharing
         // #pragma omp parallel for collapse(2) default(none) shared(directions, p_max, positions, boxlength)
         #pragma omp parallel for collapse(2) default(shared)
         for (size_t i = 0; i < directions.size(); ++i) {
-            for (int p = 1; p <= p_max; ++p) {                                // loop over multiples of q
-                const Point q = (2 * pc::pi * p / boxlength) * directions[i]; // scattering vector
+            for (int p = 1; p <= p_max; ++p) {                                             // loop over multiples of q
+                const Point q = 2.0 * pc::pi * p * directions[i].cwiseQuotient(boxlength); // scattering vector
                 T sum_cos = 0;
                 for (auto &r : positions) { // loop over positions
                     // if q[i] == 0 then its cosine == 1 hence we can avoid cosine computation for performance reasons

--- a/src/scatter.h
+++ b/src/scatter.h
@@ -276,7 +276,7 @@ class StructureFactorPBC : private TSamplingPolicy {
         #pragma omp parallel for collapse(2) default(shared)
         for (int i = 0; i < directions.size(); ++i) {
             for (int p = 1; p <= p_max; ++p) {                                         // loop over multiples of q
-                const Point q = 2.0 * pc::pi * directions[i].cwiseQuotient(boxlength); // scattering vector
+                const Point q = 2.0 * pc::pi * p * directions[i].cwiseQuotient(boxlength); // scattering vector
                 T sum_sin = 0.0;
                 T sum_cos = 0.0;
                 if constexpr (method == SIMD) {


### PR DESCRIPTION
This allow non-cubic systems in scattering analysis. This is needed for future implementation if scattering calculation in e.g. hexagonal geometries mapped onto a cuboid.