### PR TITLE
Speciation refactoring

### DIFF
--- a/docs/_docs/topology.md
+++ b/docs/_docs/topology.md
@@ -238,7 +238,7 @@ i.e. hard-sphere potentials the initial energy may be infinite.
 Faunus supports density fluctuations, coupled to chemical equilibria with
 explicit and/or implicit particles via their chemical potentials as
 defined in the `reactionlist` detailed below, as well as in `atomlist` and
-`moleculelist`. The level of flexibility is very high and reactions can be
+`moleculelist`. The level of flexibility is high and reactions can be
 freely composed.
 
 The move involves deletion and insertion of reactants and products and it is
@@ -253,7 +253,7 @@ into products (right of `=`) that may be a mix of atomic and molecular species.
 
 - all species, `+`, and `=` must be surrounded by white-space
 - atom and molecule names cannot overlap
-- species can be repeated to match the desired stoichiometry, e.g. `A + A = C`
+- species can be repeated to match the desired stoichiometry, _e.g._ `A + A = C`
 
 Available keywords:
 
@@ -278,7 +278,7 @@ moleculelist:
   - Na+: {atoms: [na], atomic: true, activity: 0.1}
   - Cl-: {atoms: [cl], atomic: true, activity: 0.1}
 reactionlist:
-  - = Na+ + Cl+: {} # note: molecules, not atoms
+  - "= Na+ + Cl+": {} # note: molecules, not atoms
 moves:
   - rcmc: {} # activate speciation move
 ~~~
@@ -286,7 +286,7 @@ moves:
 The same setup can be used also for molecular molecules, _i.e._ molecules with `atomic: false`.
 
 
-### Example: Acid/base titration with _implicit_ protons
+### Example: Acid-base titration with _implicit_ protons
 
 An _implicit_ atomic reactant or product is included in the reaction but not 
 explicitly in the simulation cell.
@@ -312,7 +312,7 @@ only with Hamiltonians where this is allowed. This could for example be in syste
 Yukawa interactions. 
 
 
-### Example: Acid/base titration coupled with Grand Canonical Salt
+### Example: Acid-base titration coupled with Grand Canonical Salt
 
 To respect electroneutrality when swapping species, we can associate the titration move with
 an artificial insertion or deletion of salt ions. These ions should be present under constant
@@ -329,9 +329,9 @@ moleculelist:
   - Na+: {atoms: [na], atomic: true, activity: 0.1}
   - Cl-: {atoms: [cl], atomic: true, activity: 0.1}
 reactionlist:
-  - COOH + Cl- = COO- + H+: {pK: 4.8} # electroneutral!
-  - COOH = Na+ + COO- + H+: {pK: 4.8} # electroneutral!
-  - = Na+ + Cl-: {} # grand canonical salt
+  - "COOH + Cl- = COO- + H+": {pK: 4.8} # electroneutral!
+  - "COOH = Na+ + COO- + H+": {pK: 4.8} # electroneutral!
+  - "= Na+ + Cl-": {} # grand canonical salt
 ~~~
 
 For the first reaction, $K$ is divided by both $a_{\mathrm{H^+}}$ and $a_{\mathrm{Cl^-}}$, so that the final equilibrium constant
@@ -345,11 +345,14 @@ since the Grand Canonical ensemble ensures constant salt activity.
 
 ### Example: Precipitation of Calcium Hydroxide using _implicit_ molecules
 
-Here we introduce a solid phase of Ca(OH)2 and its solubility product
+Here we introduce a solid phase of Ca(OH)₂ and its solubility product
 to predict the amount of dissolved calcium and hydroxide ions. Note that
 we start from an empty simulation box (both ions are inactive) and the solid
-phase is treated _implicitly_, i.e. it never inters the simulation box.
-Additional coupled reactions can naturally be introduced in order to study complex
+phase is treated _implicitly_, _i.e._ it never inters the simulation box.
+If a forward reaction is made, one implicit molecule (out 200 in total) will
+be converted into explicit molecules.
+Once all 200 have been consumed, only backward reactions are possible.
+Additional, coupled reactions can be introduced to study complex
 equilibrium systems under influence of intermolecular interactions.
 
 ~~~ yaml
@@ -368,12 +371,20 @@ reactionlist:
 
 ### Example: Swapping between molecular conformations
 
