### PR TITLE
Trajectory replay move

### DIFF
--- a/cmake/ExternalTools.cmake
+++ b/cmake/ExternalTools.cmake
@@ -220,9 +220,9 @@ endif()
 ExternalProject_Add(
     project_xdrfile
     PREFIX "${CMAKE_CURRENT_BINARY_DIR}/_deps"
-    URL "https://github.com/wesbarnett/libxdrfile/archive/2.1.2.tar.gz"
-    URL_MD5 ee114404b4a01613b2f0167a2ad92536
-    PATCH_COMMAND echo "add_library(xdrfile-static STATIC \${SRCS})" >> CMakeLists.txt
+    URL "https://github.com/chemfiles/xdrfile/archive/8935d749e1f43a87221089588d1cc3f37a0354b0.tar.gz"
+    URL_HASH SHA256=a5530703fd07a5baadc9ba75d806fe0844d7b3da0e16f5adbb966660a1cd6828
+    PATCH_COMMAND patch -p1 < ${CMAKE_SOURCE_DIR}/cmake/patches/xdrfile-01.patch
     BUILD_COMMAND ${CMAKE_MAKE_PROGRAM} xdrfile-static
     UPDATE_DISCONNECTED ON
     CMAKE_ARGS -Wno-dev -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER} -DCMAKE_POSITION_INDEPENDENT_CODE=on

