### PR TITLE
Simplify JSON processing in from_json

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -92,7 +92,7 @@ PenaltyBreakString: 1000
 PenaltyBreakTemplateDeclaration: 10
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 60
-PointerAlignment: Right
+PointerAlignment: Left
 ReflowComments:  true
 SortIncludes:    false
 SortUsingDeclarations: true
@@ -111,8 +111,7 @@ SpacesInContainerLiterals: true
 SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
-Standard:        Cpp11
+Standard:        c++17
 TabWidth:        8
 UseTab:          Never
 ...
-

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,22 +1,5 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
-    <Objective-C-extensions>
-      <rules>
-        <rule entity="NAMESPACE" visibility="ANY" specifier="ANY" prefix="" style="PASCAL_CASE" suffix="" />
-        <rule entity="MACRO" visibility="ANY" specifier="ANY" prefix="" style="SCREAMING_SNAKE_CASE" suffix="" />
-        <rule entity="CLASS" visibility="ANY" specifier="ANY" prefix="" style="PASCAL_CASE" suffix="" />
-        <rule entity="ENUM" visibility="ANY" specifier="ANY" prefix="" style="PASCAL_CASE" suffix="" />
-        <rule entity="ENUMERATOR" visibility="ANY" specifier="ANY" prefix="" style="PASCAL_CASE" suffix="" />
-        <rule entity="TYPEDEF" visibility="ANY" specifier="ANY" prefix="" style="PASCAL_CASE" suffix="" />
-        <rule entity="UNION" visibility="ANY" specifier="ANY" prefix="" style="PASCAL_CASE" suffix="" />
-        <rule entity="CLASS_MEMBER_FUNCTION,STRUCT_MEMBER_FUNCTION" visibility="ANY" specifier="ANY" prefix="" style="CAMEL_CASE" suffix="" />
-        <rule entity="CLASS_MEMBER_FIELD,STRUCT_MEMBER_FIELD" visibility="ANY" specifier="ANY" prefix="" style="CAMEL_CASE" suffix="" />
-        <rule entity="GLOBAL_FUNCTION" visibility="ANY" specifier="ANY" prefix="" style="CAMEL_CASE" suffix="" />
-        <rule entity="GLOBAL_VARIABLE" visibility="ANY" specifier="ANY" prefix="" style="SNAKE_CASE" suffix="" />
-        <rule entity="PARAMETER" visibility="ANY" specifier="ANY" prefix="" style="SNAKE_CASE" suffix="" />
-        <rule entity="LOCAL_VARIABLE" visibility="ANY" specifier="ANY" prefix="" style="SNAKE_CASE" suffix="" />
-      </rules>
-    </Objective-C-extensions>
     <clangFormatSettings>
       <option name="ENABLED" value="true" />
     </clangFormatSettings>

--- a/docs/schema.yml
+++ b/docs/schema.yml
@@ -158,7 +158,7 @@ properties:
                     keeppos: {type: boolean, default: false, description: Keep original positions of `structure`}
                     keepcharges: {type: boolean, default: true, description: Keep original charges of `structure` (aam/pqr files)}
                     rigid: {type: boolean, default: false, description: Set to true for rigid molecules. Affects energy evaluation}
-                    rotate: {type: boolean, default: true, description: Rotate structure upon insertion?}
+                    rotate: {type: boolean, default: true, description: "Rotate structure upon insertion?"}
                     structure:
                         description: Structure file or direct information; required if `atomic=false`
                         anyOf:
@@ -524,7 +524,7 @@ properties:
                     description: "External Custom Potential"
                     type: object
                     properties:
-                        com: {type: boolean, default: false, description: Operate on mass-center instead of individual atoms?}
+                        com: {type: boolean, default: false, description: "Operate on mass-center instead of individual atoms?"}
                         constants: {type: object, description: User-defined constants}
                         function: {type: string, description: Mathematical expression for the potential (units of kT)}
                         molecules:

--- a/scripts/yason.py
+++ b/scripts/yason.py
@@ -52,8 +52,9 @@ if pygments:
 
 args = parser.parse_args()
 
