### PR TITLE
Quadratic charge move

### DIFF
--- a/docs/_docs/moves.md
+++ b/docs/_docs/moves.md
@@ -153,8 +153,11 @@ are distributed on a sphere then $\kappa^2=0$, while if on a straight line, $\ka
 ---------------- | ---------------------------------
 `index`          | Atom index to operate on
 `dq`             | Charge displacement
+`quadratic=true` | Displace linearly along q^2 instead of q
 
-This performs a fractional charge move on a specific atom.
+This performs a fractional charge move on a specific atom. The charge
+displacement can be performed linerly along $q$ or linerly along $q^2$.
+The latter introduces a bias that is automatically corrected for.
 
 Limitations:
 This move changes the particle charge and therefore cannot be used with

--- a/docs/_docs/moves.md
+++ b/docs/_docs/moves.md
@@ -156,8 +156,13 @@ are distributed on a sphere then $\kappa^2=0$, while if on a straight line, $\ka
 `quadratic=true` | Displace linearly along q^2 instead of q
 
 This performs a fractional charge move on a specific atom. The charge
-displacement can be performed linerly along $q$ or linerly along $q^2$.
-The latter introduces a bias that is automatically corrected for.
+displacement can be performed linerly along $q$ or linearly along $q^2$.
+For the latter the following bias energy will be added to ensure
+uniform sampling of $q$,
+
+$$
+u = k\_BT\ln \left ( \left | q^{\prime} / q \right |\right )
+$$
 
 Limitations:
 This move changes the particle charge and therefore cannot be used with

--- a/docs/schema.yml
+++ b/docs/schema.yml
@@ -647,6 +647,16 @@ properties:
             type: object
             properties:
 
+                charge:
+                    description: "Displaces charge of selected particle"
+                    type: object
+                    properties:
+                        dq: {type: number, description: "Max displacement parameter"}
+                        index: {type: integer, description: "Index of particle to affect"}
+                        quadratic: {type: boolean, default: true, description: "Displace squared charge"}
+                    required: [dq, index]
+                    additionalProperties: false
+
                 conformationswap:
                     description: Swap molecular configurations from loaded library of structures
                     type: object

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -26,6 +26,12 @@ add_test(
         WORKING_DIRECTORY ${EXAMPLES_DIR}/swapconf)
 
 add_test(
+        NAME chargemove
+        COMMAND sh -c "${PYTHON_EXECUTABLE} ${YASON} chargemove.yml | $<TARGET_FILE:faunus> --nobar\
+    && ${PYTHON_EXECUTABLE} ${JSON_COMPARE} chargemove.out.json out.json --tol 0.05"
+        WORKING_DIRECTORY ${EXAMPLES_DIR}/chargemove)
+
+add_test(
         NAME doublelayer
         COMMAND sh -c "${PYTHON_EXECUTABLE} ${YASON} doublelayer.yml\
     | $<TARGET_FILE:faunus> --nobar --state doublelayer.state.json\

--- a/examples/chargemove/chargemove.ipynb
+++ b/examples/chargemove/chargemove.ipynb
@@ -1,0 +1,65 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2823ee4d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "import matplotlib\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "52009284",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!~/github/faunus/scripts/yason.py chargemove.yml | ~/github/faunus/cmake-build-release/faunus --nobar"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d22ea86b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "step, x, avg = np.loadtxt('q.dat.gz', unpack=True)\n",
+    "plt.hist(x, bins=20)\n",
+    "plt.xlim(0,1)\n",
+    "plt.xlabel('particle charge')\n",
+    "plt.ylabel('count')\n",
+    "plt.title('here we expect a flat distribution...')\n",
+    "plt.yscale('log')\n",
+    "print(\"average charge = {}\".format(x.mean()))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/chargemove/chargemove.ipynb
+++ b/examples/chargemove/chargemove.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "638002eb",
+   "id": "0e199935",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -16,7 +16,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a3cbcc4f",
+   "id": "d4ede657",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -26,7 +26,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b4bc90c8",
+   "id": "4b7351de",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -37,7 +37,7 @@
     "plt.xlim(qmin-0.1,qmax+0.1)\n",
     "plt.xlabel('particle charge')\n",
     "plt.ylabel('count')\n",
-    "plt.title('We expect a flat distribution...')\n",
+    "plt.title('We expect a flat distribution')\n",
     "print(\"average charge = {:.2f} (expecting {:.2f})\".format(q.mean(), 0.5*(qmax-qmin)+qmin ))"
    ]
   }