-The following can be used to alternate between different molecular conformations
+The following can be used to alternate between different molecular conformations.
+When swapping, the mass center position and orientation are randomly generated.
 
 ~~~ yaml
 moleculelist:
-  - A: {atomic: false, structure: ...}
-  - B: {atomic: false, structure: ...}
+  - A: {structure: "conformationA.xyz", ...}
+  - B: {structure: "conformationB.xyz", ...}
 reactionlist:
-  - A = B: {lnK: 0.69} # K=2, "B" twice as likely as "A"
+  - "A = B": {lnK: 0.69} # K=2, "B" twice as likely as "A"
 ~~~
+
+### Internal degrees of freedom (experimental)
+
+If a fluctuating molecule has internal degreees of freedom, the internal bond energy is included
+as a bias so that the internal state does not affect the acceptance.
+To disable this behavior, a minor code modification is currently required (see `MolecularGroupDeActivator::apply_bond_bias`).
+

--- a/src/analysis.cpp
+++ b/src/analysis.cpp
@@ -785,7 +785,7 @@ void AtomDensity::_sample() {
     DensityBase::_sample();
     std::set<id_type> unique_reactive_atoms;
     for (const auto& reaction : reactions) { // in case of reactions involving atoms (swap moves)
-        const auto& atomic_ids = reaction.getReactantsAndProducts().first;
+        const auto& atomic_ids = reaction.participatingAtomsAndMolecules().first;
         unique_reactive_atoms.insert(atomic_ids.begin(), atomic_ids.end());
     }
     ranges::cpp20::for_each(unique_reactive_atoms, [&](auto id) {
@@ -818,7 +818,7 @@ std::map<DensityBase::id_type, int> AtomDensity::count() const {
 AtomDensity::AtomDensity(const json& j, Space& spc) : DensityBase(spc, Faunus::atoms, "atom_density") {
     from_json(j);
     for (const auto& reaction : Faunus::reactions) { // in case of reactions involving atoms (swap moves)
-        const auto reactive_atomic_species = reaction.getReactantsAndProducts().first;
+        const auto reactive_atomic_species = reaction.participatingAtomsAndMolecules().first;
         for (auto atomid : reactive_atomic_species) {
             atomswap_probability_density[atomid].setResolution(1, 0);
         }
@@ -828,7 +828,7 @@ AtomDensity::AtomDensity(const json& j, Space& spc) : DensityBase(spc, Faunus::a
 void AtomDensity::_to_disk() {
     DensityBase::_to_disk();
     for (const auto& reaction : Faunus::reactions) {
-        const auto reactive_atomic_species = reaction.getReactantsAndProducts().first;
+        const auto reactive_atomic_species = reaction.participatingAtomsAndMolecules().first;
         for (auto atomid : reactive_atomic_species) {
             writeTable(names.at(atomid), atomswap_probability_density.at(atomid));
         }

--- a/src/molecule.cpp
+++ b/src/molecule.cpp
@@ -971,6 +971,10 @@ bool ReactionData::containsAtomicSwap() const {
     return (left_atoms.size() == 1 && right_atoms.size() == 1);
 }
 
+const ReactionData::MapFilter ReactionData::is_implicit_group = [](const auto& pair) {
+    return Faunus::molecules.at(pair.first).isImplicit();
+};
+
 const ReactionData::MapFilter ReactionData::not_implicit_group = [](const auto& pair) {
     return !Faunus::molecules.at(pair.first).isImplicit();
 };

--- a/src/molecule.cpp
+++ b/src/molecule.cpp
@@ -833,23 +833,20 @@ TEST_CASE("[Faunus] Conformation") {
 
 ReactionData::Direction ReactionData::getDirection() const { return direction; }
 
-void ReactionData::setDirection(ReactionData::Direction dir) {
-    if (dir != direction) {
-        direction = dir;
-        lnK = -lnK;
+void ReactionData::setDirection(ReactionData::Direction new_direction) {
+    if (new_direction != direction) {
+        direction = new_direction;
     }
 }
 
-std::pair<const ReactionData::StoichiometryMap&, const ReactionData::StoichiometryMap&>
-ReactionData::getProducts() const {
+ReactionData::AtomicAndMolecularPair ReactionData::getProducts() const {
     if (direction == Direction::RIGHT) {
         return {right_atoms, right_molecules};
     }
     return {left_atoms, left_molecules};
 }
 
-std::pair<const ReactionData::StoichiometryMap&, const ReactionData::StoichiometryMap&>
-ReactionData::getReactants() const {
+ReactionData::AtomicAndMolecularPair ReactionData::getReactants() const {
     if (direction == Direction::RIGHT) {
         return {left_atoms, left_molecules};
     }
@@ -859,7 +856,7 @@ ReactionData::getReactants() const {
 /**
  * @return Pair of sets with id's for atoms and molecules participating in the reaction (i.e. reactants & products)
  */
-std::pair<std::set<int>, std::set<int>> ReactionData::getReactantsAndProducts() const {
+std::pair<std::set<int>, std::set<int>> ReactionData::participatingAtomsAndMolecules() const {
     auto extract_keys = [](const auto &map, std::set<int> &keys) { // map keys --> set
         std::transform(map.begin(), map.end(), std::inserter(keys, keys.end()), [](auto &pair) { return pair.first; });
     };
@@ -875,15 +872,16 @@ std::pair<std::set<int>, std::set<int>> ReactionData::getReactantsAndProducts() 
 }
 
 void ReactionData::reverseDirection() {
-    if (direction == Direction::RIGHT)
+    if (direction == Direction::RIGHT) {
         setDirection(Direction::LEFT);
-    else
+    } else {
         setDirection(Direction::RIGHT);
+    }
 }
 
 void from_json(const json &j, ReactionData &a) {
     if (!j.is_object() || j.size() != 1) {
-        throw std::runtime_error("Invalid JSON data for ReactionData");
+        throw ConfigurationError("Invalid JSON data for ReactionData");
     }
 
     a.direction = ReactionData::Direction::RIGHT;
@@ -891,7 +889,7 @@ void from_json(const json &j, ReactionData &a) {
     for (const auto& molecule : Faunus::molecules) {
         for (const auto& atom : Faunus::atoms) {
             if (molecule.name == atom.name) {
-                throw std::runtime_error("Molecules and atoms must have different names");
+                throw ConfigurationError("Molecules and atoms must have different names");
             }
         }
     }
@@ -899,9 +897,9 @@ void from_json(const json &j, ReactionData &a) {
     for (const auto& [key, val] : j.items()) {
         a.reaction_str = key; // reaction string, e.g. "A + B = C"
         a.only_neutral_molecules = val.value("neutral", false);
-        if (val.count("lnK") == 1) {
+        if (val.contains("lnK")) {
             a.lnK_unmodified = val.at("lnK").get<double>();
-        } else if (val.count("pK") == 1) {
+        } else if (val.contains("pK")) {
             a.lnK_unmodified = -std::log(10) * val.at("pK").get<double>();
         } else {
             a.lnK_unmodified = 0.0;
@@ -911,20 +909,20 @@ void from_json(const json &j, ReactionData &a) {
         // helper function used to parse and register atom and molecule names; updates lnK
         auto registerNames = [&](auto& names, auto&& atom_map, auto& mol_map, double sign) {
             for (const auto& atom_or_molecule_name : names) { // loop over species on reactant side (left)
-                auto [atom_iter, molecule_iter] = a.findAtomOrMolecule(atom_or_molecule_name);
-                if (atom_iter != Faunus::atoms.end()) { // atomic reactants
-                    if (atom_iter->implicit) {          // if atom is implicit, multiply K by its activity
-                        if (atom_iter->activity > 0) {
-                            a.lnK += sign * std::log(atom_iter->activity / 1.0_molar);
+                auto [atom, molecule] = a.findAtomOrMolecule(atom_or_molecule_name);
+                if (atom != Faunus::atoms.end()) { // atomic reactants
+                    if (atom->implicit) {          // if atom is implicit, multiply K by its activity
+                        if (atom->activity > 0.0) {
+                            a.lnK += sign * std::log(atom->activity / 1.0_molar);
                         }
                     } else {
-                        assert(std::fabs(atom_iter->activity) <= pc::epsilon_dbl);
-                        atom_map[atom_iter->id()]++; // increment stoichiometric number
+                        assert(std::fabs(atom->activity) <= pc::epsilon_dbl);
+                        atom_map[atom->id()]++; // increment stoichiometric number
                     }
-                } else if (molecule_iter != Faunus::molecules.end()) { // molecular reactants (incl. "atomic" groups)
-                    mol_map[molecule_iter->id()]++;                    // increment stoichiometric number
-                    if (molecule_iter->activity > 0) { // assume activity not part of K -> divide by activity
-                        a.lnK -= sign * std::log(molecule_iter->activity / 1.0_molar);
+                } else if (molecule != Faunus::molecules.end()) { // molecular reactants (incl. "atomic" groups)
+                    mol_map[molecule->id()]++;                    // increment stoichiometric number
+                    if (molecule->activity > 0) { // assume activity not part of K -> divide by activity
+                        a.lnK -= sign * std::log(molecule->activity / 1.0_molar);
                     }
                 } else {
                     assert(false); // we should never reach here
@@ -935,11 +933,6 @@ void from_json(const json &j, ReactionData &a) {
         std::tie(a.left_names, a.right_names) = parseReactionString(a.reaction_str); // lists of species
         registerNames(a.left_names, a.left_atoms, a.left_molecules, 1.0);            // reactants
         registerNames(a.right_names, a.right_atoms, a.right_molecules, -1.0);        // products
-
-        // If exactly one atomic reactant and one atomic products, it's a swap move!
-        if (a.left_atoms.size() == 1 and a.right_atoms.size() == 1) {
-            a.swap = true;
-        }
     }
 }
 
@@ -947,11 +940,11 @@ void to_json(json &j, const ReactionData &reaction) {
     ReactionData a = reaction;
     // we want lnK to show for LEFT-->RIGHT direction
     a.setDirection(ReactionData::Direction::RIGHT);
-    j[a.reaction_str] = {{"lnK", a.lnK_unmodified},
+    j[a.getReactionString()] = {{"lnK", a.lnK_unmodified},
                          {"pK", -a.lnK_unmodified / std::log(10)},
-                         {"swap_move", a.swap},
+                         {"swap_move", a.containsAtomicSwap()},
                          {"neutral", a.only_neutral_molecules},
-                         {"pK'", -a.lnK / std::log(10)}};
+                         {"pK'", -a.freeEnergy() / std::log(10)}};
 }
 
 std::pair<decltype(Faunus::atoms)::const_iterator, decltype(Faunus::molecules)::const_iterator>
@@ -963,6 +956,31 @@ ReactionData::findAtomOrMolecule(const std::string& atom_or_molecule_name) {
     }
     return {atom_iter, molecule_iter};
 }
+
+double ReactionData::freeEnergy() const { return (direction == Direction::RIGHT) ? lnK : -lnK; }
+
+const std::string& ReactionData::getReactionString() const { return reaction_str; }
+
+bool ReactionData::containsAtomicSwap() const {
+    // If exactly one atomic reactant and one atomic products, it's a swap move!
+    return (left_atoms.size() == 1 && right_atoms.size() == 1);
+}
+
+const ReactionData::MapFilter ReactionData::not_implicit_group = [](const auto& pair) {
+    return !Faunus::molecules.at(pair.first).isImplicit();
+};
+
+const ReactionData::MapFilter ReactionData::not_implicit_atom = [](const auto& pair) {
+    return !Faunus::atoms.at(pair.first).implicit;
+};
+
+const ReactionData::MapFilter ReactionData::is_atomic_group = [](const auto& pair) {
+    return Faunus::molecules.at(pair.first).isAtomic();
+};
+
+const ReactionData::MapFilter ReactionData::is_molecular_group = [](const auto& pair) {
+    return Faunus::molecules.at(pair.first).isMolecular();
+};
 
 TEST_CASE("[Faunus] ReactionData") {
     using doctest::Approx;
@@ -986,8 +1004,8 @@ TEST_CASE("[Faunus] ReactionData") {
     r = j["reactionlist"].get<decltype(reactions)>();
 
     CHECK(r.size() == 1);
-    CHECK(r.front().reaction_str == "A = B");
-    CHECK(r.front().lnK == Approx(-10.051 - std::log(0.2)));
+    CHECK(r.front().getReactionString() == "A = B");
+    CHECK(r.front().freeEnergy() == Approx(-10.051 - std::log(0.2)));
 }
 
 void MoleculeInserter::from_json(const json &) {}

--- a/src/molecule.cpp
+++ b/src/molecule.cpp
@@ -839,6 +839,11 @@ void ReactionData::setDirection(ReactionData::Direction new_direction) {
     }
 }
 
+void ReactionData::setRandomDirection(Random& random) {
+    auto direction = static_cast<ReactionData::Direction>((char)random.range(0, 1)); // random direction
+    setDirection(direction);
+}
+
 ReactionData::AtomicAndMolecularPair ReactionData::getProducts() const {
     if (direction == Direction::RIGHT) {
         return {right_atoms, right_molecules};

--- a/src/molecule.h
+++ b/src/molecule.h
@@ -413,6 +413,7 @@ class ReactionData {
 
   public:
     void setDirection(Direction);                 //!< Set directions of the process
+    void setRandomDirection(Random &random);      //!< Set random direction (left or right)
     Direction getDirection() const;               //!< Get direction of the process
     void reverseDirection();                      //!< Reverse direction of reaction
     AtomicAndMolecularPair getProducts() const;   //!< Pair with atomic and molecular products

--- a/src/molecule.h
+++ b/src/molecule.h
@@ -383,6 +383,7 @@ class ReactionData {
     using MapFilter = std::function<bool(const ReactionData::StoichiometryPair&)>;
     enum class Direction : char { LEFT = 0, RIGHT = 1 };
 
+    const static MapFilter is_implicit_group;
     const static MapFilter not_implicit_group;
     const static MapFilter not_implicit_atom;
     const static MapFilter is_atomic_group;

--- a/src/montecarlo.cpp
+++ b/src/montecarlo.cpp
@@ -61,12 +61,6 @@ void MetropolisMonteCarlo::init() {
             throw std::runtime_error("error aligning energies - this could be a bug...");
         }
     }
-
-    // Inject reference to Space into `SpeciationMove`
-    // Needed to calc. differences in ideal excess chem. potentials
-    for (auto& speciation_move : moves->getMoves().find<Move::SpeciationMove>()) {
-        speciation_move->setOther(*state->spc);
-    }
 }
 
 /**
@@ -102,7 +96,7 @@ MetropolisMonteCarlo::MetropolisMonteCarlo(const json &j)
     faunus_logger->set_level(spdlog::level::off); // do not duplicate log info
     trial_state = std::make_unique<State>(j);     // ...for the trial state
     faunus_logger->set_level(original_log_level); // restore original log level
-    moves = std::make_unique<Move::MoveCollection>(j.at("moves"), *trial_state->spc, *trial_state->pot);
+    moves = std::make_unique<Move::MoveCollection>(j.at("moves"), *trial_state->spc, *trial_state->pot, *state->spc);
     init();
 }
 

--- a/src/move.h
+++ b/src/move.h
@@ -497,7 +497,7 @@ class MoveCollection {
     move_iterator sample();                                //!< Pick move from a weighted, random distribution
 
   public:
-    MoveCollection(const json& list_of_moves, Space& spc, Energy::Hamiltonian& hamiltonian);
+    MoveCollection(const json& list_of_moves, Space& spc, Energy::Hamiltonian& hamiltonian, Space &old_spc);
     void addMove(std::shared_ptr<MoveBase>&& move);                 //!< Register new move with correct weight
     const BasePointerVector<MoveBase>& getMoves() const;            //!< Get list of moves
     friend void to_json(json& j, const MoveCollection& propagator); //!< Generate json output

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -10,6 +10,9 @@ namespace Faunus {
 bool Change::GroupChange::operator<(const Faunus::Change::GroupChange& other) const {
     return group_index < other.group_index;
 }
+void Change::GroupChange::sort() {
+    std::sort(relative_atom_indices.begin(), relative_atom_indices.end());
+}
 
 void Change::clear() {
     *this = Change();

--- a/src/space.h
+++ b/src/space.h
@@ -43,6 +43,7 @@ struct Change {
         std::vector<index_type> relative_atom_indices; //!< A subset of particles changed (sorted; empty if `all`=true)
 
         bool operator<(const GroupChange& other) const; //!< Comparison operator based on `group_index`
+        void sort(); //!< Sort group indices
     };
 
     std::vector<GroupChange> groups; //!< Touched groups by index in group vector

--- a/src/speciation.cpp
+++ b/src/speciation.cpp
@@ -220,6 +220,10 @@ double SpeciationMove::bias([[maybe_unused]] Change& change, [[maybe_unused]] do
     return -reaction->freeEnergy() + bias_energy;
 }
 
+/**
+ * @todo Space::sync() already handles implicit reservoir updates.
+ *       Also move implicit reservoir averaging to Analysis namespace
+ */
 void SpeciationMove::_accept(Change&) {
     direction_ratio[reaction].update(reaction->getDirection(), true);
     const auto& molecular_products = reaction->getProducts().second;
@@ -244,6 +248,10 @@ void SpeciationMove::_accept(Change&) {
     }
 }
 
+/**
+ * @todo Space::sync() already handles implicit reservoir updates.
+ *       Also move implicit reservoir averaging to Analysis namespace
+ */
 void SpeciationMove::_reject([[maybe_unused]] Change& change) {
     direction_ratio[reaction].update(reaction->getDirection(), false);
 

--- a/src/speciation.h
+++ b/src/speciation.h
@@ -29,7 +29,7 @@ class ReactionValidator {
  */
 class GroupDeActivator {
   public:
-    using ChangeAndBias = std::pair<Change::GroupChange, double>; //!< Group change and possible bias energy
+    using ChangeAndBias = std::pair<Change::GroupChange, double>; //!< Group change and bias energy
     using OptionalInt = std::optional<int>;
     virtual ChangeAndBias activate(Group& group, OptionalInt num_particles = std::nullopt) = 0;
     virtual ChangeAndBias deactivate(Group& group, OptionalInt num_particles = std::nullopt) = 0;
@@ -41,9 +41,9 @@ class GroupDeActivator {
  */
 class AtomicGroupDeActivator : public GroupDeActivator {
   private:
-    Space& spc;
-    Space& old_spc;
-    Random& slump;
+    Space& spc;     //!< Trial space
+    Space& old_spc; //!< Old (accepted) space
+    Random& random;
 
   public:
     AtomicGroupDeActivator(Space& spc, Space& old_spc, Random& random);

--- a/src/speciation.h
+++ b/src/speciation.h
@@ -18,9 +18,50 @@ class ValidateReaction {
     bool canProduceMolecularGroups(const ReactionData& reaction) const;
     bool canReduceAtomicGrups(const ReactionData& reaction) const;
     bool canProduceAtomicGroups(const ReactionData& reaction) const;
+
   public:
     explicit ValidateReaction(const Space& spc);
     bool reactionIsPossible(const ReactionData& reaction) const;
+};
+
+/**
+ * Base class for (de)activating groups
+ *
+ * @todo Not yet implemented
+ */
+class GroupDeActivator {
+  public:
+    using ChangeAndBias = std::pair<Change::GroupChange, double>; //!< Group change and possible bias energy
+    using OptionalInt = std::optional<int>;
+    virtual ChangeAndBias activate(Group& group, OptionalInt num_particles = std::nullopt) = 0;
+    virtual ChangeAndBias deactivate(Group& group, OptionalInt num_particles = std::nullopt) = 0;
+    virtual ~GroupDeActivator() = default;
+};
+
+class AtomicGroupDeActivator : public GroupDeActivator {};
+
+/**
+ * Helper class to (de)activate a single molecular group
+ *
+ * Activation policy:
+ * - Set random mass center position and orientation
+ * - Apply PBC wrapping
+ * - Bias is set to *negative* internal bond energy
+ *
+ * Deactivation policy:
+ * - Remove PBC before deactivation
+ * - Bias is set to *positive* internal bond energy
+ */
+class MolecularGroupDeActivator : public GroupDeActivator {
+  private:
+    Space& spc;
+    std::function<void(Group&)> setGroupCoordinates; //!< Sets position and rotation of inserted group
+    double getBondEnergy(const Group& group) const;
+
+  public:
+    MolecularGroupDeActivator(Space& spc, Random& random);
+    ChangeAndBias activate(Group& group, OptionalInt num_particles = std::nullopt) override;
+    ChangeAndBias deactivate(Group& group, OptionalInt num_particles = std::nullopt) override;
 };
 
 /**
@@ -42,10 +83,14 @@ class ValidateReaction {
 class SpeciationMove : public MoveBase {
   private:
     using reaction_iterator = decltype(Faunus::reactions)::iterator;
-    Space* other_spc = nullptr;         //!< Old space (particles, groups)
+    Space* old_spc = nullptr;           //!< Old space (particles, groups)
     double bond_energy = 0;             //!< Accumulated bond energy if inserted/deleted molecule
     reaction_iterator reaction;         //!< Randomly selected reaction
     ValidateReaction validate_reaction; //!< Helper to check if reaction is doable
+    std::unique_ptr<GroupDeActivator> molecularGroupDeActivator; //!< (de)activator for molecular groups
+    std::unique_ptr<GroupDeActivator> atomicGroupDeActivator;    //!< (de)activator for atomic groups
+
+    std::function<void(Group&)> setActivatedGroupCoordinates; //!< Sets position and rotation of inserted group
 
     class AcceptanceData {
       public:
@@ -55,27 +100,27 @@ class SpeciationMove : public MoveBase {
     std::map<reaction_iterator, AcceptanceData> acceptance;
     std::map<int, Average<double>> average_reservoir_size; //!< Average number of implicit molecules
 
-    void _to_json(json &) const override;
-    void _from_json(const json &) override;
-    void _move(Change &) override;         //!< Perform move
-    void _accept(Change &) override;       //!< Called when accepted
-    void _reject(Change &) override;       //!< Called when rejected
-    bool enoughImplicitMolecules() const;  //!< Check if we have enough implicit matter for reaction
-    void atomicSwap(Change &);             //!< Swap atom type
-    void deactivateAllReactants(Change &); //!< Delete reactant species
-    void activateAllProducts(Change &);    //!< Insert product species
+    void _to_json(json&) const override;
+    void _from_json(const json&) override;
+    void _move(Change&) override;                            //!< Perform move
+    void _accept(Change&) override;                          //!< Called when accepted
+    void _reject(Change&) override;                          //!< Called when rejected
+    bool enoughImplicitMolecules() const;                    //!< Check if we have enough implicit matter for reaction
+    void atomicSwap(Change&);                                //!< Swap atom type
+    void deactivateAllReactants(Change&);                    //!< Delete reactant species
+    void activateAllProducts(Change&);                       //!< Insert product species
     void updateGroupMassCenters(const Change& change) const; //!< Update affected molecular mass centers
+    double getBondEnergy(const Group& group) const;          //!< Summed bond energy of group
 
     Change::GroupChange contractAtomicGroup(Space::GroupType&, Space::GroupType&, int); //!< Contract atomic group
     Change::GroupChange expandAtomicGroup(Space::GroupType&, int);                      //!< Expand atomic group
     Change::GroupChange activateMolecularGroup(Space::GroupType&);                      //!< Activate molecular group
     Change::GroupChange deactivateMolecularGroup(Space::GroupType&);                    //!< Deactivate molecular group
 
-    SpeciationMove(Space& spc, std::string_view name, std::string_view cite);
+    SpeciationMove(Space& spc, Space &old_spc, std::string_view name, std::string_view cite);
 
   public:
-    SpeciationMove(Space& spc);
-    void setOther(Space& spc);
+    SpeciationMove(Space& spc, Space &old_spc);
     double bias(Change& change, double old_energy,
                 double new_energy) override; //!< adds extra energy change not captured by the Hamiltonian
 

--- a/src/speciation.h
+++ b/src/speciation.h
@@ -113,7 +113,6 @@ class SpeciationMove : public MoveBase {
   private:
     using reaction_iterator = decltype(Faunus::reactions)::iterator;
     reaction_iterator reaction;                                //!< Randomly selected reaction
-    Space* old_spc = nullptr;                                  //!< Old space (particles, groups)
     double bias_energy = 0.0;                                  //!< Group (de)activators may add bias
     ReactionValidator reaction_validator;                      //!< Helper to check if reaction is doable
     ReactionDirectionRatio direction_ratio;                    //!< Track acceptance in each direction


### PR DESCRIPTION
This refactors the Speciation move and reaction class for increased flexibility and readability. In particular,  this will make it easier to accommodate anisotropic particles and custom insertion policies.

- [x] split monstrous `SpeciationMove` into several sub-classes
- [x] base class for group (de)activation
- [x] shuffle more responsibility to `ReactionData`
- [x] Generalise bias energy due to e.g. internal bonds
- [x] Allow for easier implementation of custom position and orientation generation
- [x] Update manual