--- a/cmake/patches/xdrfile-01.patch
+++ b/cmake/patches/xdrfile-01.patch
@@ -1,0 +1,33 @@
+diff -ur a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt	2019-10-08 15:25:04.000000000 +0200
++++ b/CMakeLists.txt	2020-10-02 11:40:54.497805838 +0200
+@@ -27,6 +27,9 @@
+ add_library(xdrfile OBJECT ${SOURCES})
+ target_include_directories(xdrfile PUBLIC include)
+ 
++add_library(xdrfile-static STATIC ${SOURCES})
++target_include_directories(xdrfile-static PUBLIC include)
++
+ if (${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
+     enable_testing()
+ 
+diff -ur a/src/xdrfile.c b/src/xdrfile.c
+--- a/src/xdrfile.c	2019-10-08 15:25:04.000000000 +0200
++++ b/src/xdrfile.c	2020-10-02 12:15:30.569318639 +0200
+@@ -2012,6 +2012,8 @@
+ /*
+  * Ops vector for stdio type XDR
+  */
++#pragma GCC diagnostic push
++#pragma GCC diagnostic ignored "-Wincompatible-pointer-types"
+ static const struct xdr_ops xdrstdio_ops = {
+     xdrstdio_getlong,  /* deserialize a long int */
+     xdrstdio_putlong,  /* serialize a long int */
+@@ -2021,6 +2023,7 @@
+     xdrstdio_setpos,   /* set offset in the stream */
+     xdrstdio_destroy,  /* destroy stream */
+ };
++#pragma GCC diagnostic pop
+ 
+ /*
+  * Initialize a stdio xdr stream.

--- a/docs/_docs/moves.md
+++ b/docs/_docs/moves.md
@@ -309,3 +309,13 @@ For more information, see the Topology section and [doi:10/fqcpg3](https://doi.o
 --------------- | ----------------------------------
 `repeat=1`      |  Average number of moves per sweep
 
+### Replay
+
+`replay`         | Description
+---------------- | ----------------------------
+`file`           | Trajectory to read (xtc)
+
+Use a next frame of the recorded trajectory as a move. The move is always unconditionally accepted,
+hence it may be used to replay a simulation, e.g., for analysis. Currently only Gromacs compressed
+trajectory file format (XTC) is supported. Note that total number of steps (macro × micro) should
+correspond to the number of frames in the trajectory.

--- a/docs/schema.yml
+++ b/docs/schema.yml
@@ -749,6 +749,17 @@ properties:
                         repeat: {type: integer}
                     additionalProperties: false
                     type: object
+
+                replay:
+                    properties:
+                        file:
+                            type: string
+                            pattern: "(.*?)\\.(xtc)$"
+                            description: An XTC file with the trajectory to replay
+                    required: [file]
+                    additionalProperties: false
+                    type: object
+
          
     analysis:
         type: array

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(EXAMPLES_DIR ${CMAKE_SOURCE_DIR}/examples)
 set(YASON ${CMAKE_SOURCE_DIR}/scripts/yason.py)
 set(JSON_COMPARE ${CMAKE_SOURCE_DIR}/scripts/jsoncompare.py)
+set(CSV_COMPARE ${CMAKE_SOURCE_DIR}/scripts/csvcompare.py)
 
 add_test(
         NAME unittests
@@ -161,6 +162,16 @@ add_test(
     | $<TARGET_FILE:faunus> --quiet --state bulk.state.json\
     ; ${PYTHON_EXECUTABLE} ${JSON_COMPARE} bulk.out.json out.json --tol 0.05"
         WORKING_DIRECTORY ${EXAMPLES_DIR}/bulk)
+set_property(TEST bulk PROPERTY FIXTURES_SETUP bulk)
+
+add_test(
+        NAME bulk-replay
+        COMMAND sh -c "${PYTHON_EXECUTABLE} ${YASON} bulk-replay.yml\
+    | $<TARGET_FILE:faunus> --quiet \
+    ; diff -q ../bulk/traj.xtc traj.xtc \
+    && ${CSV_COMPARE} -q --tol 0.04 --small 0.1 ../bulk/rdf.dat rdf.dat"
+        WORKING_DIRECTORY ${EXAMPLES_DIR}/bulk-replay)
+set_property(TEST bulk-replay PROPERTY FIXTURES_REQUIRED bulk)
 
 add_test(
         NAME seawater
@@ -185,6 +196,7 @@ add_test(
 install(FILES
         ${EXAMPLES_DIR}/README.md
         ${EXAMPLES_DIR}/bulk/bulk.yml
+        ${EXAMPLES_DIR}/bulk-replay/bulk-replay.yml
         ${EXAMPLES_DIR}/cluster/cluster.yml
         ${EXAMPLES_DIR}/cluster/cluster.agr
         ${EXAMPLES_DIR}/cluster/cluster.out.json

--- a/examples/bulk-replay/bulk-replay.yml
+++ b/examples/bulk-replay/bulk-replay.yml
@@ -1,0 +1,20 @@
+#!/usr/bin/env yason.py
+temperature: 1100
+mcloop: {macro: 10, micro: 1}
+geometry: {type: cuboid, length: 42.5}
+energy:
+    - nonbonded_coulomblj:
+        lennardjones: {mixing: LB}
+        coulomb: {type: fanourgakis, epsr: 1, cutoff: 14}
+atomlist:
+    - Na: {q:  1.0, sigma: 3.33, eps: 0.01158968, dp: 1.0} 
+    - Cl: {q: -1.0, sigma: 4.4, eps: 0.4184, dp: 0.5} 
+moleculelist:
+    - salt: {atoms: [Na,Cl], atomic: true}
+insertmolecules:
+    - salt: {N: 1152}
+moves:
+    - replay: {file: ../bulk/traj.xtc}
+analysis:
+    - atomrdf: {file: rdf.dat, nstep: 1, dr: 0.1, name1: Na, name2: Cl}
+    - xtcfile: {file: traj.xtc, nstep: 1}

--- a/scripts/csvcompare.py
+++ b/scripts/csvcompare.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+
+import sys
+
+if sys.version_info < (3, 0):
+    sys.stdout.write("Sorry, Python 3 og higher required\n")
+    sys.exit(1)
+
+import argparse, pandas
+from math import fabs
+
+parser = argparse.ArgumentParser(description='Numerically compare two CSV files')
+parser.add_argument('--tol', default=0.02, type=float, help='relative error tolerance (default: 0.02)')
+parser.add_argument('--small', default=1e-10, type=float, help='always equal if difference is smaller than this (default: 1e-10)')
+parser.add_argument('--quiet', '-q', dest='quiet', action='store_true', help='less output')
+parser.add_argument('--csv_sep', default=' ', help='CSV separator (default: " ")')
+parser.add_argument('file_ref', help='reference file')
+parser.add_argument('file_new', help='new file')
+args = parser.parse_args()
+
+returncode = 0
+
+def isapprox(a, b):
+    return fabs(a - b) < args.small or fabs(a - b) < args.tol * fabs(a)
+
+def isnumber(val):
+    ''' filter to compare only ints and floats '''
+    return isinstance(val, float) or isinstance(val, int)
+
+def compare(a, b):
+    ''' compare ints and floats to relative tolerence '''
+    if isnumber(a) and isnumber(b):
+        return isapprox(a, b)
+    else:
+        return a == b
+
+dfs = [pandas.read_csv(f, sep=args.csv_sep, header=None) for f in (args.file_ref, args.file_new)]
+
+if len(dfs) == 2:
+    for (ref_col_name, ref_col), (new_col_name, new_col) in zip(*(df.iteritems() for df in dfs)):
+        for ref_val, new_val in zip(ref_col, new_col):
+            if not compare(ref_val, new_val):
+                if returncode == 0:
+                    returncode = 1
+                if not args.quiet:
+                    print('mismatch in col {:2d} {} {}'.format(ref_col_name, ref_val, new_val))
+else:
+    returncode = 2
+
+sys.exit(returncode)

--- a/src/analysis.cpp
+++ b/src/analysis.cpp
@@ -962,13 +962,14 @@ XTCtraj::XTCtraj(const json &j, Space &s) : filter([](Particle &) { return true;
 }
 
 void XTCtraj::_to_json(json &j) const {
-    j["file"] = file;
+    j["file"] = writer->filename;
     if (not names.empty())
         j["molecules"] = names;
 }
 
 void XTCtraj::_from_json(const json &j) {
-    file = MPI::prefix + j.at("file").get<std::string>();
+    auto file = MPI::prefix + j.at("file").get<std::string>();
+    writer = std::make_shared<XTCWriter>(file);
 
     // By default, *all* active and inactive groups are saved,
     // but here allow for a user defined list of molecule ids
@@ -990,14 +991,14 @@ void XTCtraj::_from_json(const json &j) {
 }
 
 void XTCtraj::_sample() {
-    xtc.setLength(spc.geo.getLength()); // set box dimensions for frame
     // On some gcc/clang and certain ubuntu/macos combinations,
     // the ranges::view::filter(rng,unaryp) clears the `filter` function.
     // Using the ranges piping seem to solve the issue.
     assert(filter);
-    auto particles = spc.p | ranges::cpp20::views::filter(filter);
+    auto coordinates = spc.p | ranges::cpp20::views::filter(filter) |
+                       ranges::cpp20::views::transform([](auto &particle) -> Point & { return particle.pos; });
     assert(filter);
-    xtc.save(file, particles.begin(), particles.end());
+    writer->writeNext(spc.geo.getLength(), coordinates.begin(), coordinates.end());
 }
 
 // =============== MultipoleDistribution ===============

--- a/src/analysis.h
+++ b/src/analysis.h
@@ -348,16 +348,12 @@ class XTCtraj : public Analysisbase {
     std::vector<int> molids;        // molecule ids to save to disk
     std::vector<std::string> names; // molecule names of above
     std::function<bool(Particle &)> filter; // function to filter molecule ids
+    Space &spc;
+    std::shared_ptr<XTCWriter> writer;
 
     void _to_json(json &) const override;
     void _from_json(const json &) override;
-
-    FormatXTC xtc;
-    Space &spc;
-    std::string file;
-
     void _sample() override;
-
   public:
     XTCtraj(const json &j, Space &s);
 };

--- a/src/geometry.h
+++ b/src/geometry.h
@@ -341,7 +341,7 @@ class Chameleon : public GeometryBase {
     double getVolume(int dim = 3) const override;
     Point setVolume(double, VolumeMethod = ISOTROPIC) override;
     Point getLength() const override; //!< A minimal containing cubic box.
-    // setLength() needed only for IO::FormatXTC::loadnextframe().
+    // setLength() needed only for Move::ReplayMove (stems from IO::XTCReader).
     void setLength(const Point &);                            //!< Sets the box dimensions.
     void boundary(Point &) const override;                    //!< Apply boundary conditions
     Point vdist(const Point &, const Point &) const override; //!< (Minimum) distance between two points

--- a/src/space.h
+++ b/src/space.h
@@ -104,6 +104,11 @@ class Space {
         return ranges::cpp20::views::transform(p, [](auto &i) -> const Point & { return i.pos; });
     }
 
+    //! Mutable iterable range of all particle positions
+    auto positions() {
+        return ranges::cpp20::views::transform(p, [](auto &i) -> Point & { return i.pos; });
+    }
+
     /**
      * @brief Finds all groups of type `molid` (complexity: order N)
      * @param molid Molecular id to look for


### PR DESCRIPTION
# Description

* Refactor XTCReader and XTCWriter
* Add ReplayMove (stub)

A preview of mentioned features. Comments welcome.

The external xdrfile library has had to be patched. I have placed patches in `cmake/patches` and changed `CMakeLists.txt` accordingly.

## Checklist

- [ ] `make test` passes with no errors
- [ ] the source code is well documented
- [ ] new functionality includes unittests
- [ ] the user-manual has been updated to reflect the changes
- [ ] I have installed the provided commit hook to auto-format commits (requires `clang-format`):

  ``` bash
  ./scripts/git-pre-commit-format install
  ```

- [ ] code naming scheme follows the convention:

  Style        | Elements
  ------------ | ---------------------
  `PascalCase` | classes, namespaces
  `camelCase`  | functions
  `snake_case` | variables
