### PR TITLE
Add policy to swap PSC patch information only

### DIFF
--- a/docs/_docs/moves.md
+++ b/docs/_docs/moves.md
@@ -237,7 +237,7 @@ Instead, use a hard-coded variant like `nonbonded_coulomblj` etc.
 `molecule`          | Molecule name to operate on
 `repeat=N`          | Number of repeats per MC sweep
 `keeppos=False`     | Keep original positions of `traj`
-`copy_policy=all`   | What to copy from library: `all`, `positions`, `charges`
+`copy_policy=all`   | What to copy from library. See table below.
 
 This will swap between different molecular conformations
 as defined in the [Molecule Properties](topology.html#molecule-properties) with `traj` and `trajweight`
@@ -251,6 +251,13 @@ is used, i.e. no rotation and no mass-center overlay.
 
 By default all information from the conformation is copied (`copy_policy=all`), including charges and particle type.
 To for example copy only positions, use `copy_policy=positions`. This can be useful when using speciation moves.
+
+`copy_policy`  | What is copied
+-------------- | ----------------------------------------------------
+`all`          | All particle properties
+`positions`    | Positions, only
+`charges`      | Charges, only
+`patches`      | Spherocylinder patch and length, but keep directions
 
 
 ### Pivot

--- a/docs/schema.yml
+++ b/docs/schema.yml
@@ -696,7 +696,7 @@ properties:
                         copy_policy:
                             type: string
                             default: all
-                            enum: [all, positions, charges]
+                            enum: [all, positions, charges, patches]
                             description: "Data to copy from library: all, positions, charges"
                     additionalProperties: false
 

--- a/src/move.cpp
+++ b/src/move.cpp
@@ -1212,6 +1212,15 @@ void ConformationSwap::copyConformation(ParticleVector& particles, ParticleVecto
     case CopyPolicy::ALL:
         copy_function = [](const Particle& src, Particle& dst) { dst = src; };
         break;
+    case CopyPolicy::PATCHES:
+        // Copy only PSC patch and length information but keep directions and position
+        copy_function = [](const Particle& src, Particle& dst) {
+            if (src.hasExtension() && src.getExt().isCylindrical()) {
+                auto &psc_dst = dst.getExt();
+                psc_dst.half_length = src.getExt().half_length;
+                psc_dst.setDirections(src.traits().sphero_cylinder, psc_dst.scdir, psc_dst.patchdir);
+            }
+        };
     case CopyPolicy::POSITIONS:
         copy_function = [](const Particle& src, Particle& dst) { dst.pos = src.pos; };
         break;

--- a/src/move.h
+++ b/src/move.h
@@ -284,7 +284,7 @@ class SmarterTranslateRotate : public TranslateRotate {
  */
 class ConformationSwap : public MoveBase {
   public:
-    enum class CopyPolicy { ALL, POSITIONS, CHARGES, INVALID }; //!< What to copy from conformation library
+    enum class CopyPolicy { ALL, POSITIONS, CHARGES, PATCHES, INVALID }; //!< What to copy from conformation library
   private:
     CopyPolicy copy_policy;
     RandomInserter inserter;
@@ -305,6 +305,7 @@ class ConformationSwap : public MoveBase {
 
 NLOHMANN_JSON_SERIALIZE_ENUM(ConformationSwap::CopyPolicy, {{ConformationSwap::CopyPolicy::INVALID, nullptr},
                                                             {ConformationSwap::CopyPolicy::ALL, "all"},
+                                                            {ConformationSwap::CopyPolicy::PATCHES, "patches"},
                                                             {ConformationSwap::CopyPolicy::POSITIONS, "positions"},
                                                             {ConformationSwap::CopyPolicy::CHARGES, "charges"}})
 


### PR DESCRIPTION
This adds a policy to swap patch information only when using `conformationswap`. Used to simulate the fibrillation process of patchy sphero-cylinders.
