### PR TITLE
Binary search for bond search in Bonded energy

### DIFF
--- a/src/energy.cpp
+++ b/src/energy.cpp
@@ -677,20 +677,7 @@ double Bonded::sum_energy(const Bonded::BondVector &bonds) const {
     }
     return energy;
 }
-double Bonded::sum_energy(const Bonded::BondVector &bonds, const std::vector<int> &particles_ndx) const {
-    double energy = 0;
-    // outer loop over bonds to ensure that each bond is counted at most once
-    for (const auto &bond : bonds) {
-        for (const auto particle_ndx : particles_ndx) {
-            if (std::find(bond->index.begin(), bond->index.end(), particle_ndx) != bond->index.end()) {
-                assert(bond->hasEnergyFunction());
-                energy += bond->energyFunc(spc.geo.getDistanceFunc());
-                break; // count each interaction at most once
-            }
-        }
-    }
-    return energy;
-}
+
 Bonded::Bonded(const json &j, Space &spc) : spc(spc) {
     name = "bonded";
     update_intra();
@@ -730,13 +717,12 @@ double Bonded::energy(Change &change) {
                         if (not spc.groups[changed.index].empty())
                             energy += sum_energy(intra_group);
                     } else { // only partial update of affected atoms
-                        std::vector<int> atoms_ndx;
                         // an offset is the index of the first particle in the group
                         const int offset = std::distance(spc.p.begin(), spc.groups[changed.index].begin());
                         // add an offset to the group atom indices to get the absolute indices
-                        std::transform(changed.atoms.begin(), changed.atoms.end(), std::back_inserter(atoms_ndx),
-                                       [offset](int i) { return i + offset; });
-                        energy += sum_energy(intra_group, atoms_ndx);
+                        auto particle_indices =
+                            changed.atoms | ranges::cpp20::views::transform([offset](auto i) { return i + offset; });
+                        energy += sum_energy(intra_group, particle_indices);
                     }
                 }
             }

