### PR TITLE
Displacement analysis

### DIFF
--- a/docs/schema.yml
+++ b/docs/schema.yml
@@ -892,6 +892,21 @@ properties:
                     type: object
                     additionalProperties: false
 
+                displacement:
+                    properties:
+                        nstep: {type: integer}
+                        nskip: {type: integer, default: 0, description: Initial steps to skip}
+                        molecule: {type: string, description: "Molecule type to operate on"}
+                        reset_interval: {type: integer, default: 0, description: "Steps between resetting reference positions"}
+                        max_displacement: {type: number, default: 0, description: "Mox. possible displacement between samples"}
+                        histogram_file: {type: string, default: "displacement_histogram.dat", description: "Name of P(r) histogram file"}
+                        histogram_resolution: {type: number, default: 1.0, description: "Resolution of saved histogram (Å)"}
+                        file: {type: string, description: "Name of steps-x-y-z-r file", pattern: "(.*?)\\.(dat|dat.gz)$"}
+
+                    required: [molecule, nstep]
+                    type: object
+                    additionalProperties: false
+
                 polymershape:
                     properties:
                         nstep: {type: integer}

--- a/src/analysis.h
+++ b/src/analysis.h
@@ -148,6 +148,11 @@ class FileReactionCoordinate : public Analysisbase {
 
 /**
  * @brief Tracks displacements of particles
+ *
+ * This tracks particle displacements relative to a (dynamic) reference position. For
+ * first particle only, a trajectory file and histogram can be saved to disk.
+ *
+ * @todo So far an atomic group is assumed
  */
 class Displacement : public Analysisbase {
   protected:
@@ -167,13 +172,15 @@ class Displacement : public Analysisbase {
     int reference_reset_interval = std::numeric_limits<int>::max(); //!< Renew reference at given interval
 
     auto getPositions() {
-        auto full_group = [&](const Group& group) { return ranges::make_subrange(group.begin(), group.trueend()); };
+        auto active_and_inactive = [&](const Group& group) {
+            return ranges::make_subrange(group.begin(), group.trueend());
+        };
         namespace rv = ranges::cpp20::views;
-        return spc.findMolecules(molid, Space::Selection::ALL) | rv::transform(full_group) | rv::join |
+        return spc.findMolecules(molid, Space::Selection::ALL) | rv::transform(active_and_inactive) | rv::join |
                rv::transform(&Particle::pos);
     } // @todo Make this injectable to support e.g. molecular groups
 
-    void resetReferencePositions(); //!< Store current positions as reference
+    void resetReferencePosition(const Point& position, int index);   //!< Store current positions as reference
     Point getOffset(const Point& diff, Eigen::Vector3i& cell) const; //!< Offset to other cells
     void sampleDisplacementFromReference(const Point& position, const int index);
     void _sample() override;

--- a/src/aux/sparsehistogram.h
+++ b/src/aux/sparsehistogram.h
@@ -26,6 +26,7 @@ template <typename T = double> class SparseHistogram {
 
   public:
     explicit SparseHistogram(T resolution) : resolution(resolution) {}
+    const T getResolution() const { return resolution; }
     void add(const T value) {
         if (std::isfinite(value)) {
             const auto index = static_cast<map_type::key_type>(std::round(value / resolution));


### PR DESCRIPTION
Add translational displacement analysis for tracking particles from initial positions. Used for e.g. dynamic monte carlo.