### PR TITLE
fixes bug when relative time was not written to out.json when using n…

### DIFF
--- a/src/potentials.cpp
+++ b/src/potentials.cpp
@@ -779,7 +779,7 @@ FunctorPotential::uFunc FunctorPotential::combineFunc(json &j) {
 }
 
 void FunctorPotential::to_json(json &j) const {
-    j = _j;
+    j["functor potential"] = _j;
     j["selfenergy"] = {{"monopole", have_monopole_self_energy}, {"dipole", have_dipole_self_energy}};
 }
 


### PR DESCRIPTION
…onbonded potentials

# Description
minor fix of json output
relativetime field in out.json  was missing when using nonbonded potential, because json object was being rewritten

## Checklist

- [x] `make test` passes with no errors
- [x] the source code is well documented
- [x] new functionality includes unittests
- [x] the user-manual has been updated to reflect the changes
- [x] I have installed the provided commit hook to auto-format commits (requires `clang-format`):

  ``` bash
  ./scripts/git-pre-commit-format install
  ```

- [x] code naming scheme follows the convention:

  Style        | Elements
  ------------ | ---------------------
  `PascalCase` | classes, namespaces
  `camelCase`  | functions
  `snake_case` | variables