--- a/src/energy.h
+++ b/src/energy.h
@@ -274,7 +274,7 @@ class Bonded : public Energybase {
      */
     template <class RangeOfIndex>
     double sum_energy(const Bonded::BondVector &bonds, const RangeOfIndex &indices_of_particles) const {
-        assert(std::is_sorted(indices_of_particles));
+        assert(std::is_sorted(indices_of_particles.begin(), indices_of_particles.end()));
 
         auto bond_filter = [&](const auto &bond_ptr) { // determine if bond is part of indices of particles
             for (auto index : bond_ptr->index) {

--- a/src/energy.h
+++ b/src/energy.h
@@ -8,6 +8,7 @@
 #include <range/v3/view.hpp>
 #include <Eigen/Dense>
 #include <spdlog/spdlog.h>
+#include <numeric>
 
 #ifdef ENABLE_FREESASA
 #include <freesasa.h>

--- a/src/energy.h
+++ b/src/energy.h
@@ -274,7 +274,7 @@ class Bonded : public Energybase {
     double sum_energy(const Bonded::BondVector &bonds, const RangeOfIndex &indices_of_particles) const {
         assert(std::is_sorted(indices_of_particles));
 
-        auto bond_filter = [&](const auto bond_ptr) { // determine if bond is part of indices of particles
+        auto bond_filter = [&](const auto &bond_ptr) { // determine if bond is part of indices of particles
             for (auto index : bond_ptr->index) {
                 if (std::binary_search(indices_of_particles.begin(), indices_of_particles.end(), index)) {
                     return true;
@@ -285,7 +285,7 @@ class Bonded : public Energybase {
         auto affected_bonds = bonds | ranges::cpp20::views::filter(bond_filter);
 
         return std::transform_reduce(affected_bonds.begin(), affected_bonds.end(), 0.0, std::plus<>(),
-                                     [&](auto bond_ptr) -> double {
+                                     [&](const auto &bond_ptr) {
                                          assert(bond_ptr->hasEnergyFunction());
                                          return bond_ptr->energyFunc(spc.geo.getDistanceFunc());
                                      });

--- a/src/energy.h
+++ b/src/energy.h
@@ -285,11 +285,20 @@ class Bonded : public Energybase {
         };
         auto affected_bonds = bonds | ranges::cpp20::views::filter(bond_filter);
 
+#if (defined(__clang__) && __clang_major__ >= 10) || (defined(__GNUC__) && __GNUC__ >= 9 && __GNUC_MINOR__ >= 3)
         return std::transform_reduce(affected_bonds.begin(), affected_bonds.end(), 0.0, std::plus<>(),
                                      [&](const auto &bond_ptr) {
                                          assert(bond_ptr->hasEnergyFunction());
                                          return bond_ptr->energyFunc(spc.geo.getDistanceFunc());
                                      });
+#else
+        double energy = 0.0;
+        for (const auto &bond_ptr : affected_bonds) {
+            assert(bond_ptr->hasEnergyFunction());
+            energy += bond_ptr->energyFunc(spc.geo.getDistanceFunc());
+        }
+        return energy;
+#endif
     }
 
   public:

--- a/src/energy.h
+++ b/src/energy.h
@@ -9,6 +9,7 @@
 #include <Eigen/Dense>
 #include <spdlog/spdlog.h>
 #include <numeric>
+#include <algorithm>
 
 #ifdef ENABLE_FREESASA
 #include <freesasa.h>

--- a/src/energy.h
+++ b/src/energy.h
@@ -284,10 +284,11 @@ class Bonded : public Energybase {
         };
         auto affected_bonds = bonds | ranges::cpp20::views::filter(bond_filter);
 
-        return std::accumulate(affected_bonds.begin(), affected_bonds.end(), 0.0, [&](auto energy_sum, auto bond_ptr) {
-            assert(bond_ptr->hasEnergyFunction());
-            return energy_sum += bond_ptr->energyFunc(spc.geo.getDistanceFunc());
-        });
+        return std::transform_reduce(affected_bonds.begin(), affected_bonds.end(), 0.0, std::plus<>(),
+                                     [&](auto bond_ptr) -> double {
+                                         assert(bond_ptr->hasEnergyFunction());
+                                         return bond_ptr->energyFunc(spc.geo.getDistanceFunc());
+                                     });
     }
 
   public:

--- a/src/energy.h
+++ b/src/energy.h
@@ -277,7 +277,6 @@ class Bonded : public Energybase {
         assert(std::is_sorted(indices_of_particles.begin(), indices_of_particles.end()));
 
         auto bond_filter = [&](const auto &bond_ptr) { // determine if bond is part of indices of particles
-            return false;
             for (auto index : bond_ptr->index) {
                 if (std::binary_search(indices_of_particles.begin(), indices_of_particles.end(), index)) {
                     return true;
@@ -289,7 +288,7 @@ class Bonded : public Energybase {
 
         auto bond_energy = [&](const auto &bond_ptr) { return bond_ptr->energyFunc(spc.geo.getDistanceFunc()); };
 
-#if (defined(__clang__) && __clang_major__ >= 10) || (defined(__GNUC__) && __GNUC__ >= 9 && __GNUC_MINOR__ >= 3)
+#if (defined(__clang__) && __clang_major__ >= 10) || (defined(__GNUC__) && __GNUC__ >= 10)
         return std::transform_reduce(affected_bonds.begin(), affected_bonds.end(), 0.0, std::plus<>(), bond_energy);
 #else
         double energy = 0.0;

--- a/src/energy.h
+++ b/src/energy.h
@@ -270,7 +270,7 @@ class Bonded : public Energybase {
      *
      * To speed up the bond search, the given indices must be ordered which allows
      * for binary search which on large systems provides superior performance compared
-     * to simplistic search which scales with number of bonds as O(N^2).
+     * to simplistic search which scales as number_of_bonds x number_of_moved_particles
      */
     template <class RangeOfIndex>
     double sum_energy(const Bonded::BondVector &bonds, const RangeOfIndex &indices_of_particles) const {


### PR DESCRIPTION
When only a subset of particles are moved, the previous algorithm would be of complexity O(N^2). For large polymers this could be a significant bottle-neck. Here we exploit that the list of changed particle index are _sorted_, allowing for binary search. 10-100 times speedup has been observed for large polymers.
