### PR TITLE
Celllist preparation

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -178,7 +178,7 @@ add_test(
         COMMAND sh -c "${PYTHON_EXECUTABLE} ${YASON} bulk-replay.yml\
     | $<TARGET_FILE:faunus> --quiet \
     ; diff -q ../bulk/traj.xtc traj.xtc \
-    && ${CSV_COMPARE} -q --tol 0.04 --small 0.1 ../bulk/rdf.dat rdf.dat"
+    && ${CSV_COMPARE} -q --tol 0.05 --small 0.1 ../bulk/rdf.dat rdf.dat"
         WORKING_DIRECTORY ${EXAMPLES_DIR}/bulk-replay)
 set_property(TEST bulk-replay PROPERTY FIXTURES_REQUIRED bulk)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -67,7 +67,7 @@ set(hdrs analysis.h average.h atomdata.h auxiliary.h bonds.h chainmove.h cluster
         aux/eigen_cerealisation.h aux/eigensupport.h aux/iteratorsupport.h aux/multimatrix.h
         aux/eigen_cerealisation.h aux/eigensupport.h aux/equidistant_table.h aux/error_function.h
         aux/exp_function.h aux/invsqrt_function.h aux/iteratorsupport.h aux/legendre.h aux/multimatrix.h
-        aux/pairmatrix.h aux/pow_function.h aux/table_1d.h aux/table_2d.h aux/timers.h)
+        aux/pairmatrix.h aux/pow_function.h aux/table_1d.h aux/table_2d.h aux/timers.h aux/typeerasure.h)
 
 set_source_files_properties(${objs} PROPERTIES LANGUAGE CXX)
 