-red = "\033[91m"
-yellow = "\033[93m"
+terminal_red = "\033[91m"
+terminal_yellow = "\033[93m"
+terminal_default = "\033[39m"
  
 if pygments:
     if args.color:
@@ -78,7 +79,7 @@ def print_table(schema):
     ''' pretty print schema as markdown table '''
     properties = schema.get("properties", "")
     if isinstance(properties, dict):
-        eprint(yellow + "Need help, my young apprentice?\n" + red)
+        eprint(terminal_yellow + "Need help, my young apprentice?\n" + terminal_red)
         eprint("{:25} | {:7} | {:50}".format(25*"-", 7*"-", 50*"-"))
         eprint("{:25} | {:7} | {:50}".format("Property", "Type", "Description"))
         eprint("{:25} | {:7} | {:50}".format(25*"-", 7*"-", 50*"-"))
@@ -97,6 +98,7 @@ def print_table(schema):
                     eprint("{:25} | {:7} | {}".format('`'+_property+'`', _type, _description))
                 else:
                     eprint("{:25} | {:7} | {}".format('`'+_property+'`', 'n/a', _description))
+        eprint(terminal_default) # restore terminal color
 
 def validate_input(instance):
     ''' JSON schema checker '''

--- a/src/atomdata.cpp
+++ b/src/atomdata.cpp
@@ -133,8 +133,8 @@ void from_json(const json &j, AtomData &a) {
 
         from_single_use_json(val, a.interaction);
         if (!val.empty()) {
-            throw std::runtime_error("unused key(s) for atom '"s + a.name + "':\n" + val.items().begin().key() +
-                                     usageTip["atomlist"]);
+            usageTip.pick("atomlist");
+            throw ConfigurationError("unused key(s) for atom '{}':\n{}", a.name, val.items().begin().key());
         }
 
         if (std::isnan(a.interaction.get("sigma")))
@@ -216,5 +216,16 @@ TEST_CASE("[Faunus] AtomData") {
     CHECK_EQ(it, v.end());
 }
 TEST_SUITE_END();
+
+UnknownAtomError::UnknownAtomError(const std::string& atom_name)
+    : std::runtime_error(fmt::format("unknown atom: '{}'", atom_name)) {}
+
+AtomData& findAtomByName(const std::string& name) {
+    const auto result = findName(Faunus::atoms, name);
+    if (result == Faunus::atoms.end()) {
+        throw UnknownAtomError(name);
+    }
+    return *result;
+}
 
 } // namespace Faunus

--- a/src/atomdata.h
+++ b/src/atomdata.h
@@ -80,28 +80,29 @@ extern std::vector<AtomData> atoms; //!< Global instance of atom list
  * @param rng  a range of elements
  * @param name  a name to look for
  * @return an iterator to the first element, or `last` if not found
- * @see obtainName()
+ * @see findAtomByName(), findMoleculeByName()
  */
 template <class Trange> auto findName(Trange &rng, const std::string &name) {
     return std::find_if(rng.begin(), rng.end(), [&name](auto &i) { return i.name == name; });
 }
 
 /**
- * @brief Finds the first element with a member attribute `name` matching the input. Throws an exception if not found.
- *
- * @param rng  a range of elements
- * @param name  a name to look for
- * @return an iterator to the first element
- * @throw std::range_error if such an element not found
- * @see findName()
+ * @brief An exception to indicate an unknown atom name in the input.
  */
-template <class Trange> auto obtainName(Trange &rng, const std::string &name) {
-    const auto result = findName(rng, name);
-    if(result == rng.end()) {
-        throw std::out_of_range(name + " not found");
-    }
-    return result;
-}
+struct UnknownAtomError: public std::runtime_error {
+    explicit UnknownAtomError(const std::string & atom_name);
+};
+
+/**
+ * @brief Finds an atom by its name in the global Faunus atoms lexicon.
+ *
+ * The first matching atom is returned, or an UnknownAtomError is thrown when not found.
+ *
+ * @param name  an atom name to look for
+ * @return an atom found
+ * @throw UnknownAtomError  when no atom found
+ */
+AtomData& findAtomByName(const std::string& name);
 
 /**
  * @brief Search for `name` in `database` and return `id()`

--- a/src/bonds.h
+++ b/src/bonds.h
@@ -161,9 +161,9 @@ struct PeriodicDihedral : public BondData {
  * Serialize to/from json
  */
 
