### PR TITLE
Fix speciation moves for parallel tempering

### DIFF
--- a/src/speciation.cpp
+++ b/src/speciation.cpp
@@ -366,7 +366,7 @@ void SpeciationMove::atomicSwap(Change& change) {
     assert(atomic_products.size() == 1 and atomic_reactants.size() == 1);
 
     auto atomlist = spc.findAtoms(atomic_reactants.begin()->first);          // search all active molecules
-    auto& target_particle = *slump.sample(atomlist.begin(), atomlist.end()); // target particle to swap
+    auto& target_particle = *random_internal.sample(atomlist.begin(), atomlist.end()); // target particle to swap
     auto& group = *spc.findGroupContaining(target_particle);                 // find enclosing group
 
     auto& group_change = change.groups.emplace_back();
@@ -417,7 +417,8 @@ void SpeciationMove::activateMolecularGroups(Change& change) {
                               rv::filter(ReactionData::is_molecular_group);
 
     for (auto [molid, number_to_insert] : molecular_products) {
-        auto inactive = spc.findMolecules(molid, selection) | ranges::views::sample(number_to_insert, slump.engine) |
+        auto inactive = spc.findMolecules(molid, selection) |
+                        ranges::views::sample(number_to_insert, random_internal.engine) |
                         ranges::to<std::vector<std::reference_wrapper<Group>>>;
 
         ranges::for_each(inactive, [&](auto& group) {
@@ -458,7 +459,8 @@ void SpeciationMove::deactivateMolecularGroups(Change& change) {
                                rv::filter(nonzero_stoichiometric_coeff) | rv::filter(ReactionData::is_molecular_group);
 
     for (const auto& [molid, number_to_delete] : molecular_reactants) {
-        auto groups = spc.findMolecules(molid, selection) | ranges::views::sample(number_to_delete, slump.engine) |
+        auto groups = spc.findMolecules(molid, selection) |
+                      ranges::views::sample(number_to_delete, random_internal.engine) |
                       ranges::to<std::vector<std::reference_wrapper<Group>>>;
         std::for_each(groups.begin(), groups.end(), [&](auto& group) {
             auto [change_data, bias] = molecular_group_bouncer->deactivate(group);
@@ -519,8 +521,8 @@ void SpeciationMove::_move(Change& change) {
 }
 
 void SpeciationMove::setRandomReactionAndDirection() {
-    reaction = slump.sample(reactions.begin(), reactions.end());
-    reaction->setRandomDirection(slump);
+    reaction = random_internal.sample(reactions.begin(), reactions.end());
+    reaction->setRandomDirection(random_internal);
 }
 
 /**
@@ -585,9 +587,10 @@ void SpeciationMove::_reject([[maybe_unused]] Change& change) {
 
 SpeciationMove::SpeciationMove(Space& spc, Space& old_spc, std::string_view name, std::string_view cite)
     : MoveBase(spc, name, cite)
+    , random_internal(slump)
     , reaction_validator(spc) {
-    molecular_group_bouncer = std::make_unique<Speciation::MolecularGroupDeActivator>(spc, slump, true);
-    atomic_group_bouncer = std::make_unique<Speciation::AtomicGroupDeActivator>(spc, old_spc, slump);
+    molecular_group_bouncer = std::make_unique<Speciation::MolecularGroupDeActivator>(spc, random_internal, true);
+    atomic_group_bouncer = std::make_unique<Speciation::AtomicGroupDeActivator>(spc, old_spc, random_internal);
 }
 
 SpeciationMove::SpeciationMove(Space& spc, Space& old_spc)

--- a/src/speciation.cpp
+++ b/src/speciation.cpp
@@ -180,13 +180,13 @@ void MolecularGroupDeActivator::setPositionAndOrientation(Group& group) const {
     // translate to random position within simulation cell
     Point new_mass_center;
     geometry.randompos(new_mass_center, random); // place COM randomly in simulation box
-    Point displacement = geometry.vdist(new_mass_center, group.massCenter()->get());
+    const Point displacement = geometry.vdist(new_mass_center, group.massCenter()->get());
     group.translate(displacement, geometry.getBoundaryFunc());
 
     // generate random orientation
     const auto rotation_angle = 2.0 * pc::pi * (random() - 0.5); // -pi to pi
     const auto random_unit_vector = randomUnitVector(random);
-    Eigen::Quaterniond quaternion(Eigen::AngleAxisd(rotation_angle, random_unit_vector));
+    const Eigen::Quaterniond quaternion(Eigen::AngleAxisd(rotation_angle, random_unit_vector));
     group.rotate(quaternion, geometry.getBoundaryFunc());
 }
 
@@ -389,7 +389,7 @@ void SpeciationMove::atomicSwap(Change& change) {
  *
  * @todo This could make use of policies to customize how particles should be updated. Split to helper class.
  */
-void SpeciationMove::swapParticleProperties(Particle& particle, const int new_atomid) const {
+void SpeciationMove::swapParticleProperties(Particle& particle, const int new_atomid) {
     Particle new_particle(atoms.at(new_atomid), particle.pos);    // new particle with old position
     if (new_particle.hasExtension() || particle.hasExtension()) { // keep also other orientational data
         auto& source_ext = new_particle.getExt();

--- a/src/speciation.h
+++ b/src/speciation.h
@@ -147,7 +147,7 @@ class SpeciationMove : public MoveBase {
     void deactivateMolecularGroups(Change& change);
     void activateMolecularGroups(Change& change);
     void updateGroupMassCenters(const Change& change) const; //!< Update affected molecular mass centers
-    void swapParticleProperties(Particle& particle, int new_atomid) const;
+    static void swapParticleProperties(Particle& particle, int new_atomid);
     SpeciationMove(Space& spc, Space& old_spc, std::string_view name, std::string_view cite);
 
   public:

--- a/src/speciation.h
+++ b/src/speciation.h
@@ -112,11 +112,16 @@ namespace Faunus::Move {
  *    - deactivate reactants
  *    - activate products
  *
+ * To avoid touching the state of MoveBase::slump, we use an internal
+ * random number generator. This is crusial for e.g. the Parallel temper
+ * move that relies MoveBase::slump to be in sync across MPI ranks.
+ *
  * @todo Split atom-swap functionality to separate helper class
  */
 class SpeciationMove : public MoveBase {
   private:
     using reaction_iterator = decltype(Faunus::reactions)::iterator;
+    Random random_internal; //!< Private generator so as not to touch MoveBase::slump
     reaction_iterator reaction;                                            //!< Randomly selected reaction
     double bias_energy = 0.0;                                              //!< Group (de)activators may add bias
     Speciation::ReactionValidator reaction_validator;                      //!< Helper to check if reaction is doable


### PR DESCRIPTION
This fixes a runtime error when using
parallel tempering and speciation moves
caused by the random number generator to
be out of sync between MPI ranks.

# Description

Please edit this text to include a summary of the change and which issue is fixed.

## Checklist

- [ ] `make test` passes with no errors
- [ ] the source code is well documented
- [ ] new functionality includes unittests
- [ ] the user-manual has been updated to reflect the changes
- [ ] I have installed the provided commit hook to auto-format commits (requires `clang-format`):

  ``` bash
  ./scripts/git-pre-commit-format install
  ```

- [ ] code naming scheme follows the convention:

  Style        | Elements
  ------------ | ---------------------
  `PascalCase` | classes, namespaces
  `camelCase`  | functions
  `snake_case` | variables