--- a/examples/chargemove/chargemove.ipynb
+++ b/examples/chargemove/chargemove.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2823ee4d",
+   "id": "638002eb",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -16,7 +16,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "52009284",
+   "id": "a3cbcc4f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -26,18 +26,19 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d22ea86b",
+   "id": "b4bc90c8",
    "metadata": {},
    "outputs": [],
    "source": [
-    "step, x, avg = np.loadtxt('q.dat.gz', unpack=True)\n",
-    "plt.hist(x, bins=20)\n",
-    "plt.xlim(0,1)\n",
+    "qmin = -1.5\n",
+    "qmax = 1.0\n",
+    "step, q, avg = np.loadtxt('q.dat.gz', unpack=True)\n",
+    "plt.hist(q, bins=20)\n",
+    "plt.xlim(qmin-0.1,qmax+0.1)\n",
     "plt.xlabel('particle charge')\n",
     "plt.ylabel('count')\n",
-    "plt.title('here we expect a flat distribution...')\n",
-    "plt.yscale('log')\n",
-    "print(\"average charge = {}\".format(x.mean()))"
+    "plt.title('We expect a flat distribution...')\n",
+    "print(\"average charge = {:.2f} (expecting {:.2f})\".format(q.mean(), 0.5*(qmax-qmin)+qmin ))"
    ]
   }
  ],

--- a/examples/chargemove/chargemove.out.json
+++ b/examples/chargemove/chargemove.out.json
@@ -1,0 +1,86 @@
+{
+  "analysis": [
+    {
+      "reactioncoordinate": {
+        "average": -0.25,
+        "file": "q.dat.gz",
+        "index": 0,
+        "nstep": 2,
+        "property": "q",
+        "samples": 1000000,
+        "type": "atom"
+      }
+    },
+    {
+      "sanity": {
+        "nstep": 10000,
+        "samples": 200
+      }
+    }
+  ],
+  "compiler": "Apple LLVM 13.0.0 (clang-1300.0.29.30)",
+  "energy": [
+    {
+      "hamiltonian": [
+        {
+          "ContainerOverlap": {
+            "relative time": 8.512891710383912e-05
+          }
+        },
+        {
+          "constrain": {
+            "index": 0,
+            "property": "q",
+            "range": [
+              -1.5,
+              1.0
+            ],
+            "type": "atom"
+          }
+        }
+      ]
+    }
+  ],
+  "geometry": {
+    "radius": 2.0,
+    "type": "sphere"
+  },
+  "git revision": "5e172049 (2022-01-10)",
+  "groups": [
+    {
+      "ref": {
+        "compressible": false,
+        "index": [
+          0,
+          0
+        ],
+        "size": 1
+      }
+    }
+  ],
+  "montecarlo": {
+    "average potential energy (kT)": 0.0,
+    "last move": "charge"
+  },
+  "moves": [
+    {
+      "charge": {
+        "acceptance": 0.812,
+        "dq": 0.5,
+        "index": 0,
+        "mean bias energy": 0.204,
+        "moves": 2000000,
+        "quadratic": true,
+        "repeat": 1,
+        "stochastic": true,
+        "√⟨Δq²⟩": 0.176
+      }
+    }
+  ],
+  "number of groups": 1,
+  "number of particles": 1,
+  "number of sweeps": 2000000,
+  "reactionlist": null,
+  "relative drift": 0.0,
+  "temperature": 300.0
+}

--- a/examples/chargemove/chargemove.yml
+++ b/examples/chargemove/chargemove.yml
@@ -1,0 +1,36 @@
+#!/usr/bin/env yason.py
+#
+# Test charge move of a single particle
+# that can have q=[0,1] as enforced by
+# the constraint energy. We expect a uniform
+# distribution along q which may be verified
+# with the notebook.
+#
+temperature: 300
+random: {seed: hardware}
+geometry: {type: sphere, radius: 2}
+mcloop: {macro: 10, micro: 200000}
+
+atomlist:
+  - a: {mw: 1.0, q: 0.5}
+
+moleculelist:
+  - ref:
+      atomic: true
+      atoms: [a]
+
+insertmolecules:
+  - ref: {N: 1}
+
+energy:
+  - constrain: {type: atom, index: 0, property: q, range: [0,1]}
+
+moves:
+  - charge:
+      index: 0
+      dq: 0.5
+
+analysis:
+  - reactioncoordinate: {file: q.dat.gz, nstep: 5, type: atom, property: q, index: 0}
+  - sanity: {nstep: 10000}
+

--- a/examples/chargemove/chargemove.yml
+++ b/examples/chargemove/chargemove.yml
@@ -1,7 +1,7 @@
 #!/usr/bin/env yason.py
 #
 # Test charge move of a single particle
-# that can have q=[0,1] as enforced by
+# that can have q=[-1.5,1.0] as enforced by
 # the constraint energy. We expect a uniform
 # distribution along q which may be verified
 # with the notebook.
@@ -23,12 +23,13 @@ insertmolecules:
   - ref: {N: 1}
 
 energy:
-  - constrain: {type: atom, index: 0, property: q, range: [0,1]}
+  - constrain: {type: atom, index: 0, property: q, range: [-1.5,1.0]}
 
 moves:
   - charge:
       index: 0
       dq: 0.5