--- a/src/analysis.cpp
+++ b/src/analysis.cpp
@@ -226,7 +226,7 @@ SaveState::SaveState(json j, Space &spc) {
                 json j;
                 Faunus::to_json(j, spc);
                 if (save_random_number_generator_state) {
-                    j["random-move"] = Move::Movebase::slump;
+                    j["random-move"] = Move::MoveBase::slump;
                     j["random-global"] = Faunus::random;
                 }
                 f << std::setw(2) << j;
@@ -238,7 +238,7 @@ SaveState::SaveState(json j, Space &spc) {
                 json j;
                 Faunus::to_json(j, spc);
                 if (save_random_number_generator_state) {
-                    j["random-move"] = Move::Movebase::slump;
+                    j["random-move"] = Move::MoveBase::slump;
                     j["random-global"] = Faunus::random;
                 }
                 auto v = json::to_ubjson(j); // json --> binary

--- a/src/aux/typeerasure.h
+++ b/src/aux/typeerasure.h
@@ -1,0 +1,186 @@
+#pragma once
+#include <memory>
+
+namespace Faunus {
+/**
+ * @namespace Type Erasure
+ *
+ * Class templates to assist implementing the type erasure pattern. The pairwise composition of concepts is also
+ * supported.
+ *
+ * Type erasure pattern in general
+ * https://www.modernescpp.com/index.php/c-core-guidelines-type-erasure-with-templates
+ * This particular implementation was inspired by
+ * https://aherrmann.github.io/programming/2014/10/19/type-erasure-with-merged-concepts/
+ *
+ * Basic agents are
+ * - Concept – an interface
+ * - Model – a wrapper implementing Concept
+ * - Holder – a simple storage of an instance of a concrete implementation of Concept
+ * - Container – a Model stored in an appropriate Holder
+ * - Specification – a structure providing Concept, Model and Interface provided by the programmer
+ * - TypeErasure – a template directing the type erasure composition from a specification
+ * - MergeSpecifications – a template to combine two specifications into one
+ *
+ * @paragraph Example
+ *
+ * @code
+ * struct PrintableSpecification {
+ *    struct Concept {
+ *        virtual ~Concept() = default;
+ *        virtual void print() const = 0;
+ *    };
+ *
+ *    template <class Holder>
+ *    struct Model : public Holder, public virtual Concept {
+ *        using Holder::Holder;
+ *        void print() const override {
+ *            Holder::get().print();
+ *        };
+ *    };
+ *
+ *    template <class Container>
+ *    struct Interface : public Container {
+ *        using Container::Container;
+ *        void print() const {
+ *            Container::get().print();
+ *        };
+ *    };
+ * };
+ * using PrintableType = TypeErasure::TypeErasure<PrintableSpecification>
+ * using PrintableExportableType =
+ *       TypeErasure::TypeErasure<TypeErasure::MergeSpecifications<PrintableSpecification, ExportableSpecification>>
+ * @endcode
+ *
+ * @brief Class templates to assist implementing the type erasure pattern.
+ */
+namespace TypeErasure {
+/**
+ * @brief Internal templates and class templates.
+ */
+namespace Internal {
+/**
+ * @brief A universal storage of the concrete implementation with the move semantic in the constructor.
+ * @tparam TImplementation  a concrete implementation of the required interface
+ */
+template <class TImplementation> class Holder {
+  public:
+    using Implementation = TImplementation;
+
+    Holder(TImplementation implementation) : implementation(std::move(implementation)) {}
+    virtual ~Holder() = default;
+    TImplementation &get() { return implementation; }
+    const TImplementation &get() const { return implementation; }
+
+  private:
+    TImplementation implementation;
+};
+
+/**
+ * @brief A universal storage of a reference to the concrete implementation.
+ * @tparam TImplementation  a concrete implementation of the required interface
+ */
+template <class TImplementation> class ReferenceHolder {
+  public:
+    using Implementation = TImplementation;
+
+    ReferenceHolder(TImplementation &implementation) : implementation(implementation) {}
+    virtual ~ReferenceHolder() = default;
+    TImplementation &get() { return implementation; }
+    const TImplementation &get() const { return implementation; }
+
+  private:
+    TImplementation &implementation;
+};
+
+/**
+ * @brief A container storing a model representing an particular concept in an appropriate holder.
+ * @tparam TConcept  concept ecapsulated by the container
+ * @tparam TModel  model template
+ */
+template <class TConcept, template <class> class TModel> // template template sytax for TModel<...>
+class Container {
+  public:
+    using Concept = TConcept;
+
+    /**
+     * @brief Passes the implementation instance to the storage as an r-value reference using the move semantic.
+     * @tparam TImplementation  a concrete implementation of the required interface
+     * @param implementation  an implementation as an r-value, e.g., std::move(implementation)
+     */
+    template <class TImplementation>
+    Container(TImplementation &&implementation)
+        : self_ptr(std::make_shared<TModel<Holder<TImplementation>>>(std::move(implementation))) {}
+
+    /**
+     * @brief Passes the implementation instance to the storage as an l-value reference.
+     * @tparam TImplementation  a concrete implementation of the required interface
+     * @param implementation  an implementation as an l-value
+     */
+    template <class TImplementation>
+    Container(TImplementation &implementation)
+        : self_ptr(std::make_shared<TModel<ReferenceHolder<TImplementation>>>(implementation)) {}
+
+    const Concept &get() const { return *self_ptr; }
+    Concept &get() { return *self_ptr; }
+
+  private:
+    std::shared_ptr<Concept> self_ptr;
+    //std::shared_ptr<const Concept> self_ptr;
+};
+
+/**
+ * @paragraph Helpers for extracting specification parts.
+ */
+//! @brief Extracts the concept type from the specification.
+template <class TSpecification> using ConceptOf = typename TSpecification::Concept;
+//! @brief Extracts the model type (including its holder type) from the specification.
+template <class TSpecification, class THolder> using ModelOf = typename TSpecification::template Model<THolder>;
+//! @brief Extracts the interface type from the specification.
+template <class TSpecification, class TContainer>
+using InterfaceOf = typename TSpecification::template Interface<TContainer>;
+//! @brief Extracts the cotainer type from the specification.
+template <class TSpecification>
+using ContainerOf = Container<typename TSpecification::Concept, TSpecification::template Model>;
+} // namespace Internal
+
+/**
+ * @brief Creates a type erasure type from the specification.
+ *
+ * @tparam TSpecification  specification of the concept, model and interface
+ */
+template <class TSpecification>
+class TypeErasure : public Internal::InterfaceOf<TSpecification, Internal::ContainerOf<TSpecification>> {
+    using Base = Internal::InterfaceOf<TSpecification, Internal::ContainerOf<TSpecification>>;
+
+  public:
+    using Base::Base; // include parent constructor
+    using Specification = TSpecification;
+};
+
+/**
+ * @brief Merges two specification together.
+ * @tparam TSpecificationA the first specification
+ * @tparam TSpecificationB the other specification
+ */
+template <class TSpecificationA, class TSpecificationB> struct MergeSpecifications {
+    struct Concept : public virtual Internal::ConceptOf<TSpecificationA>,
+                     public virtual Internal::ConceptOf<TSpecificationB> {};
+
+    template <class THolder>
+    struct Model : public Internal::ModelOf<TSpecificationA, Internal::ModelOf<TSpecificationB, THolder>>,
+                   public virtual Concept {
+        using Base = Internal::ModelOf<TSpecificationA, Internal::ModelOf<TSpecificationB, THolder>>;
+        using Base::Base; // include parent constructor
+    };
+
+    template <class Container>
+    struct Interface
+        : public Internal::InterfaceOf<TSpecificationA, Internal::InterfaceOf<TSpecificationB, Container>> {
+
+        using Base = Internal::InterfaceOf<TSpecificationA, Internal::InterfaceOf<TSpecificationB, Container>>;
+        using Base::Base; // include parent constructor
+    };
+};
+} // namespace TypeErasure
+} // namespace Faunus

--- a/src/chainmove.h
+++ b/src/chainmove.h
@@ -8,8 +8,9 @@ namespace Move {
 /**
  * @brief An abstract base class for rotational movements of a polymer chain
  */
-class ChainRotationMovebase : public Movebase {
+class ChainRotationMoveBase : public MoveBase {
   protected:
+    using MoveBase::spc;
     std::string molname;
     size_t molid;
     double dprot;             //!< maximal angle of rotation, ±0.5*dprot
@@ -27,6 +28,7 @@ class ChainRotationMovebase : public Movebase {
     void _reject(Change &change) override;
 
   protected:
+    ChainRotationMoveBase(Space &spc, std::string name, std::string cite);
     void _from_json(const json &j) override;
     void _to_json(json &j) const override;
 
@@ -37,21 +39,19 @@ class ChainRotationMovebase : public Movebase {
 /**
  * @brief An abstract class that rotates a selected segment of a polymer chain in the given simulation box.
  */
-class ChainRotationMove : public ChainRotationMovebase {
-    using Tbase = ChainRotationMovebase;
+class ChainRotationMove : public ChainRotationMoveBase {
+    using TBase = ChainRotationMoveBase;
 
   protected:
-    Space &spc;
+    using TBase::spc;
     typename Space::Tgvec::iterator molecule_iter;
     //! Indices of atoms in the spc.p vector that mark the origin and the direction of the axis of rotation.
     std::array<size_t, 2> axis_ndx;
     //! Indices of atoms in the spc.p vector that shall be rotated.
     std::vector<size_t> segment_ndx;
 
-  public:
-    explicit ChainRotationMove(Space &spc);
+    ChainRotationMove(Space &spc, std::string name, std::string cite);
 
-  protected:
     void _from_json(const json &j) override;
 
   private:
@@ -82,12 +82,13 @@ class ChainRotationMove : public ChainRotationMovebase {
  * determined by the joints. The extend of the angle is limited by dprot.
  */
 class CrankshaftMove : public ChainRotationMove {
-    using Tbase = ChainRotationMove;
+    using TBase = ChainRotationMove;
 
   public:
-    explicit CrankshaftMove(Space &spc) : ChainRotationMove(spc) { this->name = "crankshaft"; }
+    explicit CrankshaftMove(Space &spc);
 
   protected:
+    CrankshaftMove(Space &spc, std::string name, std::string cite);
     void _from_json(const json &j) override;
 
   private:
@@ -109,7 +110,7 @@ class CrankshaftMove : public ChainRotationMove {
  * then constitutes a segment which is rotated by a random angle. The extend of the angle is limited by dprot.
  */
 class PivotMove : public ChainRotationMove {
-    using Tbase = ChainRotationMove;
+    using TBase = ChainRotationMove;
 
   private:
     BasePointerVector<Potential::HarmonicBond> bonds;
@@ -118,6 +119,8 @@ class PivotMove : public ChainRotationMove {
     explicit PivotMove(Space &spc);
 
   protected:
+    PivotMove(Space &spc, std::string name, std::string cite);
+
     void _from_json(const json &j) override;
 
     /** Selects a random harmonic bond of a random polymer chain which atoms then create an axis of rotation.

--- a/src/clustermove.cpp
+++ b/src/clustermove.cpp
@@ -170,7 +170,7 @@ std::pair<std::vector<size_t>, bool> FindCluster::findCluster(size_t seed_index)
     for (auto it1 = cluster.begin(); it1 != cluster.end(); it1++) {
         for (auto it2 = pool.begin(); it2 != pool.end();) {
             double P = clusterProbability(spc.groups.at(*it1), spc.groups.at(*it2)); // probability to cluster
-            if (Movebase::slump() <= P) {
+            if (MoveBase::slump() <= P) {
                 cluster.push_back(*it2); // add to cluster
                 it2 = pool.erase(it2);   // erase and advance (c++11)
             } else {
@@ -368,11 +368,10 @@ void Cluster::_accept(Change &) {
     translational_mean_square_displacement += translation_displacement.squaredNorm();
     rotational_mean_square_displacement += rotation_angle * rotation_angle;
 }
-Cluster::Cluster(Space &spc) : spc(spc) {
-    cite = "doi:10/cj9gnn";
-    name = "cluster";
-    repeat = -1;
-}
+
+Cluster::Cluster(Space &spc, std::string name, std::string cite) : MoveBase(spc, name, cite) { repeat = -1; }
+
+Cluster::Cluster(Space &spc) : Cluster(spc, "cluster", "doi:10/cj9gnn") {}
 
 } // namespace Move
 } // namespace Faunus

--- a/src/clustermove.h
+++ b/src/clustermove.h
@@ -113,10 +113,9 @@ void to_json(json &j, const FindCluster &cluster); //!< Serialize to json
 /**
  * @brief Molecular cluster move
  */
-class Cluster : public Movebase {
+class Cluster : public MoveBase {
   private:
     typedef typename Space::Tgroup Tgroup;
-    Tspace &spc;
     std::shared_ptr<FindCluster> find_cluster;
     std::shared_ptr<ClusterShapeAnalysis> shape_analysis;
     Average<double> average_cluster_size;
@@ -143,8 +142,12 @@ class Cluster : public Movebase {
     Change createChangeObject(const std::vector<size_t> &cluster_index) const;
     void biasRejectOrAccept(const size_t seed_index, const std::vector<size_t> &cluster_index);
 
+  protected:
+    using MoveBase::spc;
+    Cluster(Space &spc, std::string name, std::string cite);
+
   public:
-    Cluster(Space &spc);
+    explicit Cluster(Space &spc);
 };
 
 } // namespace Move

--- a/src/forcemove.cpp
+++ b/src/forcemove.cpp
@@ -7,7 +7,8 @@ namespace Faunus::Move {
 TEST_SUITE_BEGIN("ForceMove");
 
 /**
- * @brief Compute a single dimension contribution to the mean square thermal speed of a particle, i.e., compute 〈v²_x〉.
+ * @brief Compute a single dimension contribution to the mean square thermal speed of a particle, i.e.,
+ * compute 〈v²_x〉.
  *
  * This is equivalent to a one third of a total mean square thermal speed of a particle in three dimensions,
  * i.e., 〈v²〉 = 3 × 〈v²_x〉.
@@ -28,8 +29,7 @@ void to_json(json &j, const IntegratorBase &i) { i.to_json(j); }
 
 // =============== LangevinVelocityVerlet ===============
 
-LangevinVelocityVerlet::LangevinVelocityVerlet(Space &spc, Energy::Energybase &energy)
-    : IntegratorBase(spc, energy) {}
+LangevinVelocityVerlet::LangevinVelocityVerlet(Space &spc, Energy::Energybase &energy) : IntegratorBase(spc, energy) {}
 
 LangevinVelocityVerlet::LangevinVelocityVerlet(Space &spc, Energy::Energybase &energy, double time_step,
                                                double friction_coefficient)
@@ -40,11 +40,9 @@ LangevinVelocityVerlet::LangevinVelocityVerlet(Space &spc, Energy::Energybase &e
     from_json(j);
 }
 
-inline Point LangevinVelocityVerlet::positionIncrement(const Point& velocity) {
-    return 0.5 * time_step * velocity;
-}
+inline Point LangevinVelocityVerlet::positionIncrement(const Point &velocity) { return 0.5 * time_step * velocity; }
 
-inline Point LangevinVelocityVerlet::velocityIncrement(const Point& force, const double mass) {
+inline Point LangevinVelocityVerlet::velocityIncrement(const Point &force, const double mass) {
     // As forces are in kT per ångström units (a hybrid between reduced energy units and absolute units), we use
     // the mean square speed to compute acceleration from the force and as a conversion factor.
     // Dimension analysis: (ps * 1 / Å) * (Å^2 / ps^2) = Å / ps.
@@ -122,8 +120,9 @@ TEST_CASE("[Faunus] Integrator") {
 
 // =============== ForceMoveBase ===============
 
-ForceMoveBase::ForceMoveBase(Space &spc, std::shared_ptr<IntegratorBase> integrator, unsigned int nsteps)
-    : integrator(integrator), number_of_steps(nsteps), spc(spc) {
+ForceMoveBase::ForceMoveBase(Space &spc, std::string name, std::string cite,
+                             std::shared_ptr<IntegratorBase> integrator, unsigned int nsteps)
+    : MoveBase(spc, name, cite), integrator(integrator), number_of_steps(nsteps) {
     forces.reserve(spc.p.size());
     velocities.reserve(spc.p.size());
     resizeForcesAndVelocities();
@@ -184,10 +183,12 @@ const PointVector &ForceMoveBase::getVelocities() const { return velocities; }
 
 // =============== LangevinMove ===============
 
+LangevinDynamics::LangevinDynamics(Space &spc, std::string name, std::string cite,
+                                   std::shared_ptr<IntegratorBase> integrator, unsigned int nsteps)
+    : ForceMoveBase(spc, name, cite, integrator, nsteps) {}
+
 LangevinDynamics::LangevinDynamics(Space &spc, std::shared_ptr<IntegratorBase> integrator, unsigned int nsteps)
-    : ForceMoveBase::ForceMoveBase(spc, integrator, nsteps) {
-    name = "langevin_dynamics";
-}
+    : LangevinDynamics(spc, "langevin_dynamics", "", integrator, nsteps) {}
 
 LangevinDynamics::LangevinDynamics(Space &spc, Energy::Energybase &energy)
     : LangevinDynamics::LangevinDynamics(spc, std::make_shared<LangevinVelocityVerlet>(spc, energy), 0) {}
@@ -197,13 +198,8 @@ LangevinDynamics::LangevinDynamics(Space &spc, Energy::Energybase &energy, const
     from_json(j);
 }
 
-void LangevinDynamics::_to_json(json &j) const {
-    ForceMoveBase::_to_json(j);
-
-}
-void LangevinDynamics::_from_json(const json &j) {
-    ForceMoveBase::_from_json(j);
-}
+void LangevinDynamics::_to_json(json &j) const { ForceMoveBase::_to_json(j); }
+void LangevinDynamics::_from_json(const json &j) { ForceMoveBase::_from_json(j); }
 
 TEST_CASE("[Faunus] LangevinDynamics") {
     class DummyEnergy : public Energy::Energybase {
@@ -233,4 +229,4 @@ TEST_CASE("[Faunus] LangevinDynamics") {
 
 TEST_SUITE_END();
 
-} // end of namespace
+} // namespace Faunus::Move

--- a/src/forcemove.h
+++ b/src/forcemove.h
@@ -15,7 +15,6 @@ namespace Faunus::Move {
  * of the simulation in time steps. The integrators update positions and velocities of particles as needed.
  */
 
-
 /**
  * @brief Generate a random 3d vector from the normal distribution
  * @note A helper class only to be used within this module.
@@ -90,32 +89,37 @@ void to_json(json &j, const IntegratorBase &i);
  * Orchestrate execution of integrators, thermostats, etc. Store vectors for velocities and forces, which are not part
  * of the particle vector in the space.
  */
-class ForceMoveBase : public Movebase {
+class ForceMoveBase : public MoveBase {
   protected:
     std::shared_ptr<IntegratorBase> integrator;
-    unsigned int number_of_steps;     //!< number of integration steps to perform during a single MC move
-    Space &spc;                       //!< space with particles and their positions
-    PointVector velocities;           //!< Vector of velocities matching each active particle in Space
-    PointVector forces;               //!< Vector of forces matching each active particle in Space
+    unsigned int number_of_steps; //!< number of integration steps to perform during a single MC move
+    using MoveBase::spc;          //!< space with particles and their positions
+    PointVector velocities;       //!< Vector of velocities matching each active particle in Space
+    PointVector forces;           //!< Vector of forces matching each active particle in Space
 
     size_t resizeForcesAndVelocities(); //!< Resize velocities and forces to match number of active particles
     void generateVelocities();          //!< Generate initial velocities and zero forces
     void _to_json(json &j) const override;
     void _from_json(const json &j) override;
     void _move(Change &change) override;
-    ForceMoveBase(Space &, std::shared_ptr<IntegratorBase> integrator, unsigned int nsteps);
+    ForceMoveBase(Space &, std::string name, std::string cite,
+                  std::shared_ptr<IntegratorBase> integrator, unsigned int nsteps);
     virtual ~ForceMoveBase() = default;
 
   public:
     double bias(Change &, double, double) override;
-    const PointVector& getForces() const;
-    const PointVector& getVelocities() const;
+    const PointVector &getForces() const;
+    const PointVector &getVelocities() const;
 };
 
 /**
  * @brief Langevin dynamics move using Langevin equation of motion
  */
 class LangevinDynamics : public ForceMoveBase {
+  protected:
+    LangevinDynamics(Space &, std::string name, std::string cite,
+                     std::shared_ptr<IntegratorBase> integrator, unsigned int nsteps);
+
   public:
     LangevinDynamics(Space &, std::shared_ptr<IntegratorBase> integrator, unsigned int nsteps);
     LangevinDynamics(Space &, Energy::Energybase &, const json &);
@@ -124,4 +128,4 @@ class LangevinDynamics : public ForceMoveBase {
     void _from_json(const json &j) override;
 };
 
-} // end of namespace
+} // namespace Faunus::Move

--- a/src/montecarlo.cpp
+++ b/src/montecarlo.cpp
@@ -13,7 +13,7 @@ namespace Faunus {
  *       when using some MPI schemes where the simulations must be in sync.
  */
 bool MetropolisMonteCarlo::metropolis(double energy_change) {
-    const auto random_number_between_zero_and_one = Move::Movebase::slump();
+    const auto random_number_between_zero_and_one = Move::MoveBase::slump();
     if (std::isnan(energy_change)) {
         throw std::runtime_error("Metropolis error: energy cannot be NaN");
     }
@@ -111,7 +111,7 @@ void MetropolisMonteCarlo::restore(const json &j) {
         *state->spc = j;       // default, accepted state
         *trial_state->spc = j; // trial state
         if (j.count("random-move") == 1) {
-            Move::Movebase::slump = j["random-move"]; // restore move random number generator
+            Move::MoveBase::slump = j["random-move"]; // restore move random number generator
         }
         if (j.count("random-global") == 1) {
             Faunus::random = j["random-global"]; // restore global random number generator
@@ -123,7 +123,7 @@ void MetropolisMonteCarlo::restore(const json &j) {
     }
 }
 
-void MetropolisMonteCarlo::perform_move(std::shared_ptr<Move::Movebase> move) {
+void MetropolisMonteCarlo::perform_move(std::shared_ptr<Move::MoveBase> move) {
     Change change;
     move->move(change);
 #ifndef NDEBUG
@@ -166,7 +166,7 @@ void MetropolisMonteCarlo::perform_move(std::shared_ptr<Move::Movebase> move) {
     } else {
         // The `metropolis()` function propagates the engine and we need to stay in sync
         // Alternatively, we could use `engine.discard()`
-        Move::Movebase::slump();
+        Move::MoveBase::slump();
     }
 }
 

--- a/src/montecarlo.h
+++ b/src/montecarlo.h
@@ -12,7 +12,7 @@ class Hamiltonian;
 }
 
 namespace Move {
-class Movebase;
+class MoveBase;
 class Propagator;
 } // namespace Move
 
@@ -63,12 +63,12 @@ class MetropolisMonteCarlo {
     std::shared_ptr<State> state;                 //!< The accepted MC state
     std::shared_ptr<State> trial_state;           //!< Proposed or trial MC state
     std::shared_ptr<Move::Propagator> moves;      //!< Storage for all registered MC moves
-    std::shared_ptr<Move::Movebase> latest_move;  //!< Pointer to latest MC move
+    std::shared_ptr<Move::MoveBase> latest_move;  //!< Pointer to latest MC move
     double sum_of_energy_changes = 0.0;           //!< Sum of all potential energy changes
     double initial_energy = 0.0;                  //!< Initial potential energy
     Average<double> average_energy;               //!< Average potential energy of the system
     void init();                                  //!< Reset state
-    void perform_move(std::shared_ptr<Move::Movebase>); //!< Perform move using given move implementation
+    void perform_move(std::shared_ptr<Move::MoveBase>); //!< Perform move using given move implementation
 
   public:
     MetropolisMonteCarlo(const json &, MPI::MPIController &);

--- a/src/space.h
+++ b/src/space.h
@@ -40,7 +40,7 @@ struct Change {
     }
 
     //! List of changed atom index relative to first particle in system
-    std::vector<int> touchedParticleIndex(const std::vector<Group<Particle>> &);
+    std::vector<int> touchedParticleIndex(const std::vector<Group<Particle>> &) const;
 
     void clear();                                                 //!< Clear all change data
     bool empty() const;                                           //!< Check if change object is empty
@@ -290,7 +290,7 @@ class InsertMoleculesInSpace {
  * more efficient and is left here as an example of implementing a custom,
  * non-linear iterator.
  */
-struct getActiveParticles {
+struct ActiveParticles {
     const Space &spc;
     class const_iterator {
       private:
@@ -303,14 +303,15 @@ struct getActiveParticles {
       public:
         const_iterator(const Space &spc, Tparticle_iter it);
         const_iterator operator++();
-        bool operator!=(const const_iterator &other) const { return particle_iter != other.particle_iter; }
+        auto get() const { return std::pair{std::distance(particle_iter, spc.p.begin()), *particle_iter}; }
         auto operator*() const { return *particle_iter; }
+        bool operator!=(const const_iterator &other) const { return particle_iter != other.particle_iter; }
     }; // enable range-based for loops
 
     const_iterator begin() const;
     const_iterator end() const;
     size_t size() const;
-    getActiveParticles(const Space &spc);
+    ActiveParticles(const Space &spc);
 };
 
 // Make a global alias to easy transition to non-templated code

--- a/src/speciation.cpp
+++ b/src/speciation.cpp
@@ -332,7 +332,7 @@ bool SpeciationMove::deactivateAllReactants(Change &change) {
     for (auto [molid, N_delete] : molecular_reactants) { // Delete
         if (N_delete <= 0 or Faunus::molecules[molid].isImplicit()) {
             continue;                         // implicit molecules are added/deleted after move
-        } else if (molecules[molid].atomic) { // reactant is an atomic group
+        } else if (Faunus::molecules[molid].atomic) { // reactant is an atomic group
             auto mollist = spc.findMolecules(molid, Tspace::ALL);
             assert(range_size(mollist) == 1);
             auto target = spc.findMolecules(molid, Tspace::ALL).begin();
@@ -491,10 +491,12 @@ void SpeciationMove::_reject(Change &) {
     }
 }
 
-SpeciationMove::SpeciationMove(Tspace &spc) : spc(spc) {
-    name = "rcmc";
-    cite = "doi:10/fqcpg3";
+SpeciationMove::SpeciationMove(Space &spc, std::string name, std::string cite) : MoveBase(spc, name, cite) {
+    std::cout << "setting specmpve" << std::endl;
 }
+
+SpeciationMove::SpeciationMove(Space &spc) : SpeciationMove(spc, "rcmc", "doi:10/fqcpg3") {}
+
 void SpeciationMove::_from_json(const json &) {}
 
 } // end of namespace Move

--- a/src/speciation.cpp
+++ b/src/speciation.cpp
@@ -6,6 +6,11 @@
 namespace Faunus {
 namespace Move {
 
+/**
+ * @brief Internal exception to carry errors preventing the speciation move.
+ */
+struct SpeciationMoveException : public std::exception {};
+
 void SpeciationMove::_to_json(json &j) const {
     json &_j = j["reactions"];
     _j = json::object();
@@ -30,12 +35,14 @@ void SpeciationMove::setOther(Tspace &other) { other_spc = &other; }
  * one atomic reactant and one atomic product in the reaction.
  *
  * The function checks if there are sufficient atomic and molecular
- * reactants and products to perform the move. If not, false is returned
- * and the system is left untouched.
+ * reactants and products to perform the move. If not, an exception is
+ * thrown and the system is left untouched.
+ *
+ * @throw SpeciationMoveException  when atomic swap cannot be performed
  *
  * @todo If particle has extended properties, make sure to copy the state of those
  */
-bool SpeciationMove::atomicSwap(Change &change) {
+void SpeciationMove::atomicSwap(Change &change) {
     if (reaction->swap) {
         [[maybe_unused]] auto [atomic_products, molecular_products] = reaction->getProducts();
         [[maybe_unused]] auto [atomic_reactants, molecular_reactants] = reaction->getReactants();
@@ -44,7 +51,7 @@ bool SpeciationMove::atomicSwap(Change &change) {
 
         auto atomlist = spc.findAtoms(atomic_reactants.begin()->first); // search all active molecules
         if (ranges::cpp20::empty(atomlist)) { // Make sure that there are any active atoms to swap
-            return false;                     // Slip out the back door
+            throw SpeciationMoveException();
         }
 
         if (!molecular_reactants.empty()) {          // enough molecular reactants?
@@ -54,12 +61,12 @@ bool SpeciationMove::atomicSwap(Change &change) {
                 auto mollist = spc.findMolecules(molid, Tspace::ALL); // look for a single atomic group
                 assert(range_size(mollist) == 1);
                 if (mollist.begin()->empty()) {
-                    return false;
+                    throw SpeciationMoveException();
                 }
             } else { // reactant is a molecular group
                 auto mollist = spc.findMolecules(molid, Tspace::ACTIVE);
                 if (range_size(mollist) < N) {
-                    return false;
+                    throw SpeciationMoveException();
                 }
             }
         }
@@ -71,12 +78,12 @@ bool SpeciationMove::atomicSwap(Change &change) {
                 auto mollist = spc.findMolecules(molid, Tspace::ALL);
                 assert(range_size(mollist) == 1);
                 if (mollist.begin()->capacity() - mollist.begin()->size() < N) {
-                    return false;
+                    throw SpeciationMoveException();
                 }
             } else { // we're producing a molecular group
                 auto mollist = spc.findMolecules(molid, Tspace::INACTIVE);
                 if (range_size(mollist) < N) {
-                    return false;
+                    throw SpeciationMoveException();
                 }
             }
         }
@@ -98,7 +105,6 @@ bool SpeciationMove::atomicSwap(Change &change) {
         *random_particle = p; // copy new particle onto old particle
         assert(random_particle->id == atomid);
     }
-    return true;
 }
 
 /**
@@ -242,7 +248,12 @@ Change::data SpeciationMove::activateMolecularGroup(Space::Tgroup &target) {
     return d;
 }
 
-bool SpeciationMove::activateAllProducts(Change &change) {
+/**
+ * @brief Activate all atomic and molecular products.
+ *
+ * @throw SpeciationMoveException  when maximal capacity for products is exceeded
+ */
+void SpeciationMove::activateAllProducts(Change &change) {
     auto [atomic_products, molecular_products] = reaction->getProducts();
 
     // First we need to check if there are enough inactive products
@@ -256,7 +267,7 @@ bool SpeciationMove::activateAllProducts(Change &change) {
                 if (mollist.begin()->size() + number_to_insert > mollist.begin()->capacity()) {
                     faunus_logger->warn("atomic molecule {} is full; increase capacity?",
                                         Faunus::molecules[molid].name);
-                    return false;
+                    throw SpeciationMoveException();
                 }
             } else {
                 assert(false); // we should never reach here
@@ -270,7 +281,7 @@ bool SpeciationMove::activateAllProducts(Change &change) {
             if (molecules_to_activate.size() != number_to_insert) {
                 faunus_logger->warn("maximum number of {} molecules reached; increase capacity?",
                                     Faunus::molecules[molid].name);
-                return false;
+                throw SpeciationMoveException();
             }
         }
     }
@@ -311,23 +322,19 @@ bool SpeciationMove::activateAllProducts(Change &change) {
             }
         }
     }
-    return true;
 }
 
 /**
- * If possible, deactivate all atomic and molecular reactants.
+ * @brief Deactivate all atomic and molecular reactants.
  *
- * If impossible due to lack of reactant - either
- * implicit or explicit - the function returns `false`.
+ * @throw SpeciationMoveException  when impossible due to the lack of reactant – either implicit or explicit
  */
-bool SpeciationMove::deactivateAllReactants(Change &change) {
-
+void SpeciationMove::deactivateAllReactants(Change &change) {
     if (not enoughImplicitMolecules()) {
-        return false;
+        throw SpeciationMoveException();
     }
 
     auto [atomic_reactants, molecular_reactants] = reaction->getReactants();
-
     // check (only!) if there are anything to deactivate
     for (auto [molid, N_delete] : molecular_reactants) { // Delete
         if (N_delete <= 0 or Faunus::molecules[molid].isImplicit()) {
@@ -339,7 +346,7 @@ bool SpeciationMove::deactivateAllReactants(Change &change) {
             if ((int)target->size() - N_delete < 0) {
                 faunus_logger->warn("atomic group {} is depleted; increase simulation volume?",
                                     Faunus::molecules[molid].name);
-                return false;
+                throw SpeciationMoveException();
             }
         } else { // molecular reactant (non-atomic)
             auto selection = (reaction->only_neutral_molecules) ? Tspace::ACTIVE_NEUTRAL : Tspace::ACTIVE;
@@ -348,7 +355,7 @@ bool SpeciationMove::deactivateAllReactants(Change &change) {
             std::sample(active.begin(), active.end(), std::back_inserter(molecules_to_deactivate), N_delete,
                         slump.engine); // pick random molecules to delete
             if (molecules_to_deactivate.size() != N_delete) {
-                return false;
+                throw SpeciationMoveException();
             }
         }
     }
@@ -387,57 +394,52 @@ bool SpeciationMove::deactivateAllReactants(Change &change) {
                     faunus_logger->warn("all {} molecules have been deleted; increase system volume?",
                                         Faunus::molecules[molid].name);
                 }
-                return false;
+                throw SpeciationMoveException();
             }
         }
     }
-    return true;
 }
 
 /**
  * Checks if there is enough implicit molecules to carry out the reaction
  */
 bool SpeciationMove::enoughImplicitMolecules() const {
-    auto tooSmall = [&](auto &i) {                                // check if species has enough implicit
+    auto isExhausted = [&](auto &i) {                             // check if species has enough implicit
         auto [molid, nu] = i;                                     // molid and stoichiometric coefficient
         if (Faunus::molecules[molid].isImplicit()) {              // matter to perform process
             assert(spc.getImplicitReservoir().count(molid) == 1); // must be registered in space!
-            if (spc.getImplicitReservoir()[molid] - nu < 0) {
-                return true; // nope, no more material
-            }
+            return nu > spc.getImplicitReservoir()[molid];        // not enough material?
+        } else {
+            return false;                                         // non-implicit molecules cannot be exhausted
         }
-        return false;
     };
 
     [[maybe_unused]] auto [atomic_reactants, molecular_reactants] = reaction->getReactants();
 
-    if (std::count_if(molecular_reactants.begin(), molecular_reactants.end(), tooSmall) > 0) {
-        return false;
-    } else {
-        return true;
-    }
+    return std::find_if(molecular_reactants.begin(), molecular_reactants.end(), isExhausted) ==
+           molecular_reactants.end(); // no molecule exhausted?
 }
 
 void SpeciationMove::_move(Change &change) {
     assert(other_spc != nullptr);        // knowledge of other space should be provided by now
-    if (not Faunus::reactions.empty()) { // global list of reactions
+    try {
+        if (Faunus::reactions.empty()) {     // global list of reactions
+            throw SpeciationMoveException();
+        }
         reaction = slump.sample(Faunus::reactions.begin(), Faunus::reactions.end());    // random reaction
         auto direction = static_cast<ReactionData::Direction>((char)slump.range(0, 1)); // random direction
         reaction->setDirection(direction);
         bond_energy = 0.0;
-        if (atomicSwap(change)) {
-            if (deactivateAllReactants(change)) {
-                if (activateAllProducts(change)) {
-                    if (!change.empty()) {
-                        change.dN = true; // Attempting to change the number of atoms / molecules
-                        std::sort(change.groups.begin(), change.groups.end()); // change groups *must* be sorted!
-                        return;
-                    }
-                }
-            }
+        atomicSwap(change);
+        deactivateAllReactants(change);
+        activateAllProducts(change);
+        if (!change.empty()) {
+            change.dN = true; // Attempting to change the number of atoms / molecules
+            std::sort(change.groups.begin(), change.groups.end()); // change groups *must* be sorted!
         }
+    } catch(SpeciationMoveException &) {
+        change.clear();
     }
-    change.clear();
 }
 
 double SpeciationMove::bias(Change &, double, double) {
@@ -492,7 +494,7 @@ void SpeciationMove::_reject(Change &) {
 }
 
 SpeciationMove::SpeciationMove(Space &spc, std::string name, std::string cite) : MoveBase(spc, name, cite) {
-    std::cout << "setting specmpve" << std::endl;
+    std::cout << "setting specmove" << std::endl;
 }
 
 SpeciationMove::SpeciationMove(Space &spc) : SpeciationMove(spc, "rcmc", "doi:10/fqcpg3") {}

--- a/src/speciation.h
+++ b/src/speciation.h
@@ -47,9 +47,9 @@ class SpeciationMove : public MoveBase {
     void _accept(Change &) override;       //!< Called when accepted
     void _reject(Change &) override;       //!< Called when rejected
     bool enoughImplicitMolecules() const;  //!< Check if we have enough implicit matter for reaction
-    bool atomicSwap(Change &);             //!< Swap atom type
-    bool deactivateAllReactants(Change &); //!< Delete reactant species
-    bool activateAllProducts(Change &);    //!< Insert product species
+    void atomicSwap(Change &);             //!< Swap atom type
+    void deactivateAllReactants(Change &); //!< Delete reactant species
+    void activateAllProducts(Change &);    //!< Insert product species
 
     Change::data contractAtomicGroup(Space::Tgroup &, Space::Tgroup &, int);  //!< Contract atomic group
     Change::data expandAtomicGroup(Space::Tgroup &, int);                     //!< Expand atomic group

--- a/src/speciation.h
+++ b/src/speciation.h
@@ -19,10 +19,10 @@ namespace Move {
  *    - deactivate reactants
  *    - activate products
  */
-class SpeciationMove : public Movebase {
+class SpeciationMove : public MoveBase {
   private:
     typedef decltype(Faunus::reactions)::iterator reaction_iterator;
-    Space &spc;                 //!< Trial space (particles, groups)
+    using MoveBase::spc;        //!< Trial space (particles, groups)
     Space *other_spc = nullptr; //!< Old space (particles, groups)
     double bond_energy = 0;     //!< Accumulated bond energy if inserted/deleted molecule
     reaction_iterator reaction; //!< Randomly selected reaction
@@ -56,6 +56,7 @@ class SpeciationMove : public Movebase {
     Change::data activateMolecularGroup(Space::Tgroup &);                     //!< Activate molecular group
     Change::data deactivateMolecularGroup(Space::Tgroup &);                   //!< Deactivate molecular group
 
+    SpeciationMove(Space &, std::string, std::string);
   public:
     SpeciationMove(Space &);
     void setOther(Space &);


### PR DESCRIPTION
# Description

Various fixes, refactorizations and improvements done during cell list programming. They should not raise any emotions. To be reviewed and merged per commit basis, i.e., **“Rebase and merge”**.

The codebase should be gradually cleaned from C-style idioms and non-idioms. 

* A function performing some task should not return bool to indicate success or failure, but rather only throw an exception upon failure. That avoids illogical ifs – the code does a task and does not answer a yes-no question. Such ifs also tend to be nested creating difficult-to-read blocks. Using exceptions on the other hand leads to a nicely readable liner code. 
* The construct `if(condition) return true; else return false;` is unnecessary verbose: plain `return condition;` does the same.
* For discussion: Changing the code style for references (and pointers) by moving the symbol from the variable name to the type, e.g., `MyClass &object` → `MyClass& object`, `MyClass &` → `MyClass&`. C is value oriented with a rather simple type system in contrast to C++ that strongly relies on (multiple) inheritance and uses templates to control types. Hence the first style is natural for C, but not for C++ as `MyClass` and `MyClass&` are different _types_. The more I am involved in metaprogramming (templates) the more I consider C style rather distracting in C++.