### PR TITLE
Add minimum distance calculation to GroupMatrix analysis

### DIFF
--- a/docs/_docs/analysis.md
+++ b/docs/_docs/analysis.md
@@ -299,6 +299,7 @@ Note that inactive groups are always excluded from the analysis.
 -------------- | ---------------------------------------
 `energy`       | Sum of nonbonded energy terms in (_kT_)
 `com_distance` | Mass center distance (Å)
+`min_distance` | Minimum distance between particles (Å)
 
 The data is streamed in the sparse [Matrix Market format](https://math.nist.gov/MatrixMarket/formats.html)
 and can be further reduced by applying an optional `filter` defined by an

--- a/docs/schema.yml
+++ b/docs/schema.yml
@@ -944,7 +944,7 @@ properties:
                         file: {type: string, description: "Stream of matrices with group properties", pattern: "(.*?)\\.(mtx|mtx.gz)$"}
                         property:
                             type: string
-                            enum: [energy, com_distance]
+                            enum: [energy, com_distance, min_distance]
                             description: "Property to report"
                         filter:
                             type: string

--- a/src/analysis.cpp
+++ b/src/analysis.cpp
@@ -288,6 +288,10 @@ void SystemEnergy::_to_disk() {
 
 // --------------------------------
 
+/**
+ * Returns a lambda function that calculates a scalar property for a pair of groups.
+ * This can be their interaction energy; mass-center distance etc.
+ */
 std::function<double(const Group&, const Group&)> createGroupGroupProperty(const json& j, const Space& spc,
                                                                            Energy::Hamiltonian& hamiltonian) {
     const auto name = j.at("property").get<std::string>();
@@ -303,21 +307,21 @@ std::function<double(const Group&, const Group&)> createGroupGroupProperty(const
         };
     }
     if (name == "com_distance") { // mass-center distance
-        return [&](const Group& group_1, const Group& group_2) {
+        return [&geometry = spc.geometry](auto& group_1, auto& group_2) {
             assert(group_1.massCenter().has_value() && group_2.massCenter().has_value());
-            return std::sqrt(spc.geometry.sqdist(group_1.mass_center, group_2.mass_center));
+            return std::sqrt(geometry.sqdist(group_1.mass_center, group_2.mass_center));
         };
     }
-    if (name == "min_distance") { // mass-center distance
-        return [&](const Group& group_1, const Group& group_2) {
-            double min_dist = 1e9;
-            for (auto &particle1 : group_1) {
-                for (auto &particle2 : group_2) {
-                    auto dist = spc.geometry.sqdist(particle1.pos, particle2.pos);
-                    min_dist = std::min(min_dist, dist);
+    if (name == "min_distance") { // minimum distance between two groups
+        return [&geometry = spc.geometry](auto& group_1, auto& group_2) {
+            auto minimum = pc::infty;
+            for (auto &particle_i : group_1) {
+                for (auto &particle_j : group_2) {
+                    auto squared_distance = geometry.sqdist(particle_i.pos, particle_j.pos);
+                    minimum = std::min(minimum, squared_distance);
                 }
             }
-            return std::sqrt(min_dist));
+            return std::sqrt(minimum);
         };
     }    
     throw ConfigurationError("unknown property: {}", name);

--- a/src/analysis.cpp
+++ b/src/analysis.cpp
@@ -308,10 +308,16 @@ std::function<double(const Group&, const Group&)> createGroupGroupProperty(const
             return std::sqrt(spc.geometry.sqdist(group_1.mass_center, group_2.mass_center));
         };
     }
-    if (name == "com_distance") { // mass-center distance
+    if (name == "min_distance") { // mass-center distance
         return [&](const Group& group_1, const Group& group_2) {
-            assert(group_1.massCenter().has_value() && group_2.massCenter().has_value());
-            return std::sqrt(spc.geometry.sqdist(group_1.mass_center, group_2.mass_center));
+            double min_dist = 1e9;
+            for (auto &particle1 : group_1) {
+                for (auto &particle2 : group_2) {
+                    auto dist = spc.geometry.sqdist(particle1.pos, particle2.pos);
+                    min_dist = std::min(min_dist, dist);
+                }
+            }
+            return std::sqrt(min_dist));
         };
     }    
     throw ConfigurationError("unknown property: {}", name);

--- a/src/analysis.cpp
+++ b/src/analysis.cpp
@@ -308,6 +308,12 @@ std::function<double(const Group&, const Group&)> createGroupGroupProperty(const
             return std::sqrt(spc.geometry.sqdist(group_1.mass_center, group_2.mass_center));
         };
     }
+    if (name == "com_distance") { // mass-center distance
+        return [&](const Group& group_1, const Group& group_2) {
+            assert(group_1.massCenter().has_value() && group_2.massCenter().has_value());
+            return std::sqrt(spc.geometry.sqdist(group_1.mass_center, group_2.mass_center));
+        };
+    }    
     throw ConfigurationError("unknown property: {}", name);
 }
 


### PR DESCRIPTION
This adds `min_distance` keyword to groupanalysis.

- [x] Update `src/analysis.cpp`
- [x] Update `docs/schema.yml`
- [x] Update `docs/_docs/analysis.md`