### PR TITLE
Refactor ConfigurationSwap move

### DIFF
--- a/docs/_docs/moves.md
+++ b/docs/_docs/moves.md
@@ -162,7 +162,7 @@ Instead, use a hard-coded variant like `nonbonded_coulomblj` etc.
 ------------------ | ---------------------------------
 `molecule`         |  Molecule name to operate on
 `repeat=N`         |  Number of repeats per MC sweep
-`keeppos=True`     |  Keep original positions of `traj`
+`keeppos=False`    |  Keep original positions of `traj`
 
 This will swap between different molecular conformations
 as defined in the [Molecule Properties](topology.html#molecule-properties) with `traj` and `trajweight`
@@ -171,6 +171,8 @@ distribution is respected, otherwise all conformations
 have equal intrinsic weight. Upon insertion, the new conformation
 is randomly oriented and placed on top of the mass-center of
 an exising molecule. That is, there is no mass center movement.
+If `keeppos` is activated, the raw coordinates from the conformation
+is used, i.e. no rotation and no mass-center overlay.
 
 ### Pivot
 

--- a/src/move.h
+++ b/src/move.h
@@ -277,30 +277,21 @@ class SmartTranslateRotate : public MoveBase {
  * an exising molecule. That is, there is no mass center movement.
  *
  * @todo Add feature to align molecule on top of an exiting one
- * @todo Expand `_info()` to show number of conformations
- * @warning Weighted distributions untested and not verified for correctness
- * @date Malmo, November 2016
  */
 class ConformationSwap : public MoveBase {
   private:
-    typedef typename Space::Tpvec Tpvec;
-    typedef MoleculeData Tmoldata;
     RandomInserter inserter;
-    int molid = -1;
-    int newconfid = -1;
-
+    int molid = -1; //!< Molecule ID to operate on
     void _to_json(json &j) const override;
-    void _from_json(const json &j) override; //!< Configure via json object
+    void _from_json(const json &j) override;
     void _move(Change &change) override;
-    void _accept(Change &change) override;
-
-  protected:
-    using MoveBase::spc;
-    ConformationSwap(Space &spc, std::string name, std::string cite);
+    void setRepeat(); //!< Set move repeat
+    void checkMassCenterDrift(const Point &old_mass_center, const ParticleVector &particles); //!< Check for CM drift
+    void registerChanges(Change &change, const Space::Tgroup &group) const;                   //!< Update change object
+    ConformationSwap(Space &spc, const std::string &name, const std::string &cite);
 
   public:
     explicit ConformationSwap(Space &spc);
-
 }; // end of conformation swap move
 
 class VolumeMove : public MoveBase {


### PR DESCRIPTION
- self-explanatory names
- `_move()` split to several functions
- simplified group `confid` handling
- fix manual that showed wrong default value for `keeppos`