-void from_json(const json &j, std::shared_ptr<BondData> &b);
-void to_json(json &j, const std::shared_ptr<const BondData> &b);
-void to_json(Faunus::json &j, const BondData &b);
+void from_json(const json& j, std::shared_ptr<BondData>& bond);
+void to_json(json& j, const std::shared_ptr<const BondData>& bond);
+void to_json(json& j, const BondData& bond);
 
 void setBondEnergyFunction(std::shared_ptr<BondData> &b,
                            const ParticleVector &p); //!< Set the bond energy function of `BondData` which

--- a/src/chainmove.cpp
+++ b/src/chainmove.cpp
@@ -48,10 +48,7 @@ ChainRotationMove::ChainRotationMove(Space &spc, std::string name, std::string c
 
 void ChainRotationMove::_from_json(const json &j) {
     TBase::_from_json(j);
-    auto moliter = findName(molecules, molname);
-    if (moliter == molecules.end())
-        throw std::runtime_error("unknown molecule '" + molname + "'");
-    molid = moliter->id();
+    molid = findMoleculeByName(molname).id();
 }
 
 void ChainRotationMove::rotate_segment(double angle) {

--- a/src/clustermove.cpp
+++ b/src/clustermove.cpp
@@ -118,12 +118,9 @@ void FindCluster::parseThresholds(const json &j) {
         }
         for (const auto &[key, value] : j.items()) {
             if (auto name_pair = Faunus::words2vec<std::string>(key); name_pair.size() == 2) {
-                auto it1 = Faunus::findName(Faunus::molecules, name_pair[0]);
-                auto it2 = Faunus::findName(Faunus::molecules, name_pair[1]);
-                if (it1 == Faunus::molecules.end() or it2 == Faunus::molecules.end()) {
-                    throw ConfigurationError("unknown threshold molecule(s): [{} {}]", name_pair[0], name_pair[1]);
-                }
-                thresholds_squared.set(it1->id(), it2->id(), std::pow(value.get<double>(), 2));
+                const auto molecule1 = findMoleculeByName(name_pair[0]);
+                const auto molecule2 = findMoleculeByName(name_pair[1]);
+                thresholds_squared.set(molecule1.id(), molecule2.id(), std::pow(value.get<double>(), 2));
             } else {
                 throw ConfigurationError("threshold requires exactly two space-separated molecules");
             }

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -118,6 +118,10 @@ std::string TipFromTheManual::operator[](const std::string &key) {
     return (quiet) ? std::string() : t;
 }
 
+void TipFromTheManual::pick(const std::string &key) {
+    operator[](key);
+}
+
 TipFromTheManual usageTip; // Global instance
 
 // global loggers as a dummy instance
@@ -139,6 +143,15 @@ std::string addGrowingSuffix(const std::string &file) {
     } while (not exists());
     return newfile;
 }
+
+std::tuple<const std::string&, const json&> jsonSingleItem(const json& j) {
+    if (!j.is_object() || j.size() != 1) {
+        throw std::runtime_error("invalid data: single key expected");
+    }
+    const auto j_it = j.cbegin();
+    return {j_it.key(), j_it.value()};
+}
+
 
 json::size_type SingleUseJSON::count(const std::string &key) const { return json::count(key); }
 
@@ -223,8 +236,16 @@ TEST_CASE("[Faunus] ranunit_polar") {
     CHECK(rtp.z() == doctest::Approx(pc::pi / 2).epsilon(0.005)); // phi [0:pi] --> <phi>=pi/2
 }
 
-ConfigurationError::ConfigurationError(const std::string &msg) : std::runtime_error(msg) {}
-ConfigurationError::ConfigurationError(const char *msg) : std::runtime_error(msg) {}
+ConfigurationError::ConfigurationError(const std::exception& e) : ConfigurationError(e.what()) {}
+ConfigurationError::ConfigurationError(const std::runtime_error& e) : std::runtime_error(e) {}
+ConfigurationError::ConfigurationError(const std::string& msg) : std::runtime_error(msg) {}
+ConfigurationError::ConfigurationError(const char* msg) : std::runtime_error(msg) {}
+json& ConfigurationError::attachedJson() { return attached_json; }
+
+ConfigurationError& ConfigurationError::attachJson(const json j) {
+    attached_json = j;
+    return *this;
+}
 
 TEST_SUITE_BEGIN("Core");
 

--- a/src/faunus.cpp
+++ b/src/faunus.cpp
@@ -154,13 +154,18 @@ int main(int argc, const char **argv) {
 
         // --input
         json json_in;
-        if (auto input = args["--input"].asString(); input == "/dev/stdin") {
-            std::cin >> json_in;
-        } else {
-            if (prefix) {
-                input = Faunus::MPI::prefix + input;
+        try {
+            if (auto input = args["--input"].asString(); input == "/dev/stdin") {
+                    std::cin >> json_in;
+            } else {
+                if (prefix) {
+                    input = Faunus::MPI::prefix + input;
+                }
+                json_in = openjson(input);
             }
-            json_in = openjson(input);
+        } catch(json::parse_error& e) {
+            faunus_logger->debug(e.what());
+            throw ConfigurationError("empty or invalid input JSON");
         }
 
         {

--- a/src/faunus.cpp
+++ b/src/faunus.cpp
@@ -267,8 +267,18 @@ int main(int argc, const char **argv) {
     } catch (std::exception &e) {
         faunus_logger->error(e.what());
 
+        // ConfigurationError can carry a JSON snippet which should be shown for debugging.
+        if (auto config_error = dynamic_cast<ConfigurationError*>(&e);
+            config_error != nullptr && !config_error->attachedJson().empty()) {
+            faunus_logger->debug("JSON snippet:\n{}", config_error->attachedJson().dump(4));
+        }
+
         if (!usageTip.buffer.empty()) {
-            faunus_logger->error(usageTip.buffer);
+            // Use the srderr stream directly for more elaborated output of usage tip, optionally containing an ASCII
+            // art. Level info seems appropriate.
+            if (faunus_logger->should_log(spdlog::level::info)) {
+                std::cerr << usageTip.buffer << std::endl;
+            }
         }
 #ifdef ENABLE_SID
         // easter egg...

--- a/src/geometry.cpp
+++ b/src/geometry.cpp
@@ -562,8 +562,10 @@ const std::map<std::string, Variant> Chameleon::names = {{
 void from_json(const json &j, Chameleon &g) {
     try {
         g.from_json(j);
-    } catch (std::exception &e) {
-        throw std::runtime_error("geometry construction error: "s + e.what() + usageTip["geometry"]);
+    }
+    catch (std::exception &e) {
+        usageTip.pick("geometry");
+        throw ConfigurationError("geometry construction error: {}", e.what());
     }
 }
 

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -72,46 +72,43 @@ Particle FormatAAM::recordToParticle(const std::string &record) {
     std::string name;
     o << record;
     o >> name;
-    if (auto it = findName(atoms, name); it == atoms.end()) {
-        throw std::runtime_error("AAM load error: unknown atom name '" + name + "'.");
-    } else {
-        Particle particle = *it;
-        double radius;
-        double molecular_weight;
-        int atom_number;
-        o >> atom_number >> particle.pos.x() >> particle.pos.y() >> particle.pos.z() >> particle.charge >>
-            molecular_weight >> radius;
+    const auto atom = findAtomByName(name);
+    Particle particle(atom);
+    double radius;
+    double molecular_weight;
+    int atom_number;
+    o >> atom_number >> particle.pos.x() >> particle.pos.y() >> particle.pos.z() >> particle.charge >>
+        molecular_weight >> radius;
 
-        // does charge match AtomData?
-        if (std::fabs(it->charge - particle.charge) > pc::epsilon_dbl) {
-            faunus_logger->warn("charge mismatch on atom {0} {1}: {2} atomlist value", atom_number, name,
-                                (prefer_charges_from_file) ? "ignoring" : "using");
-            if (not prefer_charges_from_file) {
-                particle.charge = it->charge; // let's use atomdata charge
-            }
+    // does charge match AtomData?
+    if (std::fabs(atom.charge - particle.charge) > pc::epsilon_dbl) {
+        faunus_logger->warn("charge mismatch on atom {0} {1}: {2} atomlist value", atom_number, name,
+                            (prefer_charges_from_file) ? "ignoring" : "using");
+        if (not prefer_charges_from_file) {
+            particle.charge = atom.charge; // let's use atomdata charge
         }
-        // does radius match AtomData?
-        if (std::fabs(it->sigma - 2 * radius) > pc::epsilon_dbl) {
-            faunus_logger->warn("radius mismatch on atom {0} {1}: using atomlist value", atom_number, name);
-        }
-        return particle;
     }
+    // does radius match AtomData?
+    if (std::fabs(atom.sigma - 2 * radius) > pc::epsilon_dbl) {
+        faunus_logger->warn("radius mismatch on atom {0} {1}: using atomlist value", atom_number, name);
+    }
+    return particle;
 }
 ParticleVector FormatAAM::load(const std::string &filename, bool _keepcharges) {
     prefer_charges_from_file = _keepcharges;
     if (auto lines = IO::loadLinesFromFile(filename); lines.empty()) {
-        throw std::runtime_error("empty aam file: "s + filename);
+        throw std::runtime_error("empty file");
     } else {
         IO::strip(lines, "#"); // all lines beginning w. # are comments
         size_t number_of_atoms = std::stoul(lines[0]);
         if (lines.size() < number_of_atoms + 1) {
-            throw std::runtime_error("mismatch in number of atoms in "s + filename);
+            throw std::runtime_error("mismatch in number of atoms");
         }
         ParticleVector positions; // positions are loaded here
         positions.reserve(number_of_atoms);
         auto lines_atoms = lines | ranges::views::slice(1uL, 1uL + number_of_atoms);
-        std::transform(lines_atoms.begin(), lines_atoms.end(), std::back_inserter(positions),
-                       [](auto &i) { return recordToParticle(i); });
+            std::transform(lines_atoms.begin(), lines_atoms.end(), std::back_inserter(positions),
+                           [](auto &i) { return recordToParticle(i); });
         assert(positions.size() == number_of_atoms);
         return positions;
     }
@@ -161,14 +158,11 @@ bool FormatPQR::readAtomRecord(const std::string &record, Particle &particle, do
         std::string atom_name;
         std::string res_name;
         o >> atom_index >> atom_name;
-        if (auto it = findName(Faunus::atoms, atom_name); it != Faunus::atoms.end()) {
-            particle = *it;
-            o >> res_name >> res_index >> particle.pos.x() >> particle.pos.y() >> particle.pos.z() >> particle.charge >>
-                radius;
-            return true;
-        } else {
-            throw std::runtime_error("PQR load error: unknown atom name '" + atom_name + "'.");
-        }
+        const auto atom = findAtomByName(atom_name);
+        particle = atom;
+        o >> res_name >> res_index >> particle.pos.x() >> particle.pos.y() >> particle.pos.z() >> particle.charge >>
+            radius;
+        return true;
     }
     return false;
 }
@@ -242,10 +236,10 @@ Point FormatPQR::load(std::istream &stream, ParticleVector &destination, bool ke
  * @return Vector with unit cell dimensions. Zero length if not found.
  */
 Point FormatPQR::load(const std::string &filename, ParticleVector &particles, bool keep_charges) {
-    if (std::ifstream stream(filename); !stream) {
-        throw std::runtime_error("load error: "s + filename);
-    } else {
+    if (std::ifstream stream(filename); stream) {
         return load(stream, particles, keep_charges);
+    } else {
+        throw std::runtime_error("cannot open file");
     }
 }
 
@@ -257,9 +251,7 @@ Point FormatPQR::load(const std::string &filename, ParticleVector &particles, bo
  * ignored.
  */
 void FormatPQR::loadTrajectory(const std::string &filename, std::vector<ParticleVector> &traj) {
-    if (std::ifstream stream(filename); !stream) {
-        throw std::runtime_error("load error: "s + filename);
-    } else {
+    if (std::ifstream stream(filename); stream) {
         traj.clear();
         traj.resize(1); // prepare first frame
         std::string record;
@@ -280,6 +272,8 @@ void FormatPQR::loadTrajectory(const std::string &filename, std::vector<Particle
         if (traj.empty()) {
             faunus_logger->warn("pqr trajectory {} is empty", filename);
         }
+    } else {
+        throw std::runtime_error("cannot open file");
     }
 }
 
@@ -406,9 +400,7 @@ TEST_CASE("[Faunus] FormatPQR") {
  */
 
 void FormatXYZ::load(const std::string &filename, ParticleVector &particles, bool append) {
-    if (std::ifstream stream(filename); !stream) {
-        throw std::runtime_error("cannot open file: "s + filename);
-    } else {
+    if (std::ifstream stream(filename); stream) {
         std::string comment;
         std::string atom_name;
         size_t number_of_atoms;
@@ -421,15 +413,14 @@ void FormatXYZ::load(const std::string &filename, ParticleVector &particles, boo
         particles.reserve(particles.size() + number_of_atoms);
         for (size_t i = 0; i < number_of_atoms; i++) {
             stream >> atom_name;
-            if (auto it = findName(Faunus::atoms, atom_name); it != Faunus::atoms.end()) {
-                Particle particle = *it;
-                stream >> particle.pos.x() >> particle.pos.y() >> particle.pos.z();
-                particles.push_back(particle);
-            } else {
-                throw std::runtime_error("XYZ load error: unknown atom name '" + atom_name + "'.");
-            }
+            const auto atom = findAtomByName(atom_name);
+            Particle particle(atom);
+            stream >> particle.pos.x() >> particle.pos.y() >> particle.pos.z();
+            particles.push_back(particle);
         }
         assert(particles.size() == number_of_atoms);
+    } else {
+        throw std::runtime_error("cannot open file");
     }
 }
 
@@ -438,14 +429,11 @@ Particle FormatGRO::recordToParticle(const std::string &record) {
     std::string atom_name;
     o << record.substr(10, 5) << record.substr(20, 8) << record.substr(28, 8) << record.substr(36, 8);
     o >> atom_name;
-    if (auto it = findName(Faunus::atoms, atom_name); it != Faunus::atoms.end()) {
-        Particle particle = *it; // copy all atom properties, except positions
-        o >> particle.pos.x() >> particle.pos.y() >> particle.pos.z();
-        particle.pos *= 1.0_nm; // GRO files use nanometers
-        return particle;
-    } else {
-        throw std::runtime_error("GRO file: unknown atom name: " + atom_name);
-    }
+    const auto atom = findAtomByName(atom_name);
+    Particle particle(atom); // copy all atom properties, except positions
+    o >> particle.pos.x() >> particle.pos.y() >> particle.pos.z();
+    particle.pos *= 1.0_nm; // GRO files use nanometers
+    return particle;
 }
 
 /**
@@ -459,11 +447,11 @@ Particle FormatGRO::recordToParticle(const std::string &record) {
 ParticleVector FormatGRO::load(const std::string &filename) {
     constexpr size_t header_size = 2; // two lines before positions
     if (auto lines = IO::loadLinesFromFile(filename); lines.size() <= header_size) {
-        throw std::runtime_error("GRO file seems empty: " + filename);
+        throw std::runtime_error("GRO file seems empty");
     } else {
         size_t number_of_atoms = std::stoul(lines[1]); // second line = number of atoms
         if (lines.size() < header_size + number_of_atoms) {
-            throw std::runtime_error("Mismatch in number of atoms in GRO file");
+            throw std::runtime_error("mismatch in number of atoms");
         } else {
             ParticleVector positions; // positions are loaded here
             positions.reserve(number_of_atoms);
@@ -748,7 +736,7 @@ ParticleVector loadStructure(const std::string &file, bool keep_charges) {
         }
         return particles;
     } catch (std::exception &e) {
-        throw std::runtime_error("structure load error: "s + e.what());
+        throw std::runtime_error(fmt::format("error loading structure from file '{}': {}", file, e.what()));
     }
 }
 

--- a/src/molecule.h
+++ b/src/molecule.h
@@ -241,6 +241,25 @@ void from_json(const json &j, std::vector<MoleculeData> &v);
 // global instance of molecule vector
 extern std::vector<MoleculeData> molecules;
 
+
+/**
+ * @brief An exception to indicate an unknown molecule name in the input.
+ */
+struct UnknownMoleculeError: public std::runtime_error {
+    explicit UnknownMoleculeError(const std::string &molecule_name);
+};
+
+/**
+ * @brief Finds a molecule by its name in the global Faunus molecules lexicon.
+ *
+ * The first matching molecule is returned, or an UnknownMoleculeError is thrown when not found.
+ *
+ * @param name  a molecule name to look for
+ * @return a molecule found
+ * @throw UnknownMoleculeError  when no molecule found
+ */
+MoleculeData& findMoleculeByName(const std::string& name);
+
 /**
  * @brief Constructs MoleculeData from JSON.
  *

--- a/src/potentials.cpp
+++ b/src/potentials.cpp
@@ -199,7 +199,8 @@ void from_json(const json &j, PairPotentialBase &base) {
         }
         base.from_json(j);
     } catch (std::exception &e) {
-        throw std::runtime_error(e.what() + usageTip[base.name]);
+        usageTip.pick(base.name);
+        throw ConfigurationError(e);
     }
 }
 
@@ -659,52 +660,51 @@ FunctorPotential::uFunc FunctorPotential::combineFunc(json &j) {
     if (j.is_array()) {
         for (auto &i : j) { // loop over all defined potentials in array
             if (i.is_object() and (i.size() == 1)) {
-                for (auto it : i.items()) {
+                for (const auto& [key, j_val] : i.items()) {
                     uFunc _u = nullptr;
                     try {
-                        if (it.key() == "custom")
-                            _u = CustomPairPotential() = it.value();
+                        if (key == "custom")
+                            _u = CustomPairPotential() = j_val;
 
                         // add Coulomb potential and self-energy
                         // terms if not already added
-                        else if (it.key() == "coulomb") { // temporary name
-                            std::get<0>(potlist).from_json(it.value()); // initialize w. json object
-                            std::get<0>(potlist).to_json(it.value());   // write back to json object with added values
+                        else if (key == "coulomb") { // temporary key
+                            std::get<0>(potlist).from_json(j_val); // initialize w. json object
+                            std::get<0>(potlist).to_json(j_val);   // write back to json object with added values
                             _u = std::get<0>(potlist);
                             if (not have_monopole_self_energy) {
                                 registerSelfEnergy(&std::get<0>(potlist));
                                 have_monopole_self_energy = true;
                             }
-                        } else if (it.key() == "cos2")
+                        } else if (key == "cos2")
                             _u = std::get<1>(potlist) = i;
-                        else if (it.key() == "polar")
+                        else if (key == "polar")
                             _u = std::get<2>(potlist) = i;
-                        else if (it.key() == "hardsphere")
+                        else if (key == "hardsphere")
                             _u = std::get<3>(potlist) = i;
-                        else if (it.key() == "lennardjones")
+                        else if (key == "lennardjones")
                             _u = std::get<4>(potlist) = i;
-                        else if (it.key() == "repulsionr3")
+                        else if (key == "repulsionr3")
                             _u = std::get<5>(potlist) = i;
-                        else if (it.key() == "sasa")
+                        else if (key == "sasa")
                             _u = std::get<6>(potlist) = i;
-                        else if (it.key() == "wca")
+                        else if (key == "wca")
                             _u = std::get<7>(potlist) = i;
-                        else if (it.key() == "pm")
-                            _u = std::get<8>(potlist) = it.value();
-                        else if (it.key() == "pmwca")
-                            _u = std::get<9>(potlist) = it.value();
-                        else if (it.key() == "hertz")
+                        else if (key == "pm")
+                            _u = std::get<8>(potlist) = j_val;
+                        else if (key == "pmwca")
+                            _u = std::get<9>(potlist) = j_val;
+                        else if (key == "hertz")
                             _u = std::get<10>(potlist) = i;
-                        else if (it.key() == "squarewell")
+                        else if (key == "squarewell")
                             _u = std::get<11>(potlist) = i;
-                        else if (it.key() == "dipoledipole") {
-                            faunus_logger->error("'{}' is deprecated, use 'multipole' instead", it.key());
-                        } else if (it.key() == "stockmayer") {
-                            faunus_logger->error("'{}' is deprecated, use 'lennardjones'+'multipole' instead",
-                                                 it.key());
-                        } else if (it.key() == "multipole") {
-                            std::get<12>(potlist).from_json(it.value()); // init from json
-                            std::get<12>(potlist).to_json(it.value());   // write back added info to json
+                        else if (key == "dipoledipole") {
+                            faunus_logger->error("'{}' is deprecated, use 'multipole' instead", key);
+                        } else if (key == "stockmayer") {
+                            faunus_logger->error("'{}' is deprecated, use 'lennardjones'+'multipole' instead", key);
+                        } else if (key == "multipole") {
+                            std::get<12>(potlist).from_json(j_val); // init from json
+                            std::get<12>(potlist).to_json(j_val);   // write back added info to json
                             _u = std::get<12>(potlist);
                             isotropic = false;                         // potential is now angular dependent
                             if (not have_dipole_self_energy) {
@@ -714,7 +714,8 @@ FunctorPotential::uFunc FunctorPotential::combineFunc(json &j) {
                         }
                         // place additional potentials here...
                     } catch (std::exception &e) {
-                        throw std::runtime_error(it.key() + ": " + e.what() + usageTip[it.key()]);
+                        usageTip.pick(key);
+                        throw ConfigurationError("potential '{}': {}", key, e.what());
                     }
 
                     if (_u != nullptr) // if found, sum them into new function object
@@ -722,7 +723,7 @@ FunctorPotential::uFunc FunctorPotential::combineFunc(json &j) {
                             return u(a, b, r2, r) + _u(a, b, r2, r);
                         };
                     else
-                        throw std::runtime_error("unknown potential: " + it.key());
+                        throw ConfigurationError("potential '{}': unknown potential", key);
                 }
             }
         }


### PR DESCRIPTION
# Description

Brief and definitely not comprehensive refactorisation to unify and simplify error handling when reading JSON.

- Move commonly repeated patterns from `from_json` to functions `jsonSingleItem`, `findAtomByName` and `findMoleculeByName`. Error states are handled with exceptions.
- Use `ConfigurationError` to indicate JSON error in `from_json`. Improve text and flow of error messages. JSON snippet can be attached to `ConfigurationError` and shown at debug level.
- Refactor routing `from_json` functions for moves, analyses, energies, bonds and reaction coordinates. A single if-chain is followed to simplify the logic and making unknown JSON keys obvious. A request of features not included at compile time is treated as an explicit error.
- Refactor `from_json` methods of moves, analysis, energies, bonds and reaction coordinate.
- Refactor classes in IO namespace to use `findAtomByName`.
- Remove usageTip from the exception message and display it directly on stderr.
- Improve Faunus error message on empty input.
- Improve code style.

Question: Should be allowed to have more key-value objects in the same array item? Currently it is silently supported (except of bonds), however I did not verified if the code correctly handles this case.
Answer: It shall not be allowed.

Remark: With structural binding `const auto& […]` it becomes more obvious that the reference symbol `&` belongs rather to the type than to the variable name. Hence I suggest to change the code style from C-like to C++-like, e.g., `json &j` → `json& j`.
Resolution: C++ style will be followed.

Another commit just improve a compatibility issue with `pyyaml` I have encountered by accident. I think that the `pyyaml` parser does not fully adhere to the standard but the workaround is painless.

Comments welcome. After approval, please let me merge the PR by myself.