+      quadratic: false
 
 analysis:
   - reactioncoordinate: {file: q.dat.gz, nstep: 5, type: atom, property: q, index: 0}

--- a/examples/chargemove/chargemove.yml
+++ b/examples/chargemove/chargemove.yml
@@ -29,9 +29,9 @@ moves:
   - charge:
       index: 0
       dq: 0.5
-      quadratic: false
+      quadratic: true
 
 analysis:
-  - reactioncoordinate: {file: q.dat.gz, nstep: 5, type: atom, property: q, index: 0}
+  - reactioncoordinate: {file: q.dat.gz, nstep: 2, type: atom, property: q, index: 0}
   - sanity: {nstep: 10000}
 

--- a/src/energy.cpp
+++ b/src/energy.cpp
@@ -652,7 +652,7 @@ ContainerOverlap::ContainerOverlap(const Space& spc) : spc(spc) { name = "Contai
 
 Isobaric::Isobaric(const json& j, const Space& spc) : spc(spc) {
     name = "isobaric";
-    citation_information = "Frenkel & Smith 2nd Ed (Eq. 5.4.13)";
+    citation_information = "doi:10/dhn4v6 alt. Frenkel & Smith, 2nd Ed (Eq. 5.4.13)";
 
     for (const auto& [key, conversion_factor] : pressure_units) {
         if (auto it = j.find(key); it != j.end()) {

--- a/src/move.h
+++ b/src/move.h
@@ -358,26 +358,41 @@ class VolumeMove : public MoveBase {
  */
 class ChargeMove : public MoveBase {
   private:
-    Average<double> mean_bias;
-    bool use_quadratic_displacement = true; //!< Displace linearly along q^2
     Average<double> mean_squared_charge_displacement;
+    Change::GroupChange group_change;
+
+    void _move(Change& change) override;
+    void _accept(Change&) override;
+    void _reject(Change&) override;
+    void _from_json(const json& j) override;
+    virtual double getChargeDisplacement(const Particle& particle) const;
+    ChargeMove(Space& spc, std::string_view name, std::string_view cite);
+
+  protected:
     double max_charge_displacement = 0.0;
     double charge_displacement = 0.0;
     ParticleVector::size_type particle_index;
-    Change::GroupChange group_change;
-
-    void _to_json(json &j) const override;
-    void _from_json(const json &j) override;
-    void _move(Change &change) override;
-    void _accept(Change &) override;
-    void _reject(Change &) override;
-    double bias(Change& change, double old_energy, double new_energy) override;
-    double getChargeDisplacement(const Particle& particle) const;
-
-    ChargeMove(Space& spc, std::string_view name, std::string_view cite);
+    void _to_json(json& j) const override;
 
   public:
-    explicit ChargeMove(Space &spc);
+    explicit ChargeMove(Space& spc);
+};
+
+/**
+ * @brief As `ChargeMove` but performs displacements in squared charge
+ *
+ * The displacement is q' = sqrt(q^2 + dq^2) and the following bias
+ * must be added to enforce symmetry: u/kT = ln( |q'/q| )
+ */
+class QuadraticChargeMove : public ChargeMove {
+  private:
+    Average<double> mean_bias;
+    void _to_json(json& j) const override;
+    double getChargeDisplacement(const Particle& particle) const override;
+    double bias(Change& change, double old_energy, double new_energy) override;
+
+  public:
+    explicit QuadraticChargeMove(Space& spc);
 };
 
 /**

--- a/src/move.h
+++ b/src/move.h
@@ -358,6 +358,8 @@ class VolumeMove : public MoveBase {
  */
 class ChargeMove : public MoveBase {
   private:
+    Average<double> mean_bias;
+    bool use_quadratic_displacement = true; //!< Displace linearly along q^2
     Average<double> mean_squared_charge_displacement;
     double max_charge_displacement = 0.0;
     double charge_displacement = 0.0;
@@ -370,9 +372,8 @@ class ChargeMove : public MoveBase {
     void _accept(Change &) override;
     void _reject(Change &) override;
     double bias(Change& change, double old_energy, double new_energy) override;
+    double getChargeDisplacement(const Particle& particle) const;
 
-  public:
-  private:
     ChargeMove(Space& spc, std::string_view name, std::string_view cite);
 
   public:

--- a/src/move.h
+++ b/src/move.h
@@ -369,7 +369,10 @@ class ChargeMove : public MoveBase {
     void _move(Change &change) override;
     void _accept(Change &) override;
     void _reject(Change &) override;
+    double bias(Change& change, double old_energy, double new_energy) override;
 
+  public:
+  private:
     ChargeMove(Space& spc, std::string_view name, std::string_view cite);
 
   public:


### PR DESCRIPTION
This adds the ability to displace charges linearly along q^2, useful for e.g. solvation free energy calculations.

- [x] Add test to CTest
- [x] Verify bias algorithm