### PR TITLE
Rename namespace and base classes

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -12,7 +12,7 @@ jobs:
     # well on Windows or Mac.  You can convert this to a matrix build if you need
     # cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
 

--- a/docs/_docs/energy.md
+++ b/docs/_docs/energy.md
@@ -635,9 +635,9 @@ the keywords `rho`, `rhoinv`, and `phi0` are mutually exclusive.
 ## Custom Group-Group Potential
 
 For two different or equal molecule types (`name1`, `name2`), this adds a user-defined energy function
-given at run-time. In addition to physical constants, the following varibles are available:
+given at run-time. The following variables are available:
 
-`constants`        | Description
+`variable`        | Description
 -----------------  | --------------------------------
 `R`                | Mass center separation (Å)
 `Z1`               | Average net-charge of group 1
@@ -656,6 +656,17 @@ custom-groupgroup:
         -bjerrum_length * Z1 * Z2 / R * exp(-R / debye_length)
 ~~~
 
+The function is passed using the efficient
+[ExprTk library](http://www.partow.net/programming/exprtk/index.html) and
+a rich set of mathematical functions and logic is available.
+In addition to user-defined `constants`, the following symbols are also defined:
+
+`symbol`   | Description
+---------- | ---------------------------------------------
+`e0`       | Vacuum permittivity [C²/J/m]
+`kB`       | Boltzmann constant [J/K]
+`kT`       | Boltzmann constant × temperature [J]
+`Nav`      | Avogadro's number [1/mol]
 
 ## Bonded Interactions
 

--- a/docs/_docs/energy.md
+++ b/docs/_docs/energy.md
@@ -632,6 +632,31 @@ the keywords `rho`, `rhoinv`, and `phi0` are mutually exclusive.
 `linearise=false`  | Use linearised Poisson-Boltzmann approximation?
 
 
+## Custom Group-Group Potential
+
+For two different or equal molecule types (`name1`, `name2`), this adds a user-defined energy function
+given at run-time. In addition to physical constants, the following varibles are available:
+
+`constants`        | Description
+-----------------  | --------------------------------
+`R`                | Mass center separation (Å)
+`Z1`               | Average net-charge of group 1
+`Z2`               | Average net-charge of group 2
+
+When used together with regular non-bonded interactions, this can e.g. be used to bias simulations.
+In the following example, we _subtract_ a Yukawa potential and the bias can later be removed by
+re-weighting using information from the `systemenergy` analysis output.
+
+~~~ yaml
+custom-groupgroup:
+    name1: charged_colloid
+    name2: charged_colloid
+    constants: { bjerrum_length: 7.1, debye_length: 50 }
+    function: >
+        -bjerrum_length * Z1 * Z2 / R * exp(-R / debye_length)
+~~~
+
+
 ## Bonded Interactions
 
 Bonds and angular potentials are added via the keyword `bondlist` either directly

--- a/docs/schema.yml
+++ b/docs/schema.yml
@@ -561,6 +561,17 @@ properties:
                                             additionalProperties: false
                                         required: [range, resolution]
 
+                custom-groupgroup:
+                    description: "Custom group-group energy"
+                    type: object
+                    properties:
+                        constants: {type: object, description: User-defined constants}
+                        function: {type: string, description: Mathematical expression for the potential (units of kT)}
+                        name1: {type: string, description: "First molecule type"}
+                        name2: {type: string, description: "Second molecule type"}
+                    required: [function, name1, name2]
+                    additionalProperties: false
+
                 customexternal:
                     description: "External Custom Potential"
                     type: object

--- a/src/analysis.cpp
+++ b/src/analysis.cpp
@@ -22,7 +22,7 @@
 #include <iostream>
 #include <memory>
 
-namespace Faunus::Analysis {
+namespace Faunus::analysis {
 
 void to_json(json& j, const Analysisbase& base) { base.to_json(j); }
 
@@ -2365,4 +2365,4 @@ void SavePenaltyEnergy::_sample() {
     }
 }
 
-} // namespace Faunus::Analysis
+} // namespace Faunus::analysis

--- a/src/analysis.cpp
+++ b/src/analysis.cpp
@@ -496,7 +496,7 @@ void SaveState::saveBinaryJsonStateFile(const std::string& filename, const Space
         json j;
         Faunus::to_json(j, spc);
         if (save_random_number_generator_state) {
-            j["random-move"] = Move::MoveBase::slump;
+            j["random-move"] = move::MoveBase::slump;
             j["random-global"] = random;
         }
         auto buffer = json::to_ubjson(j); // json --> binary
@@ -509,7 +509,7 @@ void SaveState::saveJsonStateFile(const std::string& filename, const Space& spc)
         Faunus::to_json(j, spc);
         j.erase("reactionlist");
         if (save_random_number_generator_state) {
-            j["random-move"] = Move::MoveBase::slump;
+            j["random-move"] = move::MoveBase::slump;
             j["random-global"] = random;
         }
         f << std::setw(1) << j;

--- a/src/analysis.cpp
+++ b/src/analysis.cpp
@@ -598,9 +598,12 @@ void PerturbationAnalysisBase::_to_disk() {
         stream->flush(); // empty buffer
     }
 }
-PerturbationAnalysisBase::PerturbationAnalysisBase(const std::string& name, Energy::Energybase& pot, Space& spc,
+PerturbationAnalysisBase::PerturbationAnalysisBase(const std::string& name, Energy::EnergyTerm& pot, Space& spc,
                                                    const std::string& filename)
-    : Analysisbase(spc, name), mutable_space(spc), pot(pot), filename(filename) {
+    : Analysisbase(spc, name)
+    , mutable_space(spc)
+    , pot(pot)
+    , filename(filename) {
     if (!filename.empty()) {
         this->filename = MPI::prefix + filename;
         stream = IO::openCompressedOutputStream(this->filename, true); // throws if error
@@ -690,7 +693,7 @@ void VirtualVolumeMove::_to_json(json& j) const {
     }
 }
 
-VirtualVolumeMove::VirtualVolumeMove(const json& j, Space& spc, Energy::Energybase& pot)
+VirtualVolumeMove::VirtualVolumeMove(const json& j, Space& spc, Energy::EnergyTerm& pot)
     : PerturbationAnalysisBase("virtualvolume", pot, spc, j.value("file", ""s)) {
     cite = "doi:10.1063/1.472721";
     from_json(j);
@@ -2149,7 +2152,7 @@ void VirtualTranslate::_to_json(json& j) const {
              {"dir", perturbation_direction}};
     }
 }
-VirtualTranslate::VirtualTranslate(const json& j, Space& spc, Energy::Energybase& pot)
+VirtualTranslate::VirtualTranslate(const json& j, Space& spc, Energy::EnergyTerm& pot)
     : PerturbationAnalysisBase("virtualtranslate", pot, spc, j.value("file", ""s)) {
     change.groups.resize(1);
     change.groups.front().internal = false;

--- a/src/analysis.cpp
+++ b/src/analysis.cpp
@@ -496,7 +496,7 @@ void SaveState::saveBinaryJsonStateFile(const std::string& filename, const Space
         json j;
         Faunus::to_json(j, spc);
         if (save_random_number_generator_state) {
-            j["random-move"] = move::MoveBase::slump;
+            j["random-move"] = move::Move::slump;
             j["random-global"] = random;
         }
         auto buffer = json::to_ubjson(j); // json --> binary
@@ -509,7 +509,7 @@ void SaveState::saveJsonStateFile(const std::string& filename, const Space& spc)
         Faunus::to_json(j, spc);
         j.erase("reactionlist");
         if (save_random_number_generator_state) {
-            j["random-move"] = move::MoveBase::slump;
+            j["random-move"] = move::Move::slump;
             j["random-global"] = random;
         }
         f << std::setw(1) << j;

--- a/src/analysis.cpp
+++ b/src/analysis.cpp
@@ -2232,8 +2232,8 @@ ElectricPotential::ElectricPotential(const json& j, const Space& spc)
     : Analysis(spc, "electricpotential")
     , potential_correlation_histogram(histogram_resolution) {
     from_json(j);
-    coulomb = std::make_unique<Potential::NewCoulombGalore>();
-    Potential::from_json(j, *coulomb);
+    coulomb = std::make_unique<pairpotential::NewCoulombGalore>();
+    pairpotential::from_json(j, *coulomb);
     getTargets(j);
     setPolicy(j);
     calculations_per_sample_event = j.value("ncalc", 1);

--- a/src/analysis.cpp
+++ b/src/analysis.cpp
@@ -24,17 +24,17 @@
 
 namespace Faunus::analysis {
 
-void to_json(json& j, const Analysisbase& base) { base.to_json(j); }
+void to_json(json& j, const Analysis& base) { base.to_json(j); }
 
 /**
  * This is virtual and can be overridden in derived classes
  */
-void Analysisbase::_to_disk() {}
+void Analysis::_to_disk() {}
 
 /**
  * Wrapper function used for non-intrusive future padding around _to_disk().
  */
-void Analysisbase::to_disk() { _to_disk(); }
+void Analysis::to_disk() { _to_disk(); }
 
 /**
  * For each call:
@@ -45,7 +45,7 @@ void Analysisbase::to_disk() { _to_disk(); }
  *
  * The call to the sampling function is timed.
  */
-void Analysisbase::sample() {
+void Analysis::sample() {
     try {
         number_of_steps++;
         if (sample_interval > 0 && number_of_steps > number_of_skipped_steps) {
@@ -61,7 +61,7 @@ void Analysisbase::sample() {
     }
 }
 
-void Analysisbase::from_json(const json& j) {
+void Analysis::from_json(const json& j) {
     try {
         number_of_skipped_steps = j.value("nskip", 0);
         sample_interval = j.value("nstep", 0);
@@ -71,7 +71,7 @@ void Analysisbase::from_json(const json& j) {
     }
 }
 
-void Analysisbase::to_json(json& json_output) const {
+void Analysis::to_json(json& json_output) const {
     try {
         auto& j = json_output[name];
         _to_json(j); // fill in info from derived classes
@@ -93,15 +93,19 @@ void Analysisbase::to_json(json& json_output) const {
     }
 }
 
-void Analysisbase::_to_json(json&) const {}
+void Analysis::_to_json(json&) const {}
 
-void Analysisbase::_from_json(const json&) {}
+void Analysis::_from_json(const json&) {}
 
-int Analysisbase::getNumberOfSteps() const { return number_of_steps; }
+int Analysis::getNumberOfSteps() const { return number_of_steps; }
 
-Analysisbase::Analysisbase(const Space& spc, std::string_view name) : spc(spc), name(name) { assert(!name.empty()); }
+Analysis::Analysis(const Space& spc, std::string_view name)
+    : spc(spc)
+    , name(name) {
+    assert(!name.empty());
+}
 
-Analysisbase::Analysisbase(const Space& spc, std::string_view name, int sample_interval, int number_of_skipped_steps)
+Analysis::Analysis(const Space& spc, std::string_view name, int sample_interval, int number_of_skipped_steps)
     : number_of_skipped_steps(number_of_skipped_steps)
     , spc(spc)
     , sample_interval(sample_interval)
@@ -115,8 +119,7 @@ Analysisbase::Analysisbase(const Space& spc, std::string_view name, int sample_i
  * @param pot Hamiltonian
  * @return shared pointer to created analysis base class
  */
-std::unique_ptr<Analysisbase> createAnalysis(const std::string& name, const json& j, Space& spc,
-                                             Energy::Hamiltonian& pot) {
+std::unique_ptr<Analysis> createAnalysis(const std::string& name, const json& j, Space& spc, Energy::Hamiltonian& pot) {
     try {
         if (name == "atomprofile") {
             return std::make_unique<AtomProfile>(j, spc);
@@ -270,7 +273,8 @@ void SystemEnergy::createOutputStream() {
 }
 
 SystemEnergy::SystemEnergy(const json& j, const Space& spc, Energy::Hamiltonian& hamiltonian)
-    : Analysisbase(spc, "systemenergy"), hamiltonian(hamiltonian) {
+    : Analysis(spc, "systemenergy")
+    , hamiltonian(hamiltonian) {
     from_json(j);
     energy_histogram.setResolution(0.25);
     initial_energy = ranges::accumulate(calculateEnergies(), 0.0);
@@ -368,7 +372,7 @@ std::function<bool(double)> createValueFilter(const std::string& name, const jso
 // --------------------------------
 
 PairMatrixAnalysis::PairMatrixAnalysis(const json& j, const Space& spc)
-    : Analysisbase(spc, "cluster")
+    : Analysis(spc, "cluster")
     , spc(spc) {
     from_json(j);
     filename = j.at("file").get<std::string>();
@@ -455,7 +459,8 @@ SaveState::~SaveState() {
     }
 }
 
-SaveState::SaveState(json j, const Space& spc) : Analysisbase(spc, "savestate") {
+SaveState::SaveState(json j, const Space& spc)
+    : Analysis(spc, "savestate") {
     if (j.count("nstep") == 0) { // by default, disable _sample() and
         j["nstep"] = -1;         // store only when _to_disk() is called
     }
@@ -522,7 +527,8 @@ void SaveState::saveAsCuboid(const std::string& filename, const Space& spc, Stru
     }
 }
 
-PairFunctionBase::PairFunctionBase(const Space& spc, const json& j, const std::string_view name) : Analysisbase(spc, name) {
+PairFunctionBase::PairFunctionBase(const Space& spc, const json& j, const std::string_view name)
+    : Analysis(spc, name) {
     from_json(j);
 }
 
@@ -600,7 +606,7 @@ void PerturbationAnalysisBase::_to_disk() {
 }
 PerturbationAnalysisBase::PerturbationAnalysisBase(const std::string& name, Energy::EnergyTerm& pot, Space& spc,
                                                    const std::string& filename)
-    : Analysisbase(spc, name)
+    : Analysis(spc, name)
     , mutable_space(spc)
     , pot(pot)
     , filename(filename) {
@@ -721,7 +727,7 @@ void MolecularConformationID::_sample() {
 void MolecularConformationID::_to_json(json& j) const { j["histogram"] = histogram; }
 
 MolecularConformationID::MolecularConformationID(const json& j, const Space& spc)
-    : Analysisbase(spc, "moleculeconformation") {
+    : Analysis(spc, "moleculeconformation") {
     from_json(j);
     const auto molname = j.at("molecule").get<std::string>();
     molid = Faunus::findMoleculeByName(molname).id();
@@ -731,7 +737,8 @@ void QRtraj::_sample() { write_to_file(); }
 
 void QRtraj::_to_json(json& j) const { j = {{"file", filename}}; }
 
-QRtraj::QRtraj(const json& j, const Space& spc, const std::string &name) : Analysisbase(spc, name) {
+QRtraj::QRtraj(const json& j, const Space& spc, const std::string& name)
+    : Analysis(spc, name) {
     from_json(j);
     filename = MPI::prefix + j.value("file", "qrtraj.dat"s);
     stream = IO::openCompressedOutputStream(filename, true);
@@ -804,7 +811,7 @@ void FileReactionCoordinate::_sample() {
 FileReactionCoordinate::FileReactionCoordinate(
     const Space& spc, const std::string& filename,
     std::unique_ptr<ReactionCoordinate::ReactionCoordinateBase> reaction_coordinate)
-    : Analysisbase(spc, "reactioncoordinate")
+    : Analysis(spc, "reactioncoordinate")
     , filename(filename)
     , reaction_coordinate(std::move(reaction_coordinate)) {
     if (filename.empty()) {
@@ -828,7 +835,7 @@ void FileReactionCoordinate::_to_disk() {
 }
 
 AtomicDisplacement::AtomicDisplacement(const json& j, const Space& spc, std::string_view name)
-    : Analysisbase(spc, name)
+    : Analysis(spc, name)
     , displacement_histogram(j.value("histogram_resolution", 1.0))
     , reference_reset_interval(j.value("reset_interval", std::numeric_limits<int>::max())) {
 
@@ -1246,7 +1253,8 @@ void SanityCheck::checkMassCenter(const Space::GroupType& group) {
     }
 }
 
-SanityCheck::SanityCheck(const json& j, const Space& spc) : Analysisbase(spc, "sanity") {
+SanityCheck::SanityCheck(const json& j, const Space& spc)
+    : Analysis(spc, "sanity") {
     from_json(j);
     sample_interval = j.value("nstep", -1);
 }
@@ -1374,7 +1382,7 @@ AtomDipDipCorr::AtomDipDipCorr(const json& j, const Space& spc) : PairAngleFunct
  * @param molecule_names Save only a subset of molecules with matching names (default empty = all)
  */
 XTCtraj::XTCtraj(const Space& spc, const std::string& filename, const std::vector<std::string>& molecule_names)
-    : Analysisbase(spc, "xtcfile") {
+    : Analysis(spc, "xtcfile") {
     namespace rv = ranges::cpp20::views;
     writer = std::make_unique<XTCWriter>(filename);
     if (!molecule_names.empty()) {
@@ -1391,7 +1399,7 @@ XTCtraj::XTCtraj(const Space& spc, const std::string& filename, const std::vecto
 
 XTCtraj::XTCtraj(const json& j, const Space& spc)
     : XTCtraj(spc, MPI::prefix + j.at("file").get<std::string>(), j.value("molecules", std::vector<std::string>())) {
-    Analysisbase::from_json(j);
+    Analysis::from_json(j);
 }
 
 void XTCtraj::_to_json(json& j) const {
@@ -1475,7 +1483,8 @@ void MultipoleDistribution::_sample() {
 
 void MultipoleDistribution::_to_json(json& j) const { j = {{"molecules", names}, {"file", filename}, {"dr", dr}}; }
 
-MultipoleDistribution::MultipoleDistribution(const json& j, const Space& spc) : Analysisbase(spc, "Multipole Distribution") {
+MultipoleDistribution::MultipoleDistribution(const json& j, const Space& spc)
+    : Analysis(spc, "Multipole Distribution") {
     from_json(j);
     dr = j.at("dr").get<double>();
     filename = j.at("file").get<std::string>();
@@ -1505,7 +1514,8 @@ void AtomInertia::_sample() {
         output_stream << getNumberOfSteps() << " " << compute().transpose() << "\n";
     }
 }
-AtomInertia::AtomInertia(const json& j, const Space& spc) : Analysisbase(spc, "Atomic Inertia Eigenvalues") {
+AtomInertia::AtomInertia(const json& j, const Space& spc)
+    : Analysis(spc, "Atomic Inertia Eigenvalues") {
     from_json(j);
     filename = MPI::prefix + j.at("file").get<std::string>();
     output_stream.open(filename);
@@ -1546,7 +1556,7 @@ void InertiaTensor::_sample() {
 }
 
 InertiaTensor::InertiaTensor(const json& j, const Space& spc)
-    : Analysisbase(spc, "Inertia Tensor") {
+    : Analysis(spc, "Inertia Tensor") {
     from_json(j);
     group_index = j.at("index").get<size_t>();
     const auto& group = spc.groups.at(group_index);
@@ -1611,7 +1621,8 @@ void MultipoleMoments::_sample() {
                       << multipole.eivec.transpose() << "\n";
     }
 }
-MultipoleMoments::MultipoleMoments(const json& j, const Space& spc) : Analysisbase(spc, "Multipole Moments") {
+MultipoleMoments::MultipoleMoments(const json& j, const Space& spc)
+    : Analysis(spc, "Multipole Moments") {
     from_json(j);
     try {
         use_molecular_mass_center = j.value("mol_cm", true); // use the mass center of the whole molecule
@@ -1711,7 +1722,8 @@ void PolymerShape::_to_disk() {
     }
 }
 
-PolymerShape::PolymerShape(const json& j, const Space& spc) : Analysisbase(spc, "Polymer Shape") {
+PolymerShape::PolymerShape(const json& j, const Space& spc)
+    : Analysis(spc, "Polymer Shape") {
     from_json(j);
     cite = "https://dx.doi.org/10/d6ff";
     if (j.count("molecules") > 0) {
@@ -1775,7 +1787,10 @@ double AtomProfile::distanceToOrigin(const Point& position) const {
     return distance.cwiseProduct(dir.cast<double>()).norm();
 }
 
-AtomProfile::AtomProfile(const json& j, const Space& spc) : Analysisbase(spc, "atomprofile") { from_json(j); }
+AtomProfile::AtomProfile(const json& j, const Space& spc)
+    : Analysis(spc, "atomprofile") {
+    from_json(j);
+}
 
 void AtomProfile::_to_disk() {
     std::ofstream f(MPI::prefix + file);
@@ -1842,7 +1857,10 @@ void SlicedDensity::_sample() {
         histogram(particle.pos.z() - z_offset)++;
     }
 }
-SlicedDensity::SlicedDensity(const json& j, const Space& spc) : Analysisbase(spc, "sliceddensity") { from_json(j); }
+SlicedDensity::SlicedDensity(const json& j, const Space& spc)
+    : Analysis(spc, "sliceddensity") {
+    from_json(j);
+}
 
 void SlicedDensity::_to_disk() {
     if (number_of_samples == 0) {
@@ -1936,7 +1954,8 @@ ParticleVector ChargeFluctuations::averageChargeParticles(const Space::GroupType
 /**
  * @todo replace `mol_iter` with simple molid integer
  */
-ChargeFluctuations::ChargeFluctuations(const json& j, const Space& spc) : Analysisbase(spc, "chargefluctuations") {
+ChargeFluctuations::ChargeFluctuations(const json& j, const Space& spc)
+    : Analysis(spc, "chargefluctuations") {
     from_json(j);
     filename = j.value("pqrfile", ""s);
     verbose = j.value("verbose", true);
@@ -1975,7 +1994,10 @@ void Multipole::_to_json(json& j) const {
                                          {unicode::mu + unicode::squared, average.dipole_moment_squared.avg()}};
     }
 }
-Multipole::Multipole(const json& j, const Space& spc) : Analysisbase(spc, "multipole") { from_json(j); }
+Multipole::Multipole(const json& j, const Space& spc)
+    : Analysis(spc, "multipole") {
+    from_json(j);
+}
 
 void ScatteringFunction::_sample() {
     namespace rv = ranges::cpp20::views;
@@ -2035,7 +2057,8 @@ void ScatteringFunction::_to_json(json& j) const {
     }
 }
 
-ScatteringFunction::ScatteringFunction(const json& j, const Space& spc) try : Analysisbase(spc, "scatter") {
+ScatteringFunction::ScatteringFunction(const json& j, const Space& spc) try
+    : Analysis(spc, "scatter") {
     from_json(j);
 
     mass_center_scattering = j.value("com", true);
@@ -2160,7 +2183,8 @@ VirtualTranslate::VirtualTranslate(const json& j, Space& spc, Energy::EnergyTerm
 }
 
 SpaceTrajectory::SpaceTrajectory(const json& j, const Space& spc)
-    : Analysisbase(spc, "space trajectory"), groups(spc.groups) {
+    : Analysis(spc, "space trajectory")
+    , groups(spc.groups) {
     from_json(j);
     filename = j.at("file").get<std::string>();
 
@@ -2205,7 +2229,8 @@ void SpaceTrajectory::_to_disk() { stream->flush(); }
 // -----------------------------
 
 ElectricPotential::ElectricPotential(const json& j, const Space& spc)
-    : Analysisbase(spc, "electricpotential"), potential_correlation_histogram(histogram_resolution) {
+    : Analysis(spc, "electricpotential")
+    , potential_correlation_histogram(histogram_resolution) {
     from_json(j);
     coulomb = std::make_unique<Potential::NewCoulombGalore>();
     Potential::from_json(j, *coulomb);
@@ -2343,10 +2368,10 @@ bool ElectricPotential::overlapWithParticles(const Point& position) const {
 }
 
 SavePenaltyEnergy::SavePenaltyEnergy(const json& j, const Space& spc, const Energy::Hamiltonian& pot)
-    : Analysisbase(spc, "penaltyfunction")
+    : Analysis(spc, "penaltyfunction")
     , filename(j.at("file").get<std::string>())
     , penalty_energy(pot.findFirstOf<Energy::Penalty>()) {
-    Analysisbase::from_json(j);
+    Analysis::from_json(j);
     if (!penalty_energy) {
         faunus_logger->warn("{}: analysis disabled as no penalty function found", name);
     }

--- a/src/analysis.h
+++ b/src/analysis.h
@@ -21,7 +21,7 @@ class NewCoulombGalore;
 
 namespace Faunus::Energy {
 class Hamiltonian;
-class Energybase;
+class EnergyTerm;
 class Penalty;
 } // namespace Faunus::Energy
 
@@ -117,13 +117,13 @@ class PerturbationAnalysisBase : public Analysisbase {
 
   protected:
     Space& mutable_space; //!< This reference to space can be changed
-    Energy::Energybase& pot;
+    Energy::EnergyTerm& pot;
     std::string filename;                                 //!< output filename (optional)
     std::unique_ptr<std::ostream> stream = nullptr;       //!< output file stream if filename given
     Change change;                                        //!< Change object to describe perturbation
     Average<double> mean_exponentiated_energy_change;     //!< < exp(-du/kT) >
     bool collectWidomAverage(const double energy_change); //!< add to exp(-du/kT) incl. safety checks
-    PerturbationAnalysisBase(const std::string& name, Energy::Energybase& pot, Space& spc,
+    PerturbationAnalysisBase(const std::string& name, Energy::EnergyTerm& pot, Space& spc,
                              const std::string& filename = ""s);
     double meanFreeEnergy() const; //!< Average perturbation free energy, `-ln(<exp(-du/kT)>)`
 };
@@ -652,7 +652,7 @@ class VirtualVolumeMove : public PerturbationAnalysisBase {
     void writeToFileStream(const Point& scale, double energy_change) const;
 
   public:
-    VirtualVolumeMove(const json& j, Space& spc, Energy::Energybase& pot);
+    VirtualVolumeMove(const json& j, Space& spc, Energy::EnergyTerm& pot);
 };
 
 /**
@@ -689,7 +689,7 @@ class VirtualTranslate : public PerturbationAnalysisBase {
     void writeToFileStream(double energy_change) const;
 
   public:
-    VirtualTranslate(const json& j, Space& spc, Energy::Energybase& pot);
+    VirtualTranslate(const json& j, Space& spc, Energy::EnergyTerm& pot);
 };
 
 /**

--- a/src/analysis.h
+++ b/src/analysis.h
@@ -15,7 +15,7 @@ namespace cereal {
 class BinaryOutputArchive;
 }
 
-namespace Faunus::Potential {
+namespace Faunus::pairpotential {
 class NewCoulombGalore;
 }
 
@@ -237,7 +237,7 @@ class ElectricPotential : public Analysis {
     };
     std::vector<Target> targets;                             //!< List of target points where to sample the potential
     Policies policy;                                         //!< Policy to apply to targets before each sample event
-    std::unique_ptr<Potential::NewCoulombGalore> coulomb;    //!< Class for calculating the potential
+    std::unique_ptr<pairpotential::NewCoulombGalore> coulomb; //!< Class for calculating the potential
     Average<double> mean_potential_correlation;              //!< Correlation between targets, <phi1 x phi2 x ... >
     SparseHistogram<double> potential_correlation_histogram; //!< Distribution of correlations, P(<phi1 x phi2 x ... >)
     void getTargets(const json& j);                          //!< Get user defined target positions

--- a/src/analysis.h
+++ b/src/analysis.h
@@ -34,7 +34,7 @@ namespace Faunus {
  * 3. Recommended: add the required json input format to `docs/schema.yml`
  * 4. Recommended: add documentation to `docs/_docs/analysis.md`
  */
-namespace Analysis {
+namespace analysis {
 
 /**
  * @brief Base class for all analysis functions
@@ -934,6 +934,6 @@ class SavePenaltyEnergy : public Analysisbase {
     SavePenaltyEnergy(const json &j, const Space &spc, const Energy::Hamiltonian &pot);
 };
 
-} // namespace Analysis
+} // namespace analysis
 
 } // namespace Faunus

--- a/src/bonds.cpp
+++ b/src/bonds.cpp
@@ -3,7 +3,7 @@
 #include "geometry.h"
 #include "auxiliary.h"
 
-namespace Faunus::Potential {
+namespace Faunus::pairpotential {
 
 void to_json(Faunus::json& j, const std::shared_ptr<const BondData>& bond) { to_json(j, *bond); }
 
@@ -822,4 +822,4 @@ TEST_CASE("[Faunus] BondData") {
 }
 TEST_SUITE_END();
 
-} // namespace Faunus::Potential
+} // namespace Faunus::pairpotential

--- a/src/bonds.h
+++ b/src/bonds.h
@@ -7,7 +7,7 @@ namespace Faunus::Geometry {
 typedef std::function<Point(const Point&, const Point&)> DistanceFunction;
 } // namespace Faunus::Geometry
 
-namespace Faunus::Potential {
+namespace Faunus::pairpotential {
 
 /**
  * @brief Base class for bonded potentials

--- a/src/chainmove.cpp
+++ b/src/chainmove.cpp
@@ -161,7 +161,7 @@ PivotMove::PivotMove(Space &spc) : PivotMove(spc, "pivot", "") {}
 
 void PivotMove::_from_json(const json &j) {
     TBase::_from_json(j);
-    bonds = molecules[this->molid].bonds.find<Potential::HarmonicBond>();
+    bonds = molecules[this->molid].bonds.find<pairpotential::HarmonicBond>();
     if (bonds.empty()) {
         throw ConfigurationError("no harmonic bonds found for pivot move");
     }

--- a/src/chainmove.cpp
+++ b/src/chainmove.cpp
@@ -38,8 +38,8 @@ void ChainRotationMoveBase::_accept(Change &) { msqdispl += sqdispl; }
 void ChainRotationMoveBase::_reject(Change &) { msqdispl += 0; }
 double ChainRotationMoveBase::bias(Change &, double, double) { return permit_move ? 0 : pc::infty; }
 
-ChainRotationMoveBase::ChainRotationMoveBase(Space &spc, std::string name, std::string cite)
-    : MoveBase(spc, name, cite) {}
+ChainRotationMoveBase::ChainRotationMoveBase(Space& spc, std::string name, std::string cite)
+    : Move(spc, name, cite) {}
 
 ChainRotationMove::ChainRotationMove(Space &spc, std::string name, std::string cite)
     : ChainRotationMoveBase(spc, name, cite) {

--- a/src/chainmove.cpp
+++ b/src/chainmove.cpp
@@ -3,7 +3,7 @@
 #include "bonds.h"
 
 namespace Faunus {
-namespace Move {
+namespace move {
 
 void ChainRotationMoveBase::_from_json(const json &j) {
     molname = j.at("molecule");
@@ -205,5 +205,5 @@ size_t PivotMove::select_segment() {
     return segment_size;
 }
 
-} // end of namespace Move
+} // namespace move
 } // namespace Faunus

--- a/src/chainmove.h
+++ b/src/chainmove.h
@@ -8,9 +8,9 @@ namespace move {
 /**
  * @brief An abstract base class for rotational movements of a polymer chain
  */
-class ChainRotationMoveBase : public MoveBase {
+class ChainRotationMoveBase : public Move {
   protected:
-    using MoveBase::spc;
+    using Move::spc;
     std::string molname;
     size_t molid;
     double dprot;             //!< maximal angle of rotation, ±0.5*dprot

--- a/src/chainmove.h
+++ b/src/chainmove.h
@@ -113,7 +113,7 @@ class PivotMove : public ChainRotationMove {
     using TBase = ChainRotationMove;
 
   private:
-    BasePointerVector<Potential::HarmonicBond> bonds;
+    BasePointerVector<pairpotential::HarmonicBond> bonds;
 
   public:
     explicit PivotMove(Space &spc);

--- a/src/chainmove.h
+++ b/src/chainmove.h
@@ -4,7 +4,7 @@
 #include "bonds.h"
 
 namespace Faunus {
-namespace Move {
+namespace move {
 /**
  * @brief An abstract base class for rotational movements of a polymer chain
  */
@@ -132,5 +132,5 @@ class PivotMove : public ChainRotationMove {
     size_t select_segment() override;
 };
 
-} // namespace Move
+} // namespace move
 } // namespace Faunus

--- a/src/clustermove.cpp
+++ b/src/clustermove.cpp
@@ -5,7 +5,7 @@
 #include <range/v3/algorithm/for_each.hpp>
 
 namespace Faunus {
-namespace Move {
+namespace move {
 
 ClusterShapeAnalysis::ClusterShapeAnalysis(bool shape_anisotropy_use_com, const std::string &filename,
                                            bool dump_pqr_files)
@@ -240,7 +240,7 @@ void Cluster::_to_json(json &j) const {
          {"⟨N⟩", average_cluster_size.avg()},
          {"cluster analysis", *shape_analysis},
          {"cluster analysis interval", shape_analysis_interval}};
-    Move::to_json(j, *find_cluster);
+    move::to_json(j, *find_cluster);
     roundJSON(j, 3);
 }
 
@@ -404,5 +404,5 @@ std::function<void(Group&)> GroupRotator::getLambda(Geometry::BoundaryFunction b
 
 // -------------------------------------------
 
-} // namespace Move
+} // namespace move
 } // namespace Faunus

--- a/src/clustermove.cpp
+++ b/src/clustermove.cpp
@@ -176,7 +176,7 @@ std::pair<std::vector<size_t>, bool> FindCluster::findCluster(size_t seed_index)
     for (auto it1 = cluster.begin(); it1 != cluster.end(); it1++) {
         for (auto it2 = pool.begin(); it2 != pool.end();) {
             const auto p = clusterProbability(spc.groups.at(*it1), spc.groups.at(*it2)); // probability to cluster
-            if (MoveBase::slump() <= p) {                                                // is group part of cluster?
+            if (Move::slump() <= p) {                                                    // is group part of cluster?
                 cluster.push_back(*it2);                                                 // yes, expand cluster...
                 it2 = pool.erase(it2);                                                   // ...and remove from pool
             } else {
@@ -345,7 +345,7 @@ void Cluster::_accept([[maybe_unused]] Change& change) {
 }
 
 Cluster::Cluster(Space& spc, std::string_view name, std::string_view cite)
-    : MoveBase(spc, name, cite) {
+    : Move(spc, name, cite) {
     repeat = -1;
 }
 

--- a/src/clustermove.h
+++ b/src/clustermove.h
@@ -146,7 +146,7 @@ class GroupRotator : public GroupMover {
 /**
  * @brief Molecular cluster move
  */
-class Cluster : public MoveBase {
+class Cluster : public Move {
   private:
     std::unique_ptr<FindCluster> find_cluster;
     std::unique_ptr<ClusterShapeAnalysis> shape_analysis;

--- a/src/clustermove.h
+++ b/src/clustermove.h
@@ -5,7 +5,7 @@
 #include <map>
 
 namespace Faunus {
-namespace Move {
+namespace move {
 
 /**
  * @brief Helper class for Cluster move for analysing shape and size of found clusters
@@ -178,5 +178,5 @@ class Cluster : public MoveBase {
     explicit Cluster(Space &spc);
 };
 
-} // namespace Move
+} // namespace move
 } // namespace Faunus

--- a/src/energy.cpp
+++ b/src/energy.cpp
@@ -1086,7 +1086,7 @@ void Hamiltonian::sync(EnergyTerm* other_hamiltonian, const Change& change) {
  * New energy terms should be added to the if-else chain in the function
  */
 std::unique_ptr<EnergyTerm> Hamiltonian::createEnergy(Space& spc, const std::string& name, const json& j) {
-    using namespace Potential;
+    using namespace pairpotential;
     using CoulombLJ = CombinedPairPotential<NewCoulombGalore, LennardJones>;
     using CoulombWCA = CombinedPairPotential<NewCoulombGalore, WeeksChandlerAndersen>;
     using PrimitiveModelWCA = CombinedPairPotential<Coulomb, WeeksChandlerAndersen>;
@@ -1103,15 +1103,15 @@ std::unique_ptr<EnergyTerm> Hamiltonian::createEnergy(Space& spc, const std::str
             return std::make_unique<NonbondedCached<PairEnergy<CoulombLJ, false>, PairingPolicy>>(j, spc, *this);
         }
         if (name == "nonbonded_splined") {
-            return std::make_unique<Nonbonded<PairEnergy<Potential::SplinedPotential, false>, PairingPolicy>>(j, spc,
+            return std::make_unique<Nonbonded<PairEnergy<pairpotential::SplinedPotential, false>, PairingPolicy>>(j, spc,
                                                                                                               *this);
         }
         if (name == "nonbonded" || name == "nonbonded_exact") {
-            return std::make_unique<Nonbonded<PairEnergy<Potential::FunctorPotential, true>, PairingPolicy>>(j, spc,
+            return std::make_unique<Nonbonded<PairEnergy<pairpotential::FunctorPotential, true>, PairingPolicy>>(j, spc,
                                                                                                              *this);
         }
         if (name == "nonbonded_cached") {
-            return std::make_unique<NonbondedCached<PairEnergy<Potential::SplinedPotential>, PairingPolicy>>(j, spc,
+            return std::make_unique<NonbondedCached<PairEnergy<pairpotential::SplinedPotential>, PairingPolicy>>(j, spc,
                                                                                                              *this);
         }
         if (name == "nonbonded_coulombwca") {

--- a/src/energy.cpp
+++ b/src/energy.cpp
@@ -559,7 +559,7 @@ void Ewald::force(std::vector<Point> &forces) {
  */
 void Ewald::setOldGroups(const Space::GroupVector& old_groups) { this->old_groups = &old_groups; }
 
-void Ewald::sync(Energybase* energybase, const Change& change) {
+void Ewald::sync(EnergyTerm* energybase, const Change& change) {
     if (auto* other = dynamic_cast<const Ewald*>(energybase)) {
         if (!old_groups && other->state == MonteCarloState::ACCEPTED) {
             setOldGroups(other->spc.groups);
@@ -1060,7 +1060,7 @@ void Hamiltonian::updateState(const Change& change) {
     std::for_each(energy_terms.begin(), energy_terms.end(), [&](auto& energy) { energy->updateState(change); });
 }
 
-void Hamiltonian::sync(Energybase* other_hamiltonian, const Change& change) {
+void Hamiltonian::sync(EnergyTerm* other_hamiltonian, const Change& change) {
     if (auto* other = dynamic_cast<Hamiltonian*>(other_hamiltonian)) {
         if (other->size() == size()) {
             latest_energies = other->latestEnergies();
@@ -1085,7 +1085,7 @@ void Hamiltonian::sync(Energybase* other_hamiltonian, const Change& change) {
  *
  * New energy terms should be added to the if-else chain in the function
  */
-std::unique_ptr<Energybase> Hamiltonian::createEnergy(Space& spc, const std::string& name, const json& j) {
+std::unique_ptr<EnergyTerm> Hamiltonian::createEnergy(Space& spc, const std::string& name, const json& j) {
     using namespace Potential;
     using CoulombLJ = CombinedPairPotential<NewCoulombGalore, LennardJones>;
     using CoulombWCA = CombinedPairPotential<NewCoulombGalore, WeeksChandlerAndersen>;
@@ -1230,7 +1230,7 @@ double FreeSASAEnergy::energy(const Change& change) {
     return energy;
 }
 
-void FreeSASAEnergy::sync(Energybase* energybase_ptr, const Change& change) {
+void FreeSASAEnergy::sync(EnergyTerm* energybase_ptr, const Change& change) {
     // since the full SASA is calculated in each energy evaluation, this is
     // currently not needed.
     if (auto* other = dynamic_cast<FreeSASAEnergy*>(energybase_ptr); other != nullptr) {
@@ -1404,7 +1404,7 @@ double SASAEnergyReference::energy(const Change& change) {
     return energy;
 }
 
-void SASAEnergyReference::sync(Energybase* energybase_ptr, const Change& change) {
+void SASAEnergyReference::sync(EnergyTerm* energybase_ptr, const Change& change) {
     if (auto* other = dynamic_cast<SASAEnergyReference*>(energybase_ptr)) {
         areas = other->areas;
         if (sasa->needs_syncing) {
@@ -1503,7 +1503,7 @@ double SASAEnergy::energy(const Change& change) {
     return energy;
 }
 
-void SASAEnergy::sync(Energybase* energybase_ptr, const Change& change) {
+void SASAEnergy::sync(EnergyTerm* energybase_ptr, const Change& change) {
     if (auto* other = dynamic_cast<SASAEnergy*>(energybase_ptr)) {
         const auto sync_data = [this, other](const size_t changed_index) {
             this->current_neighbours.at(changed_index) = other->current_neighbours.at(changed_index);

--- a/src/energy.cpp
+++ b/src/energy.cpp
@@ -1138,6 +1138,9 @@ std::unique_ptr<Energybase> Hamiltonian::createEnergy(Space& spc, const std::str
         if (name == "constrain") {
             return std::make_unique<Constrain>(j, spc);
         }
+        if (name == "custom-groupgroup") {
+            return std::make_unique<CustomGroupGroup>(j, spc);
+        }
         if (name == "example2d") {
             return std::make_unique<Example2D>(j, spc);
         }
@@ -1734,5 +1737,66 @@ void EnergyAccumulatorBase::from_json(const json& j) {
 }
 
 void EnergyAccumulatorBase::to_json(json& j) const { j["summation_policy"] = scheme; }
+
+CustomGroupGroup::CustomGroupGroup(const json& j, const Space& spc)
+    : spc(spc)
+    , json_input_backup(j) {
+    name = "custom-groupgroup";
+    molid1 = findMoleculeByName(j.at("name1").get<std::string>()).id();
+    molid2 = findMoleculeByName(j.at("name2").get<std::string>()).id();
+    std::string function = j.at("function");
+    auto& constants = json_input_backup["constants"];
+    if (constants == nullptr) {
+        constants = json::object();
+    }
+    constants["e0"] = pc::vacuum_permittivity;
+    constants["kB"] = pc::boltzmann_constant;
+    constants["kT"] = pc::kT();
+    constants["Nav"] = pc::avogadro;
+    constants["T"] = pc::temperature;
+    expr = std::make_unique<ExprFunction<double>>();
+    expr->set(json_input_backup, {{"R", &properties.mass_center_separation},
+                                  {"Z1", &properties.mean_charge1},
+                                  {"Z2", &properties.mean_charge2}});
+}
+
+double CustomGroupGroup::energy([[maybe_unused]] const Change& change) {
+    // matches active groups with either molid1 or molid2
+    auto match_groups = [&](const auto& group) -> bool {
+        return group.isFull() & (group.id == molid1 | group.id == molid2);
+    };
+
+    auto group_group_energy = [&](auto index1, auto index2) -> double {
+        const Group& group1 = spc.groups[index1];
+        const Group& group2 = spc.groups[index2];
+        if ((group1.id == molid1 & group2.id == molid2) | (group1.id == molid2 & group2.id == molid1)) {
+            setExprParameters(group1, group2);
+            return expr->operator()();
+        }
+        return 0.0;
+    };
+
+    // all indices matching either molid1 or molid2
+    auto indices = spc.groups | ranges::cpp20::views::filter(match_groups) |
+                   ranges::cpp20::views::transform([&](const auto& group) { return spc.getGroupIndex(group); }) |
+                   ranges::to_vector;
+
+    return for_each_unique_pair(indices.begin(), indices.end(), group_group_energy, std::plus<double>());
+}
+
+void CustomGroupGroup::setExprParameters(const Group& group1, const Group& group2) {
+    auto& mean_charge1 = mean_charges[group1.id];
+    auto& mean_charge2 = mean_charges[group2.id];
+    mean_charge1 += monopoleMoment(group1.begin(), group1.end());
+    mean_charge2 += monopoleMoment(group2.begin(), group2.end());
+    properties.mean_charge1 = mean_charge1.avg();
+    properties.mean_charge2 = mean_charge2.avg();
+    properties.mass_center_separation = sqrt(spc.geometry.sqdist(group1.mass_center, group2.mass_center));
+}
+
+void CustomGroupGroup::to_json(json& j) const {
+    j = json_input_backup;
+    j["mean_charges"] = {{"Z1", mean_charges.at(molid1).avg()}, {"Z2", mean_charges.at(molid2).avg()}};
+};
 
 } // end of namespace Faunus::Energy

--- a/src/energy.h
+++ b/src/energy.h
@@ -68,7 +68,7 @@ class Hamiltonian;
  * If any particles is ouside, infinite energy is returned; zero otherwirse.
  * This is not needed for cuboidal geometry as particles are always wrapped using PBC.
  */
-class ContainerOverlap : public Energybase {
+class ContainerOverlap : public EnergyTerm {
   private:
     const Space& spc;
     bool groupIsOutsideContainer(const Change::GroupChange& group_change) const;
@@ -236,7 +236,7 @@ struct PolicyIonIonIPBCEigen : public PolicyIonIonIPBC {
  * @todo energy() currently has the responsibility to update k-vectors.
  *       This is error prone and should be handled *before* this step.
  */
-class Ewald : public Energybase {
+class Ewald : public EnergyTerm {
   private:
     const Space& spc;
     EwaldData data;
@@ -250,7 +250,7 @@ class Ewald : public Energybase {
     void setOldGroups(const Space::GroupVector& old_groups); //!< Optimization if old groups are available (optional)
     void updateState(const Change& change) override;
     double energy(const Change& change) override;
-    void sync(Energybase* energybase, const Change& change) override;
+    void sync(EnergyTerm* energybase, const Change& change) override;
     void to_json(json& j) const override;
     void force(std::vector<Point>& forces) override; // update forces on all particles
 };
@@ -258,7 +258,7 @@ class Ewald : public Energybase {
 /**
  * @brief Pressure term for NPT ensemble
  */
-class Isobaric : public Energybase {
+class Isobaric : public EnergyTerm {
   private:
     const Space& spc;
     double pressure = 0.0;                                     //!< Applied pressure
@@ -274,7 +274,7 @@ class Isobaric : public Energybase {
  *
  * If outside specified `range`, infinity energy is returned, causing rejection.
  */
-class Constrain : public Energybase {
+class Constrain : public EnergyTerm {
   private:
     std::string type;
     std::unique_ptr<ReactionCoordinate::ReactionCoordinateBase> coordinate;
@@ -293,7 +293,7 @@ class Constrain : public Energybase {
  *
  * @todo Optimize.
  */
-class Bonded : public Energybase {
+class Bonded : public EnergyTerm {
   private:
     using BondVector = BasePointerVector<Potential::BondData>;
     const Space& spc;
@@ -360,13 +360,13 @@ class PairEnergy {
     const Space::GeometryType& geometry;       //!< geometry to operate with
     TPairPotential pair_potential;             //!< pair potential function/functor
     Space& spc;                                //!< space to init ParticleSelfEnergy with addPairPotentialSelfEnergy
-    BasePointerVector<Energybase>& potentials; //!< registered non-bonded potentials, see addPairPotentialSelfEnergy
+    BasePointerVector<EnergyTerm>& potentials; //!< registered non-bonded potentials, see addPairPotentialSelfEnergy
   public:
     /**
      * @param spc
      * @param potentials  registered non-bonded potentials
      */
-    PairEnergy(Space& spc, BasePointerVector<Energybase>& potentials)
+    PairEnergy(Space& spc, BasePointerVector<EnergyTerm>& potentials)
         : geometry(spc.geometry)
         , spc(spc)
         , potentials(potentials) {}
@@ -1320,7 +1320,7 @@ class GroupPairing {
     }
 };
 
-class NonbondedBase : public Energybase {
+class NonbondedBase : public EnergyTerm {
   public:
     virtual double particleParticleEnergy(const Particle &particle1, const Particle &particle2) = 0;
     virtual double groupGroupEnergy(const Group& group1, const Group& group2) = 0;
@@ -1341,8 +1341,10 @@ template <RequirePairEnergy TPairEnergy, typename TPairingPolicy> class Nonbonde
         energy_accumulator; //!< energy accumulator used for storing and summing pair-wise energies
 
   public:
-    Nonbonded(const json& j, Space& spc, BasePointerVector<Energybase>& pot)
-        : spc(spc), pair_energy(spc, pot), pairing(spc) {
+    Nonbonded(const json& j, Space& spc, BasePointerVector<EnergyTerm>& pot)
+        : spc(spc)
+        , pair_energy(spc, pot)
+        , pairing(spc) {
         name = "nonbonded";
         from_json(j);
         energy_accumulator = createEnergyAccumulator(j, pair_energy, 0.0);
@@ -1426,7 +1428,7 @@ class NonbondedCached : public Nonbonded<TPairEnergy, TPairingPolicy> {
         if (j < i) {
             std::swap(i, j);
         }
-        if (Energybase::state == Energybase::MonteCarloState::TRIAL) { // if this is from the trial system
+        if (EnergyTerm::state == EnergyTerm::MonteCarloState::TRIAL) { // if this is from the trial system
             TAccumulator energy_accumulator(Base::pair_energy);
             Base::pairing.group2group(energy_accumulator, g1, g2);
             energy_cache(i, j) = static_cast<double>(energy_accumulator);  // update the cache
@@ -1441,7 +1443,8 @@ class NonbondedCached : public Nonbonded<TPairEnergy, TPairingPolicy> {
     }
 
   public:
-    NonbondedCached(const json &j, Space &spc, BasePointerVector<Energybase> &pot) : Base(j, spc, pot) {
+    NonbondedCached(const json& j, Space& spc, BasePointerVector<EnergyTerm>& pot)
+        : Base(j, spc, pot) {
         Base::name += "EM";
         init();
     }
@@ -1525,7 +1528,7 @@ class NonbondedCached : public Nonbonded<TPairEnergy, TPairingPolicy> {
      * @param base_ptr
      * @param change
      */
-    void sync(Energybase* base_ptr, const Change& change) override {
+    void sync(EnergyTerm* base_ptr, const Change& change) override {
         auto other = dynamic_cast<decltype(this)>(base_ptr);
         assert(other);
         if (change.everything || change.volume_change) {
@@ -1552,7 +1555,7 @@ class NonbondedCached : public Nonbonded<TPairEnergy, TPairingPolicy> {
  * @todo - Implement partial evaluation refelcting `change` object
  *       - Average volume currently mixes accepted/rejected states
  */
-class FreeSASAEnergy : public Energybase {
+class FreeSASAEnergy : public EnergyTerm {
   private:
     std::vector<double> positions; //!< Flattened position buffer for all particles
     std::vector<double> radii;     //!< Radii buffer for all particles
@@ -1564,7 +1567,7 @@ class FreeSASAEnergy : public Energybase {
     Average<double> mean_surface_area;
 
     void to_json(json &j) const override;
-    void sync(Energybase* energybase_ptr, const Change& change) override;
+    void sync(EnergyTerm* energybase_ptr, const Change& change) override;
     void updateSASA(const Change& change);
     void init() override;
 
@@ -1620,10 +1623,10 @@ class FreeSASAEnergy : public Energybase {
  * (and slow) system update is performed on each call to `energy()`. This class is used as
  * a reference and base class for more clever implementations.
  */
-class SASAEnergyReference : public Energybase {
+class SASAEnergyReference : public EnergyTerm {
   private:
     void to_json(json& j) const override;
-    void sync(Energybase* energybase_ptr, const Change& change) override;
+    void sync(EnergyTerm* energybase_ptr, const Change& change) override;
 
   protected:
     void init() override;
@@ -1655,7 +1658,7 @@ class SASAEnergy : public SASAEnergyReference {
         current_neighbours; //!< holds cached neighbour indices for each particle in ParticleVector
     std::vector<index_type> changed_indices; //!< paritcle indices whose SASA changed based on change object
 
-    void sync(Energybase* energybase_ptr, const Change& change) override;
+    void sync(EnergyTerm* energybase_ptr, const Change& change) override;
     void init() override;
 
     void updateChangedIndices(const Change& change);
@@ -1675,7 +1678,7 @@ class SASAEnergy : public SASAEnergyReference {
  * to illustrate parallel tempering in the book
  * "Understanding Molecular Simulation" by D. Frenkel.
  */
-class Example2D : public Energybase {
+class Example2D : public EnergyTerm {
   private:
     bool use_2d = true;        // Set to false to apply energy only along x (as by the book)
     double scale_energy = 1.0; // effective temperature
@@ -1696,7 +1699,7 @@ class Example2D : public Energybase {
  * - "R" Mass center separation
  * - "Z1" and "Z2" mean charges of the two molecules
  */
-class CustomGroupGroup : public Energybase {
+class CustomGroupGroup : public EnergyTerm {
   private:
     const Space& spc;
     MoleculeData::index_type molid1;
@@ -1722,7 +1725,7 @@ class CustomGroupGroup : public Energybase {
 /**
  * @brief Aggregate and sum energy terms
  */
-class Hamiltonian : public Energybase, public BasePointerVector<Energybase> {
+class Hamiltonian : public EnergyTerm, public BasePointerVector<EnergyTerm> {
   private:
     double maximum_allowed_energy = pc::infty; //!< Maximum allowed energy change
     std::vector<double> latest_energies;       //!< Placeholder for the lastest energies for each energy term
@@ -1731,13 +1734,13 @@ class Hamiltonian : public Energybase, public BasePointerVector<Energybase> {
     void checkBondedMolecules() const;         //!< Warn if bonded molecules and no bonded energy term
     void to_json(json& j) const override;
     void force(PointVector& forces) override;
-    std::unique_ptr<Energybase> createEnergy(Space& spc, const std::string& name, const json& j);
+    std::unique_ptr<EnergyTerm> createEnergy(Space& spc, const std::string& name, const json& j);
 
   public:
     Hamiltonian(Space& spc, const json& j);
     void init() override;
     void updateState(const Change& change) override;
-    void sync(Energybase* other_hamiltonian, const Change& change) override;
+    void sync(EnergyTerm* other_hamiltonian, const Change& change) override;
     double energy(const Change& change) override;      //!< Energy due to changes
     const std::vector<double>& latestEnergies() const; //!< Energies for each term from the latest call to `energy()`
 };

--- a/src/energy.h
+++ b/src/energy.h
@@ -1688,6 +1688,38 @@ class Example2D : public Energybase {
 };
 
 /**
+ * @brief Custom energy between pair of molecules
+ *
+ * For two different or equal molecule ids, this adds a user defined
+ * energy in a function given at run-time. In addition to physical
+ * constants, the the following parameters are exposed:
+ * - "R" Mass center separation
+ * - "Z1" and "Z2" mean charges of the two molecules
+ */
+class CustomGroupGroup : public Energybase {
+  private:
+    const Space& spc;
+    MoleculeData::index_type molid1;
+    MoleculeData::index_type molid2;
+    std::map<MoleculeData::index_type, Average<double>> mean_charges;
+    std::unique_ptr<ExprFunction<double>> expr;
+    json json_input_backup; // initial json input
+    struct Properties {     // storage for particle properties
+        double mean_charge1 = 0;
+        double mean_charge2 = 0;
+        double mass_center_separation = 0;
+    };
+    Properties properties;
+
+    void to_json(json& j) const override;
+    void setExprParameters(const Group& group1, const Group& group2);
+
+  public:
+    CustomGroupGroup(const json& j, const Space& spc);
+    double energy(const Change& change) override;
+};
+
+/**
  * @brief Aggregate and sum energy terms
  */
 class Hamiltonian : public Energybase, public BasePointerVector<Energybase> {

--- a/src/energy.h
+++ b/src/energy.h
@@ -36,7 +36,7 @@ class ReactionCoordinateBase;
 }
 
 namespace Potential {
-class PairPotentialBase;
+class PairPotential;
 }
 
 /**

--- a/src/energy.h
+++ b/src/energy.h
@@ -35,7 +35,7 @@ namespace ReactionCoordinate {
 class ReactionCoordinateBase;
 }
 
-namespace Potential {
+namespace pairpotential {
 class PairPotential;
 }
 
@@ -295,7 +295,7 @@ class Constrain : public EnergyTerm {
  */
 class Bonded : public EnergyTerm {
   private:
-    using BondVector = BasePointerVector<Potential::BondData>;
+    using BondVector = BasePointerVector<pairpotential::BondData>;
     const Space& spc;
     BondVector external_bonds;                                      //!< inter-molecular bonds
     std::map<int, BondVector> internal_bonds;                       //!< intra-molecular bonds; key is group index
@@ -355,7 +355,7 @@ auto indexComplement(std::integral auto size, const ranges::cpp20::range auto& r
  * @tparam TPairPotential  a pair potential to compute with
  * @tparam allow_anisotropic_pair_potential  pass also a distance vector to the pair potential, slower
  */
-template <Potential::RequirePairPotential TPairPotential, bool allow_anisotropic_pair_potential = true>
+template <pairpotential::RequirePairPotential TPairPotential, bool allow_anisotropic_pair_potential = true>
 class PairEnergy {
     const Space::GeometryType& geometry;       //!< geometry to operate with
     TPairPotential pair_potential;             //!< pair potential function/functor
@@ -415,7 +415,7 @@ class PairEnergy {
     }
 
     void from_json(const json& j) {
-        Potential::from_json(j, pair_potential);
+        pairpotential::from_json(j, pair_potential);
         if (!pair_potential.isotropic && !allow_anisotropic_pair_potential) {
             throw std::logic_error("Only isotropic pair potentials are allowed.");
         }

--- a/src/energy.h
+++ b/src/energy.h
@@ -1692,7 +1692,7 @@ class Example2D : public Energybase {
  *
  * For two different or equal molecule ids, this adds a user defined
  * energy in a function given at run-time. In addition to physical
- * constants, the the following parameters are exposed:
+ * constants, the following parameters are exposed:
  * - "R" Mass center separation
  * - "Z1" and "Z2" mean charges of the two molecules
  */

--- a/src/externalpotential.cpp
+++ b/src/externalpotential.cpp
@@ -10,25 +10,25 @@ namespace Faunus::Energy {
 
 // ------------ Energybase -------------
 
-void Energybase::to_json(json &) const {}
+void EnergyTerm::to_json(json&) const {}
 
 /**
  * @param other_energy Other energy instance to copy data from
  * @param change Describes the difference with the other energy term
  */
-void Energybase::sync([[maybe_unused]] Energybase* other_energy, [[maybe_unused]] const Change& change) {}
+void EnergyTerm::sync([[maybe_unused]] EnergyTerm* other_energy, [[maybe_unused]] const Change& change) {}
 
-void Energybase::init() {}
-void Energybase::force([[maybe_unused]] PointVector& forces) {}
+void EnergyTerm::init() {}
+void EnergyTerm::force([[maybe_unused]] PointVector& forces) {}
 
 /**
  * This should be called whenever the Space is modified (particles, volume, etc)
  * as some energy terms may depend on this. One example is Ewald summation that
  * needs to update k-vectors before calculating the energy.
  */
-void Energybase::updateState([[maybe_unused]] const Change& change) {}
+void EnergyTerm::updateState([[maybe_unused]] const Change& change) {}
 
-void to_json(json &j, const Energybase &base) {
+void to_json(json& j, const EnergyTerm& base) {
     assert(not base.name.empty());
     if (base.timer)
         j[base.name]["relative time"] = base.timer.result();
@@ -295,7 +295,7 @@ double ExternalAkesson::evalPotential(const double z, const double a) const {
            2 * z * (0.5 * pc::pi + std::asin((a2 * a2 - z2 * z2 - 2 * a2 * z2) / std::pow(a2 + z2, 2)));
 }
 
-void ExternalAkesson::sync(Energybase* source, const Change&) {
+void ExternalAkesson::sync(EnergyTerm* source, const Change&) {
     if (fixed_potential) {
         return;
     }

--- a/src/externalpotential.h
+++ b/src/externalpotential.h
@@ -17,7 +17,7 @@ namespace Energy {
 /**
  * All energies inherit from this class
  */
-class Energybase {
+class EnergyTerm {
   public:
     enum class MonteCarloState { ACCEPTED, TRIAL, NONE };
     MonteCarloState state = MonteCarloState::NONE;
@@ -26,14 +26,14 @@ class Energybase {
     TimeRelativeOfTotal<std::chrono::microseconds> timer; //!< Timer for measuring speed
     virtual double energy(const Change& change) = 0;      //!< energy due to change
     virtual void to_json(json& j) const;                  //!< json output
-    virtual void sync(Energybase* other_energy, const Change& change); //!< Sync (copy from) another energy instance
+    virtual void sync(EnergyTerm* other_energy, const Change& change); //!< Sync (copy from) another energy instance
     virtual void init();                                  //!< reset and initialize
     virtual void updateState(const Change& change);       //!< Update internal state to reflect change in e.g. Space
     virtual void force(PointVector& forces);              //!< update forces on all particles
-    inline virtual ~Energybase() = default;
+    inline virtual ~EnergyTerm() = default;
 };
 
-void to_json(json &j, const Energybase &base); //!< Converts any energy class to json object
+void to_json(json& j, const EnergyTerm& base); //!< Converts any energy class to json object
 
 /**
  * @brief Base class for external potentials
@@ -44,7 +44,7 @@ void to_json(json &j, const Energybase &base); //!< Converts any energy class to
  *
  * @todo The `dN` check is inefficient as it calculates the external potential on *all* particles.
  */
-class ExternalPotential : public Energybase {
+class ExternalPotential : public EnergyTerm {
   private:
     bool act_on_mass_center = false;              //!< apply only on center-of-mass
     std::set<int> molecule_ids;                   //!< ids of molecules to act on
@@ -124,7 +124,7 @@ class ExternalAkesson : public ExternalPotential {
     void saveChargeDensity();                       //!< save charge density profile to disk
     void loadChargeDensity();                       //!< load charge density profile from disk
     void to_json(json &) const override;
-    void sync(Energybase*, const Change&) override;
+    void sync(EnergyTerm*, const Change&) override;
 
   public:
     ExternalAkesson(const json& j, const Space& spc);

--- a/src/faunus.cpp
+++ b/src/faunus.cpp
@@ -43,11 +43,10 @@ void showProgress(std::shared_ptr<ProgressIndicator::ProgressTracker>& progress_
 void playRetroMusic();
 template <typename TimePoint>
 void saveOutput(TimePoint& starting_time, docopt::Options& args, MetropolisMonteCarlo& simulation,
-                const Analysis::CombinedAnalysis& analysis);
+                const analysis::CombinedAnalysis& analysis);
 
 void mainLoop(bool show_progress, const json& json_in, MetropolisMonteCarlo& simulation,
-              Analysis::CombinedAnalysis& analysis);
-
+              analysis::CombinedAnalysis& analysis);
 
 static const char USAGE[] =
     R"(Faunus - the Monte Carlo code you're looking for!
@@ -103,7 +102,7 @@ int main(int argc, const char** argv) {
         MetropolisMonteCarlo simulation(input);
         loadState(args, simulation);
         checkElectroNeutrality(simulation);
-        Analysis::CombinedAnalysis analysis(input.at("analysis"), simulation.getSpace(), simulation.getHamiltonian());
+        analysis::CombinedAnalysis analysis(input.at("analysis"), simulation.getSpace(), simulation.getHamiltonian());
 
         bool show_progress = !quiet && !args["--nobar"].asBool();
 #ifdef ENABLE_MPI
@@ -204,7 +203,7 @@ int runUnittests(int argc, const char* const* argv) {
 }
 
 void mainLoop(bool show_progress, const json& json_in, MetropolisMonteCarlo& simulation,
-              Analysis::CombinedAnalysis& analysis) {
+              analysis::CombinedAnalysis& analysis) {
     const auto& loop = json_in.at("mcloop");
     const auto macro = loop.at("macro").get<int>();
     const auto micro = loop.at("micro").get<int>();
@@ -423,7 +422,7 @@ void loadState(docopt::Options& args, MetropolisMonteCarlo& simulation) {
 
 template <typename TimePoint>
 void saveOutput(TimePoint& starting_time, docopt::Options& args, MetropolisMonteCarlo& simulation,
-                const Analysis::CombinedAnalysis& analysis) {
+                const analysis::CombinedAnalysis& analysis) {
 
     if (std::ofstream stream(Faunus::MPI::prefix + args["--output"].asString()); stream) {
         json j;

--- a/src/faunus.cpp
+++ b/src/faunus.cpp
@@ -125,7 +125,7 @@ int main(int argc, const char** argv) {
 }
 void setRandomNumberGenerator(const json& input) {
     if (auto it = input.find("random"); it != input.end()) {
-        from_json(*it, move::MoveBase::slump); // static --> shared for all moves
+        from_json(*it, move::Move::slump); // static --> shared for all moves
         from_json(*it, Faunus::random);
     }
 }

--- a/src/faunus.cpp
+++ b/src/faunus.cpp
@@ -125,7 +125,7 @@ int main(int argc, const char** argv) {
 }
 void setRandomNumberGenerator(const json& input) {
     if (auto it = input.find("random"); it != input.end()) {
-        from_json(*it, Move::MoveBase::slump); // static --> shared for all moves
+        from_json(*it, move::MoveBase::slump); // static --> shared for all moves
         from_json(*it, Faunus::random);
     }
 }

--- a/src/forcemove.cpp
+++ b/src/forcemove.cpp
@@ -23,20 +23,25 @@ static inline double meanSquareSpeedComponent(T mass) {
 
 // =============== IntegratorBase  ===============
 
-IntegratorBase::IntegratorBase(Space &spc, Energy::Energybase &energy) : spc(spc), energy(energy) {}
+IntegratorBase::IntegratorBase(Space& spc, Energy::EnergyTerm& energy)
+    : spc(spc)
+    , energy(energy) {}
 
 void from_json(const json &j, IntegratorBase &i) { i.from_json(j); }
 void to_json(json &j, const IntegratorBase &i) { i.to_json(j); }
 
 // =============== LangevinVelocityVerlet ===============
 
-LangevinVelocityVerlet::LangevinVelocityVerlet(Space &spc, Energy::Energybase &energy) : IntegratorBase(spc, energy) {}
+LangevinVelocityVerlet::LangevinVelocityVerlet(Space& spc, Energy::EnergyTerm& energy)
+    : IntegratorBase(spc, energy) {}
 
-LangevinVelocityVerlet::LangevinVelocityVerlet(Space &spc, Energy::Energybase &energy, double time_step,
+LangevinVelocityVerlet::LangevinVelocityVerlet(Space& spc, Energy::EnergyTerm& energy, double time_step,
                                                double friction_coefficient)
-    : IntegratorBase(spc, energy), time_step(time_step), friction_coefficient(friction_coefficient) {}
+    : IntegratorBase(spc, energy)
+    , time_step(time_step)
+    , friction_coefficient(friction_coefficient) {}
 
-LangevinVelocityVerlet::LangevinVelocityVerlet(Space &spc, Energy::Energybase &energy, const json &j)
+LangevinVelocityVerlet::LangevinVelocityVerlet(Space& spc, Energy::EnergyTerm& energy, const json& j)
     : LangevinVelocityVerlet::LangevinVelocityVerlet(spc, energy) {
     from_json(j);
 }
@@ -107,7 +112,7 @@ void LangevinVelocityVerlet::to_json(json &j) const {
 }
 
 TEST_CASE("[Faunus] Integrator") {
-    class DummyEnergy : public Energy::Energybase {
+    class DummyEnergy : public Energy::EnergyTerm {
         double energy([[maybe_unused]] const Change& change) override { return 0.0; }
     };
     Space spc;
@@ -196,10 +201,10 @@ LangevinDynamics::LangevinDynamics(Space &spc, std::string name, std::string cit
 LangevinDynamics::LangevinDynamics(Space &spc, std::shared_ptr<IntegratorBase> integrator, unsigned int nsteps)
     : LangevinDynamics(spc, "langevin_dynamics", "", integrator, nsteps) {}
 
-LangevinDynamics::LangevinDynamics(Space &spc, Energy::Energybase &energy)
+LangevinDynamics::LangevinDynamics(Space& spc, Energy::EnergyTerm& energy)
     : LangevinDynamics::LangevinDynamics(spc, std::make_shared<LangevinVelocityVerlet>(spc, energy), 0) {}
 
-LangevinDynamics::LangevinDynamics(Space &spc, Energy::Energybase &energy, const json &j)
+LangevinDynamics::LangevinDynamics(Space& spc, Energy::EnergyTerm& energy, const json& j)
     : LangevinDynamics::LangevinDynamics(spc, energy) {
     from_json(j);
 }
@@ -208,7 +213,7 @@ void LangevinDynamics::_to_json(json &j) const { ForceMoveBase::_to_json(j); }
 void LangevinDynamics::_from_json(const json &j) { ForceMoveBase::_from_json(j); }
 
 TEST_CASE("[Faunus] LangevinDynamics") {
-    class DummyEnergy : public Energy::Energybase {
+    class DummyEnergy : public Energy::EnergyTerm {
         double energy([[maybe_unused]] const Change& change) override { return 0.0; }
     };
     Space spc;

--- a/src/forcemove.cpp
+++ b/src/forcemove.cpp
@@ -126,9 +126,11 @@ TEST_CASE("[Faunus] Integrator") {
 
 // =============== ForceMoveBase ===============
 
-ForceMoveBase::ForceMoveBase(Space &spc, std::string name, std::string cite,
-                             std::shared_ptr<IntegratorBase> integrator, unsigned int nsteps)
-    : MoveBase(spc, name, cite), integrator(integrator), number_of_steps(nsteps) {
+ForceMoveBase::ForceMoveBase(Space& spc, std::string name, std::string cite, std::shared_ptr<IntegratorBase> integrator,
+                             unsigned int nsteps)
+    : Move(spc, name, cite)
+    , integrator(integrator)
+    , number_of_steps(nsteps) {
     forces.reserve(spc.particles.size());
     velocities.reserve(spc.particles.size());
     resizeForcesAndVelocities();

--- a/src/forcemove.cpp
+++ b/src/forcemove.cpp
@@ -126,8 +126,8 @@ TEST_CASE("[Faunus] Integrator") {
 
 // =============== ForceMoveBase ===============
 
-ForceMoveBase::ForceMoveBase(Space& spc, std::string name, std::string cite, std::shared_ptr<IntegratorBase> integrator,
-                             unsigned int nsteps)
+ForceMove::ForceMove(Space& spc, std::string name, std::string cite, std::shared_ptr<IntegratorBase> integrator,
+                     unsigned int nsteps)
     : Move(spc, name, cite)
     , integrator(integrator)
     , number_of_steps(nsteps) {
@@ -142,14 +142,14 @@ ForceMoveBase::ForceMoveBase(Space& spc, std::string name, std::string cite, std
  *
  * Upon resizing, new elements in `forces` and `velocities` are zeroed.
  */
-size_t ForceMoveBase::resizeForcesAndVelocities() {
+size_t ForceMove::resizeForcesAndVelocities() {
     const auto num_active_particles = spc.numParticles(Space::Selection::ACTIVE);
     forces.resize(num_active_particles, Point::Zero());
     velocities.resize(num_active_particles, Point::Zero());
     return num_active_particles;
 }
 
-void ForceMoveBase::_move(Change &change) {
+void ForceMove::_move(Change& change) {
     change.clear();
     change.everything = true;
     resizeForcesAndVelocities();
@@ -161,18 +161,18 @@ void ForceMoveBase::_move(Change &change) {
     }
 }
 
-void ForceMoveBase::_to_json(json &j) const {
+void ForceMove::_to_json(json& j) const {
     j = {{"nsteps", number_of_steps}};
     j["integrator"] = *integrator;
 }
 
-void ForceMoveBase::_from_json(const json &j) {
+void ForceMove::_from_json(const json& j) {
     number_of_steps = j.at("nsteps").get<unsigned int>();
     integrator->from_json(j["integrator"]);
     generateVelocities();
 }
 
-double ForceMoveBase::bias(Change &, double, double) {
+double ForceMove::bias(Change&, double, double) {
     return pc::neg_infty; // always accept the move
 }
 
@@ -181,7 +181,7 @@ double ForceMoveBase::bias(Change &, double, double) {
  *        a dangling Point& reference being returned. Observed with Clang10/RelWithDebInfo, but not in Debug, or
  *        with GCC.
  */
-void ForceMoveBase::generateVelocities() {
+void ForceMove::generateVelocities() {
     NormalRandomVector random_vector; // generator of random 3d vector from a normal distribution
     const auto particles = spc.activeParticles();
     resizeForcesAndVelocities();
@@ -191,14 +191,14 @@ void ForceMoveBase::generateVelocities() {
     std::fill(forces.begin(), forces.end(), Point::Zero());
 }
 
-const PointVector &ForceMoveBase::getForces() const { return forces; }
-const PointVector &ForceMoveBase::getVelocities() const { return velocities; }
+const PointVector& ForceMove::getForces() const { return forces; }
+const PointVector& ForceMove::getVelocities() const { return velocities; }
 
 // =============== LangevinMove ===============
 
-LangevinDynamics::LangevinDynamics(Space &spc, std::string name, std::string cite,
+LangevinDynamics::LangevinDynamics(Space& spc, std::string name, std::string cite,
                                    std::shared_ptr<IntegratorBase> integrator, unsigned int nsteps)
-    : ForceMoveBase(spc, name, cite, integrator, nsteps) {}
+    : ForceMove(spc, name, cite, integrator, nsteps) {}
 
 LangevinDynamics::LangevinDynamics(Space &spc, std::shared_ptr<IntegratorBase> integrator, unsigned int nsteps)
     : LangevinDynamics(spc, "langevin_dynamics", "", integrator, nsteps) {}
@@ -211,8 +211,8 @@ LangevinDynamics::LangevinDynamics(Space& spc, Energy::EnergyTerm& energy, const
     from_json(j);
 }
 
-void LangevinDynamics::_to_json(json &j) const { ForceMoveBase::_to_json(j); }
-void LangevinDynamics::_from_json(const json &j) { ForceMoveBase::_from_json(j); }
+void LangevinDynamics::_to_json(json& j) const { ForceMove::_to_json(j); }
+void LangevinDynamics::_from_json(const json& j) { ForceMove::_from_json(j); }
 
 TEST_CASE("[Faunus] LangevinDynamics") {
     class DummyEnergy : public Energy::EnergyTerm {

--- a/src/forcemove.cpp
+++ b/src/forcemove.cpp
@@ -3,7 +3,7 @@
 #include "energy.h"
 #include <range/v3/view/zip.hpp>
 
-namespace Faunus::Move {
+namespace Faunus::move {
 
 TEST_SUITE_BEGIN("ForceMove");
 
@@ -240,4 +240,4 @@ TEST_CASE("[Faunus] LangevinDynamics") {
 
 TEST_SUITE_END();
 
-} // namespace Faunus::Move
+} // namespace Faunus::move

--- a/src/forcemove.h
+++ b/src/forcemove.h
@@ -38,8 +38,8 @@ class NormalRandomVector {
 class IntegratorBase {
   protected:
     Space &spc;
-    Energy::Energybase &energy;
-    IntegratorBase(Space &, Energy::Energybase &);
+    Energy::EnergyTerm& energy;
+    IntegratorBase(Space&, Energy::EnergyTerm&);
     virtual ~IntegratorBase() = default;
 
   public:
@@ -72,9 +72,9 @@ class LangevinVelocityVerlet : public IntegratorBase {
     inline Point velocityFluctuationDissipation(const Point &velocity, const double mass);
 
   public:
-    LangevinVelocityVerlet(Space &spc, Energy::Energybase &energy);
-    LangevinVelocityVerlet(Space &spc, Energy::Energybase &energy, double time_step, double friction_coefficient);
-    LangevinVelocityVerlet(Space &spc, Energy::Energybase &energy, const json &j);
+    LangevinVelocityVerlet(Space& spc, Energy::EnergyTerm& energy);
+    LangevinVelocityVerlet(Space& spc, Energy::EnergyTerm& energy, double time_step, double friction_coefficient);
+    LangevinVelocityVerlet(Space& spc, Energy::EnergyTerm& energy, const json& j);
     void step(PointVector &velocities, PointVector &forces) override;
     void from_json(const json &j) override;
     void to_json(json &j) const override;
@@ -121,8 +121,8 @@ class LangevinDynamics : public ForceMoveBase {
 
   public:
     LangevinDynamics(Space& spc, std::shared_ptr<IntegratorBase> integrator, unsigned int nsteps);
-    LangevinDynamics(Space& spc, Energy::Energybase&, const json&);
-    LangevinDynamics(Space& spc, Energy::Energybase&);
+    LangevinDynamics(Space& spc, Energy::EnergyTerm&, const json&);
+    LangevinDynamics(Space& spc, Energy::EnergyTerm&);
     void _to_json(json &j) const override;
     void _from_json(const json &j) override;
 };

--- a/src/forcemove.h
+++ b/src/forcemove.h
@@ -2,7 +2,7 @@
 #include "move.h"
 #include "energy.h"
 
-namespace Faunus::Move {
+namespace Faunus::move {
 
 /** @section Force moves
  *

--- a/src/forcemove.h
+++ b/src/forcemove.h
@@ -89,7 +89,7 @@ void to_json(json &j, const IntegratorBase &i);
  * Orchestrate execution of integrators, thermostats, etc. Store vectors for velocities and forces, which are not part
  * of the particle vector in the space.
  */
-class ForceMoveBase : public MoveBase {
+class ForceMoveBase : public Move {
   protected:
     std::shared_ptr<IntegratorBase> integrator;
     unsigned int number_of_steps; //!< number of integration steps to perform during a single MC move

--- a/src/forcemove.h
+++ b/src/forcemove.h
@@ -89,7 +89,7 @@ void to_json(json &j, const IntegratorBase &i);
  * Orchestrate execution of integrators, thermostats, etc. Store vectors for velocities and forces, which are not part
  * of the particle vector in the space.
  */
-class ForceMoveBase : public Move {
+class ForceMove : public Move {
   protected:
     std::shared_ptr<IntegratorBase> integrator;
     unsigned int number_of_steps; //!< number of integration steps to perform during a single MC move
@@ -101,9 +101,9 @@ class ForceMoveBase : public Move {
     void _to_json(json &j) const override;
     void _from_json(const json &j) override;
     void _move(Change &change) override;
-    ForceMoveBase(Space& spc, std::string name, std::string cite, std::shared_ptr<IntegratorBase> integrator,
-                  unsigned int nsteps);
-    virtual ~ForceMoveBase() = default;
+    ForceMove(Space& spc, std::string name, std::string cite, std::shared_ptr<IntegratorBase> integrator,
+              unsigned int nsteps);
+    virtual ~ForceMove() = default;
 
   public:
     double bias(Change &, double, double) override;
@@ -114,7 +114,7 @@ class ForceMoveBase : public Move {
 /**
  * @brief Langevin dynamics move using Langevin equation of motion
  */
-class LangevinDynamics : public ForceMoveBase {
+class LangevinDynamics : public ForceMove {
   protected:
     LangevinDynamics(Space& spc, std::string name, std::string cite, std::shared_ptr<IntegratorBase> integrator,
                      unsigned int nsteps);

--- a/src/molecule.h
+++ b/src/molecule.h
@@ -8,7 +8,7 @@
 
 namespace Faunus {
 
-namespace Potential {
+namespace pairpotential {
 struct BondData;
 }
 
@@ -210,13 +210,13 @@ class MoleculeData {
     double activity = 0.0;       //!< Chemical activity (mol/l)
 
     std::vector<AtomData::index_type> atoms; //!< Sequence of atoms in molecule (atom id's)
-    BasePointerVector<Potential::BondData> bonds;
+    BasePointerVector<pairpotential::BondData> bonds;
     WeightedDistribution<ParticleVector> conformations; //!< Conformations of molecule
     size_t numConformations() const;                    //!< Number of conformations
 
     MoleculeData();
     MoleculeData(const std::string& name, const ParticleVector& particles,
-                 const BasePointerVector<Potential::BondData>& bonds);
+                 const BasePointerVector<pairpotential::BondData>& bonds);
 
     bool isImplicit() const; //!< Is molecule implicit and explicitly absent from simulation cell?
     bool isPairExcluded(int i, int j) const;

--- a/src/montecarlo.cpp
+++ b/src/montecarlo.cpp
@@ -18,7 +18,7 @@ bool MetropolisMonteCarlo::metropolisCriterion(const double energy_change) {
     if (std::isnan(energy_change)) {
         throw std::runtime_error("Metropolis error: energy cannot be NaN");
     }
-    const auto random_number_between_zero_and_one = move::MoveBase::slump(); // engine *must* be propagated!
+    const auto random_number_between_zero_and_one = move::Move::slump();     // engine *must* be propagated!
     if (std::isinf(energy_change) && energy_change < 0.0) {                  // if negative infinity -> quietly accept
         return true;
     }
@@ -110,7 +110,7 @@ void MetropolisMonteCarlo::restore(const json &j) {
         from_json(j, *state->spc);       // default, accepted state
         from_json(j, *trial_state->spc); // trial state
         if (j.contains("random-move")) {
-            move::MoveBase::slump = j["random-move"]; // restore move random number generator
+            move::Move::slump = j["random-move"]; // restore move random number generator
         }
         if (j.contains("random-global")) {
             Faunus::random = j["random-global"]; // restore global random number generator
@@ -124,7 +124,7 @@ void MetropolisMonteCarlo::restore(const json &j) {
     }
 }
 
-void MetropolisMonteCarlo::performMove(move::MoveBase& move) {
+void MetropolisMonteCarlo::performMove(move::Move& move) {
     Change change;
     move.move(change);
 #ifndef NDEBUG
@@ -164,7 +164,7 @@ void MetropolisMonteCarlo::performMove(move::MoveBase& move) {
     } else {
         // The `metropolis()` function propagates the engine and we need to stay in sync
         // Alternatively, we could use `engine.discard()`
-        move::MoveBase::slump();
+        move::Move::slump();
     }
 }
 

--- a/src/montecarlo.cpp
+++ b/src/montecarlo.cpp
@@ -41,8 +41,8 @@ void MetropolisMonteCarlo::init() {
     Change change;
     change.everything = true;
 
-    state->pot->state = Energy::Energybase::MonteCarloState::ACCEPTED;    // this is the old energy (current, accepted)
-    trial_state->pot->state = Energy::Energybase::MonteCarloState::TRIAL; // this is the new energy (trial)
+    state->pot->state = Energy::EnergyTerm::MonteCarloState::ACCEPTED;    // this is the old energy (current, accepted)
+    trial_state->pot->state = Energy::EnergyTerm::MonteCarloState::TRIAL; // this is the new energy (trial)
 
     state->pot->init();
     auto energy = state->pot->energy(change);

--- a/src/montecarlo.cpp
+++ b/src/montecarlo.cpp
@@ -18,7 +18,7 @@ bool MetropolisMonteCarlo::metropolisCriterion(const double energy_change) {
     if (std::isnan(energy_change)) {
         throw std::runtime_error("Metropolis error: energy cannot be NaN");
     }
-    const auto random_number_between_zero_and_one = Move::MoveBase::slump(); // engine *must* be propagated!
+    const auto random_number_between_zero_and_one = move::MoveBase::slump(); // engine *must* be propagated!
     if (std::isinf(energy_change) && energy_change < 0.0) {                  // if negative infinity -> quietly accept
         return true;
     }
@@ -96,7 +96,7 @@ MetropolisMonteCarlo::MetropolisMonteCarlo(const json &j)
     faunus_logger->set_level(spdlog::level::off); // do not duplicate log info
     trial_state = std::make_unique<State>(j);     // ...for the trial state
     faunus_logger->set_level(original_log_level); // restore original log level
-    moves = std::make_unique<Move::MoveCollection>(j.at("moves"), *trial_state->spc, *trial_state->pot, *state->spc);
+    moves = std::make_unique<move::MoveCollection>(j.at("moves"), *trial_state->spc, *trial_state->pot, *state->spc);
     init();
 }
 
@@ -110,7 +110,7 @@ void MetropolisMonteCarlo::restore(const json &j) {
         from_json(j, *state->spc);       // default, accepted state
         from_json(j, *trial_state->spc); // trial state
         if (j.contains("random-move")) {
-            Move::MoveBase::slump = j["random-move"]; // restore move random number generator
+            move::MoveBase::slump = j["random-move"]; // restore move random number generator
         }
         if (j.contains("random-global")) {
             Faunus::random = j["random-global"]; // restore global random number generator
@@ -124,7 +124,7 @@ void MetropolisMonteCarlo::restore(const json &j) {
     }
 }
 
-void MetropolisMonteCarlo::performMove(Move::MoveBase& move) {
+void MetropolisMonteCarlo::performMove(move::MoveBase& move) {
     Change change;
     move.move(change);
 #ifndef NDEBUG
@@ -164,7 +164,7 @@ void MetropolisMonteCarlo::performMove(Move::MoveBase& move) {
     } else {
         // The `metropolis()` function propagates the engine and we need to stay in sync
         // Alternatively, we could use `engine.discard()`
-        Move::MoveBase::slump();
+        move::MoveBase::slump();
     }
 }
 

--- a/src/montecarlo.h
+++ b/src/montecarlo.h
@@ -11,7 +11,7 @@ namespace Energy {
 class Hamiltonian;
 }
 
-namespace Move {
+namespace move {
 class MoveBase;
 class MoveCollection;
 } // namespace Move
@@ -59,13 +59,13 @@ class MetropolisMonteCarlo {
     spdlog::level::level_enum original_log_level; //!< Storage for original loglevel
     std::unique_ptr<State> state;                 //!< The accepted MC state
     std::unique_ptr<State> trial_state;           //!< Proposed or trial MC state
-    std::unique_ptr<Move::MoveCollection> moves;  //!< Storage for all registered MC moves
+    std::unique_ptr<move::MoveCollection> moves;  //!< Storage for all registered MC moves
     std::string latest_move_name;                 //!< Name of latest MC move
     double sum_of_energy_changes = 0.0;           //!< Sum of all potential energy changes
     double initial_energy = 0.0;                  //!< Initial potential energy
     Average<double> average_energy;               //!< Average potential energy of the system
     void init();                                  //!< Reset state
-    void performMove(Move::MoveBase& move);       //!< Perform move using given move implementation
+    void performMove(move::MoveBase& move);       //!< Perform move using given move implementation
     double getEnergyChange(double new_energy, double old_energy) const;
     friend void to_json(json&, const MetropolisMonteCarlo&); //!< Write information to JSON object
     unsigned int number_of_sweeps = 0;                       //!< Number of MC sweeps, e.g. calls to sweep()

--- a/src/montecarlo.h
+++ b/src/montecarlo.h
@@ -12,7 +12,7 @@ class Hamiltonian;
 }
 
 namespace move {
-class MoveBase;
+class Move;
 class MoveCollection;
 } // namespace Move
 
@@ -65,7 +65,7 @@ class MetropolisMonteCarlo {
     double initial_energy = 0.0;                  //!< Initial potential energy
     Average<double> average_energy;               //!< Average potential energy of the system
     void init();                                  //!< Reset state
-    void performMove(move::MoveBase& move);       //!< Perform move using given move implementation
+    void performMove(move::Move& move);           //!< Perform move using given move implementation
     double getEnergyChange(double new_energy, double old_energy) const;
     friend void to_json(json&, const MetropolisMonteCarlo&); //!< Write information to JSON object
     unsigned int number_of_sweeps = 0;                       //!< Number of MC sweeps, e.g. calls to sweep()

--- a/src/move.cpp
+++ b/src/move.cpp
@@ -395,7 +395,7 @@ MoveCollection::move_iterator MoveCollection::sample() {
 #ifdef ENABLE_MPI
     auto& random_engine = MPI::mpi.random.engine; // parallel processes (tempering) must be in sync
 #else
-    auto& random_engine = Move::MoveBase::slump.engine;
+    auto& random_engine = move::Move::slump.engine;
 #endif
     if (!moves.empty()) {
         return moves.begin() + distribution(random_engine);

--- a/src/move.cpp
+++ b/src/move.cpp
@@ -15,7 +15,7 @@
 #include <range/v3/algorithm/count.hpp>
 #include <range/v3/view/transform.hpp>
 
-namespace Faunus::Move {
+namespace Faunus::move {
 
 Random MoveBase::slump; // static instance of Random (shared for all moves)
 
@@ -1131,7 +1131,7 @@ SmarterTranslateRotate::SmarterTranslateRotate(Space& spc, const json& j)
     , smartmc(spc, j.at("region")) {
     this->from_json(j);
 }
-} // namespace Faunus::Move
+} // namespace Faunus::move
 
 #ifdef DOCTEST_LIBRARY_INCLUDED
 TEST_CASE("[Faunus] TranslateRotate") {
@@ -1140,7 +1140,7 @@ TEST_CASE("[Faunus] TranslateRotate") {
     CHECK(!molecules.empty()); // set in a previous test
 
     Space spc;
-    Move::TranslateRotate mv(spc);
+    move::TranslateRotate mv(spc);
     json j = R"( {"molecule":"A", "dp":1.0, "dprot":0.5, "dir":[0,1,0], "repeat":2 })"_json;
     mv.from_json(j);
 
@@ -1153,8 +1153,7 @@ TEST_CASE("[Faunus] TranslateRotate") {
 }
 #endif
 
-namespace Faunus::Move {
-
+namespace Faunus::move {
 
 void ConformationSwap::_to_json(json& j) const {
     j = {{"molid", molid},
@@ -1319,4 +1318,4 @@ void ConformationSwap::checkConformationSize() const {
     }
 }
 
-} // namespace Faunus::Move
+} // namespace Faunus::move

--- a/src/move.h
+++ b/src/move.h
@@ -21,7 +21,7 @@ namespace Energy {
 class Hamiltonian;
 }
 
-namespace Move {
+namespace move {
 
 class MoveCollection;
 
@@ -538,5 +538,5 @@ class MoveCollection {
 
 void to_json(json& j, const MoveCollection& propagator);
 
-} // namespace Move
+} // namespace move
 } // namespace Faunus

--- a/src/multipole.h
+++ b/src/multipole.h
@@ -66,7 +66,7 @@ double q2quad(double qA, const Tmat &quadB, double qB, const Tmat &quadA, const 
     return (qA * WAB + qB * WBA);
 }
 
-namespace Potential {
+namespace pairpotential {
 
 /**
  * @brief Returns the factorial of 'n'. Note that 'n' must be positive semidefinite.
@@ -160,7 +160,7 @@ TEST_CASE("[Faunus] qPochhammerSymbol") {
     // add tests...
 }
 
-} // namespace Potential
+} // namespace pairpotential
 
 /**
  * @brief Returns the total charge for a set of particles

--- a/src/penalty.cpp
+++ b/src/penalty.cpp
@@ -162,7 +162,7 @@ void Penalty::logBarrierInformation() const {
  *  Called when a move is accepted or rejected, as well as when initializing the system
  *  @todo: this doubles the MPI communication
  */
-void Penalty::sync(Energybase* other, [[maybe_unused]] const Change& change) {
+void Penalty::sync(EnergyTerm* other, [[maybe_unused]] const Change& change) {
     auto* other_penalty = dynamic_cast<decltype(this)>(other);
     if (other_penalty == nullptr) {
         throw std::runtime_error("error in Penalty::sync - please report");

--- a/src/penalty.h
+++ b/src/penalty.h
@@ -14,7 +14,7 @@ namespace Faunus::Energy {
  * same in both the trial and old state energies it will not affect
  * MC move acceptance.
  */
-class Penalty : public Energybase {
+class Penalty : public EnergyTerm {
   private:
     const Space& spc;
     std::string penalty_function_filename;
@@ -49,7 +49,7 @@ class Penalty : public Energybase {
     Penalty(const json& j, const Space& spc);
     virtual ~Penalty(); //!< destruct and save to disk (!)
     double energy(const Change& change) override;
-    void sync(Energybase* other, const Change& change) override;
+    void sync(EnergyTerm* other, const Change& change) override;
     void streamPenaltyFunction(std::ostream &stream) const;
     void streamHistogram(std::ostream &stream) const;
 };

--- a/src/potentials.cpp
+++ b/src/potentials.cpp
@@ -188,8 +188,10 @@ void from_json(const json& j, std::vector<CustomInteractionData>& interactions) 
 
 // =============== PairPotentialBase ===============
 
-PairPotentialBase::PairPotentialBase(const std::string &name, const std::string &cite, bool isotropic)
-    : name(name), cite(cite), isotropic(isotropic) {}
+PairPotential::PairPotential(const std::string& name, const std::string& cite, bool isotropic)
+    : name(name)
+    , cite(cite)
+    , isotropic(isotropic) {}
 
 /**
  * @brief Calculates force on particle a due to another particle, b
@@ -199,17 +201,14 @@ PairPotentialBase::PairPotentialBase(const std::string &name, const std::string 
  * @param b_towards_a Distance vector 𝐛 -> 𝐚 = 𝐚 - 𝐛
  * @return Force on particle a due to particle b
  */
-Point PairPotentialBase::force([[maybe_unused]] const Particle& a, [[maybe_unused]] const Particle& b,
-                               [[maybe_unused]] double squared_distance,
-                               [[maybe_unused]] const Point& b_towards_a) const {
+Point PairPotential::force([[maybe_unused]] const Particle& a, [[maybe_unused]] const Particle& b,
+                           [[maybe_unused]] double squared_distance, [[maybe_unused]] const Point& b_towards_a) const {
     throw(std::logic_error("Force computation not implemented for this setup!"));
 }
 
-void to_json(json &j, const PairPotentialBase &base) {
-    base.name.empty() ? base.to_json(j) : base.to_json(j[base.name]);
-}
+void to_json(json& j, const PairPotential& base) { base.name.empty() ? base.to_json(j) : base.to_json(j[base.name]); }
 
-void from_json(const json &j, PairPotentialBase &base) {
+void from_json(const json& j, PairPotential& base) {
     try {
         if (not base.name.empty()) {
             if (j.count(base.name) == 1) {
@@ -265,7 +264,8 @@ void MixerPairPotentialBase::to_json(json &j) const {
 void MixerPairPotentialBase::extractorsFromJson(const json&) {}
 MixerPairPotentialBase::MixerPairPotentialBase(const std::string& name, const std::string& cite,
                                                CombinationRuleType combination_rule, bool isotropic)
-    : PairPotentialBase(name, cite, isotropic), combination_rule(combination_rule){}
+    : PairPotential(name, cite, isotropic)
+    , combination_rule(combination_rule) {}
 
 // =============== RepulsionR3 ===============
 
@@ -295,7 +295,7 @@ double CosAttract::cutOffSquared() const {
     return rcwc2;
 }
 CosAttract::CosAttract(const std::string& name)
-    : PairPotentialBase(name) {}
+    : PairPotential(name) {}
 
 TEST_CASE("[Faunus] CosAttract") {
     Particle a, b;
@@ -381,7 +381,8 @@ void Coulomb::from_json(const json &j) {
         throw ConfigurationError("Plain Coulomb potential expects 'epsr' key (only)");
     }
 }
-Coulomb::Coulomb(const std::string &name) : PairPotentialBase(name) {}
+Coulomb::Coulomb(const std::string& name)
+    : PairPotential(name) {}
 
 // =============== DipoleDipole (old) ===============
 
@@ -392,8 +393,7 @@ void DipoleDipole::to_json(json &j) const {
 
 void DipoleDipole::from_json(const json& j) { bjerrum_length = pc::bjerrumLength(j.at("epsr")); }
 DipoleDipole::DipoleDipole(const std::string& name, const std::string& cite)
-    :
-    PairPotentialBase(name, cite, false) {}
+    : PairPotential(name, cite, false) {}
 
 // =============== FENE ===============
 
@@ -405,7 +405,7 @@ void FENE::from_json(const json &j) {
 
 void FENE::to_json(json &j) const { j = {{"stiffness", k}, {"maxsep", std::sqrt(r02)}}; }
 FENE::FENE(const std::string& name)
-    : PairPotentialBase(name) {}
+    : PairPotential(name) {}
 
 // =============== SASApotential ===============
 
@@ -456,8 +456,7 @@ void SASApotential::to_json(json &j) const {
     j["shift"] = shift;
 }
 SASApotential::SASApotential(const std::string& name, const std::string& cite)
-    :
-    PairPotentialBase(name, cite) {}
+    : PairPotential(name, cite) {}
 
 TEST_CASE("[Faunus] SASApotential") {
     using doctest::Approx;
@@ -515,7 +514,8 @@ void CustomPairPotential::to_json(json& j) const {
     }
 }
 CustomPairPotential::CustomPairPotential(const std::string& name)
-    : PairPotentialBase(name), symbols(std::make_shared<Symbols>()) {}
+    : PairPotential(name)
+    , symbols(std::make_shared<Symbols>()) {}
 
 TEST_CASE("[Faunus] CustomPairPotential") {
     using doctest::Approx;
@@ -819,7 +819,7 @@ void Polarizability::to_json(json& j) const { j = {{"epsr", epsr}}; }
 
 // =============== FunctorPotential ===============
 
-void FunctorPotential::registerSelfEnergy(PairPotentialBase* pot) {
+void FunctorPotential::registerSelfEnergy(PairPotential* pot) {
     if (pot->selfEnergy) {
         if (not selfEnergy) { // no self energy is defined
             selfEnergy = pot->selfEnergy;
@@ -935,7 +935,8 @@ void FunctorPotential::from_json(const json &j) {
     }
 }
 
-FunctorPotential::FunctorPotential(const std::string &name) : PairPotentialBase(name) {}
+FunctorPotential::FunctorPotential(const std::string& name)
+    : PairPotential(name) {}
 
 TEST_CASE("[Faunus] FunctorPotential") {
     using doctest::Approx;
@@ -1181,7 +1182,10 @@ void NewCoulombGalore::setSelfEnergy() {
     }; // expose self-energy as a functor in potential base class
 }
 
-NewCoulombGalore::NewCoulombGalore(const std::string &name) : PairPotentialBase(name) { setSelfEnergy(); }
+NewCoulombGalore::NewCoulombGalore(const std::string& name)
+    : PairPotential(name) {
+    setSelfEnergy();
+}
 
 TEST_CASE("[Faunus] NewCoulombGalore") {
     Particle a, b;

--- a/src/potentials.h
+++ b/src/potentials.h
@@ -6,7 +6,7 @@
 #include "spherocylinder.h"
 #include <coulombgalore.h>
 
-namespace Faunus::Potential {
+namespace Faunus::pairpotential {
 
 /**
  * @brief Lennard-Jones potential with an arbitrary combination rule.

--- a/src/potentials.h
+++ b/src/potentials.h
@@ -169,7 +169,7 @@ class SquareWell : public MixerPairPotentialBase {
     }
 };
 
-class RepulsionR3 : public PairPotentialBase {
+class RepulsionR3 : public PairPotential {
   private:
     double f = 0, s = 0, e = 0;
     void from_json(const json& j) override;
@@ -177,7 +177,7 @@ class RepulsionR3 : public PairPotentialBase {
 
   public:
     explicit RepulsionR3(const std::string& name = "repulsionr3")
-        : PairPotentialBase(name){};
+        : PairPotential(name){};
 
     inline double operator()(const Particle&, const Particle&, double squared_distance, const Point&) const override {
         const auto r = sqrt(squared_distance);
@@ -204,7 +204,7 @@ class RepulsionR3 : public PairPotentialBase {
  * `wc`    | Decay range, w_c [angstrom]
  *
  */
-class CosAttract : public PairPotentialBase {
+class CosAttract : public PairPotential {
     double eps = 0.0;
     double wc = 0.0;
     double rc = 0.0;
@@ -316,7 +316,7 @@ class CosAttractMixed : public MixerPairPotentialBase {
 /**
  * @brief Pairwise SASA potential calculating the surface area of inter-secting spheres
  */
-class SASApotential : public PairPotentialBase {
+class SASApotential : public PairPotential {
   private:
     bool shift = true; // shift potential to zero at large separations?
     double proberadius = 0, conc = 0;
@@ -341,7 +341,7 @@ class SASApotential : public PairPotentialBase {
 /**
  * @brief Plain Coulomb potential
  */
-class Coulomb : public PairPotentialBase {
+class Coulomb : public PairPotential {
   private:
     void from_json(const json& j) override;
 
@@ -356,7 +356,7 @@ class Coulomb : public PairPotentialBase {
     void to_json(json& j) const override;
 };
 
-class DipoleDipole : public PairPotentialBase {
+class DipoleDipole : public PairPotential {
   private:
     void from_json(const json& j) override;
 
@@ -418,7 +418,7 @@ class Polarizability : public Coulomb {
  *
  * More info: doi:10.1103/PhysRevE.59.4248
  */
-class FENE : public PairPotentialBase {
+class FENE : public PairPotential {
     double k = 0;
     double r02 = 0;
     double r02inv = 0;
@@ -442,7 +442,7 @@ class FENE : public PairPotentialBase {
 /**
  * @brief Wrapper for external CoulombGalore library
  */
-class NewCoulombGalore : public PairPotentialBase {
+class NewCoulombGalore : public PairPotential {
   protected:
     ::CoulombGalore::Splined pot;
     virtual void setSelfEnergy();
@@ -504,7 +504,7 @@ class Multipole : public NewCoulombGalore {
  * @note `symbols` is a shared_ptr as this allows it to be modified by `operator() const`.
  *       A hack, but would otherwise require const-removal in all pair-potentials.
  */
-class CustomPairPotential : public PairPotentialBase {
+class CustomPairPotential : public PairPotential {
   private:
     // Only ExprFunction<double> is explicitly instantiated in functionparser.cpp. Other types as well as
     // the implicit template instantiation is disabled to save reasources during the compilation/build.
@@ -566,12 +566,12 @@ using CigarCosAttractWCA = CompleteCigarPotential<CosAttractMixed, WeeksChandler
  * @warning Each atom pair will be assigned an instance of a pair-potential. This *could* be
  *          problematic if these have large memory requirements.
  */
-class FunctorPotential : public PairPotentialBase {
+class FunctorPotential : public PairPotential {
     using EnergyFunctor = std::function<double(const Particle&, const Particle&, double, const Point&)>;
     json backed_up_json_input; // storage for input json
     bool have_monopole_self_energy = false;
     bool have_dipole_self_energy = false;
-    void registerSelfEnergy(PairPotentialBase*); //!< helper func to add to selv_energy_vector
+    void registerSelfEnergy(PairPotential*); //!< helper func to add to selv_energy_vector
     EnergyFunctor
     combinePairPotentials(json& potential_array); // parse json array of potentials to a single pair-energy functor
 

--- a/src/potentials_base.h
+++ b/src/potentials_base.h
@@ -6,7 +6,7 @@
 #include <functional>
 
 /** Namespace for particle pair-potentials */
-namespace Faunus::Potential {
+namespace Faunus::pairpotential {
 
 //! type of a matrix containing pair potential coefficients
 using TPairMatrix = Eigen::MatrixXd;
@@ -151,12 +151,12 @@ void from_json(const json& j, PairPotential& base); //!< Serialize any pair pote
  * Concept matching a particle pair potential derived from `Potential::PairPotentialBase`
  */
 template <class T>
-concept RequirePairPotential = std::derived_from<T, Potential::PairPotential>;
+concept RequirePairPotential = std::derived_from<T, pairpotential::PairPotential>;
 
 /** @brief Convenience function to generate a pair potential initialized from JSON object */
 template <RequirePairPotential T> auto makePairPotential(const json& j) {
     T pair_potential;
-    Potential::from_json(j, pair_potential);
+    pairpotential::from_json(j, pair_potential);
     return pair_potential;
 }
 
@@ -217,8 +217,8 @@ template <RequirePairPotential T1, RequirePairPotential T2> struct CombinedPairP
     } //!< Combine force
 
     void from_json(const json& j) override {
-        Faunus::Potential::from_json(j, first);
-        Faunus::Potential::from_json(j, second);
+        Faunus::pairpotential::from_json(j, first);
+        Faunus::pairpotential::from_json(j, second);
         name = first.name + "/" + second.name;
         if (first.selfEnergy or second.selfEnergy) { // combine self-energies
             selfEnergy = [u1 = first.selfEnergy, u2 = second.selfEnergy](const Particle& p) {

--- a/src/pyfaunus.cpp
+++ b/src/pyfaunus.cpp
@@ -177,17 +177,17 @@ PYBIND11_MODULE(pyfaunus, m) {
     // --------- Pair Potentials ---------
 
     // Base
-    py::class_<Potential::PairPotentialBase>(m, "PairPotentialBase")
-        .def_readwrite("name", &Potential::PairPotentialBase::name)
-        .def_readwrite("cite", &Potential::PairPotentialBase::cite)
-        .def_readwrite("isotropic", &Potential::PairPotentialBase::isotropic)
-        .def_readwrite("selfEnergy", &Potential::PairPotentialBase::selfEnergy)
-        .def("force", &Potential::PairPotentialBase::force)
-        .def("energy", [](Potential::PairPotentialBase& pot, const Particle& a, const Particle& b, double r2,
+    py::class_<Potential::PairPotential>(m, "PairPotentialBase")
+        .def_readwrite("name", &Potential::PairPotential::name)
+        .def_readwrite("cite", &Potential::PairPotential::cite)
+        .def_readwrite("isotropic", &Potential::PairPotential::isotropic)
+        .def_readwrite("selfEnergy", &Potential::PairPotential::selfEnergy)
+        .def("force", &Potential::PairPotential::force)
+        .def("energy", [](Potential::PairPotential& pot, const Particle& a, const Particle& b, double r2,
                           const Point& r) { return pot(a, b, r2, r); });
 
     // Potentials::FunctorPotential
-    py::class_<Potential::FunctorPotential, Potential::PairPotentialBase>(m, "FunctorPotential")
+    py::class_<Potential::FunctorPotential, Potential::PairPotential>(m, "FunctorPotential")
         .def(py::init([](py::dict dict) {
             auto pairpot = Potential::makePairPotential<Potential::FunctorPotential>(dict);
             return std::make_unique<Potential::FunctorPotential>(pairpot);

--- a/src/pyfaunus.cpp
+++ b/src/pyfaunus.cpp
@@ -177,20 +177,20 @@ PYBIND11_MODULE(pyfaunus, m) {
     // --------- Pair Potentials ---------
 
     // Base
-    py::class_<Potential::PairPotential>(m, "PairPotentialBase")
-        .def_readwrite("name", &Potential::PairPotential::name)
-        .def_readwrite("cite", &Potential::PairPotential::cite)
-        .def_readwrite("isotropic", &Potential::PairPotential::isotropic)
-        .def_readwrite("selfEnergy", &Potential::PairPotential::selfEnergy)
-        .def("force", &Potential::PairPotential::force)
-        .def("energy", [](Potential::PairPotential& pot, const Particle& a, const Particle& b, double r2,
+    py::class_<pairpotential::PairPotential>(m, "PairPotentialBase")
+        .def_readwrite("name", &pairpotential::PairPotential::name)
+        .def_readwrite("cite", &pairpotential::PairPotential::cite)
+        .def_readwrite("isotropic", &pairpotential::PairPotential::isotropic)
+        .def_readwrite("selfEnergy", &pairpotential::PairPotential::selfEnergy)
+        .def("force", &pairpotential::PairPotential::force)
+        .def("energy", [](pairpotential::PairPotential& pot, const Particle& a, const Particle& b, double r2,
                           const Point& r) { return pot(a, b, r2, r); });
 
     // Potentials::FunctorPotential
-    py::class_<Potential::FunctorPotential, Potential::PairPotential>(m, "FunctorPotential")
+    py::class_<pairpotential::FunctorPotential, pairpotential::PairPotential>(m, "FunctorPotential")
         .def(py::init([](py::dict dict) {
-            auto pairpot = Potential::makePairPotential<Potential::FunctorPotential>(dict);
-            return std::make_unique<Potential::FunctorPotential>(pairpot);
+            auto pairpot = pairpotential::makePairPotential<pairpotential::FunctorPotential>(dict);
+            return std::make_unique<pairpotential::FunctorPotential>(pairpot);
         }));
 
     // Change::Data

--- a/src/pyfaunus.cpp
+++ b/src/pyfaunus.cpp
@@ -241,18 +241,18 @@ PYBIND11_MODULE(pyfaunus, m) {
     }));
 
     // Analysisbase
-    py::class_<analysis::Analysisbase>(m, "Analysisbase")
-        .def_readonly("name", &analysis::Analysisbase::name)
-        .def_readwrite("cite", &analysis::Analysisbase::cite)
-        .def("to_disk", &analysis::Analysisbase::to_disk)
-        .def("sample", &analysis::Analysisbase::sample)
-        .def("to_dict", [](analysis::Analysisbase& self) {
+    py::class_<analysis::Analysis>(m, "Analysisbase")
+        .def_readonly("name", &analysis::Analysis::name)
+        .def_readwrite("cite", &analysis::Analysis::cite)
+        .def("to_disk", &analysis::Analysis::to_disk)
+        .def("sample", &analysis::Analysis::sample)
+        .def("to_dict", [](analysis::Analysis& self) {
             json j;
             analysis::to_json(j, self);
             return py::dict(j);
         });
 
-    py::bind_vector<std::vector<std::shared_ptr<analysis::Analysisbase>>>(m, "AnalysisVector");
+    py::bind_vector<std::vector<std::shared_ptr<analysis::Analysis>>>(m, "AnalysisVector");
 
     // CombinedAnalysis
     py::class_<analysis::CombinedAnalysis>(m, "Analysis")

--- a/src/pyfaunus.cpp
+++ b/src/pyfaunus.cpp
@@ -241,30 +241,30 @@ PYBIND11_MODULE(pyfaunus, m) {
     }));
 
     // Analysisbase
-    py::class_<Analysis::Analysisbase>(m, "Analysisbase")
-        .def_readonly("name", &Analysis::Analysisbase::name)
-        .def_readwrite("cite", &Analysis::Analysisbase::cite)
-        .def("to_disk", &Analysis::Analysisbase::to_disk)
-        .def("sample", &Analysis::Analysisbase::sample)
-        .def("to_dict", [](Analysis::Analysisbase& self) {
+    py::class_<analysis::Analysisbase>(m, "Analysisbase")
+        .def_readonly("name", &analysis::Analysisbase::name)
+        .def_readwrite("cite", &analysis::Analysisbase::cite)
+        .def("to_disk", &analysis::Analysisbase::to_disk)
+        .def("sample", &analysis::Analysisbase::sample)
+        .def("to_dict", [](analysis::Analysisbase& self) {
             json j;
-            Analysis::to_json(j, self);
+            analysis::to_json(j, self);
             return py::dict(j);
         });
 
-    py::bind_vector<std::vector<std::shared_ptr<Analysis::Analysisbase>>>(m, "AnalysisVector");
+    py::bind_vector<std::vector<std::shared_ptr<analysis::Analysisbase>>>(m, "AnalysisVector");
 
     // CombinedAnalysis
-    py::class_<Analysis::CombinedAnalysis>(m, "Analysis")
+    py::class_<analysis::CombinedAnalysis>(m, "Analysis")
         .def(py::init([](Space& spc, Thamiltonian& pot, py::list list) {
-            return std::make_unique<Analysis::CombinedAnalysis>(list, spc, pot);
+            return std::make_unique<analysis::CombinedAnalysis>(list, spc, pot);
         }))
-        .def_readwrite("vector", &Analysis::CombinedAnalysis::vec)
+        .def_readwrite("vector", &analysis::CombinedAnalysis::vec)
         .def("to_dict",
-             [](Analysis::CombinedAnalysis& self) {
+             [](analysis::CombinedAnalysis& self) {
                  json j;
                  Faunus::to_json(j, self);
                  return py::dict(j);
              })
-        .def("sample", &Analysis::CombinedAnalysis::sample);
+        .def("sample", &analysis::CombinedAnalysis::sample);
 }

--- a/src/speciation.cpp
+++ b/src/speciation.cpp
@@ -255,7 +255,7 @@ MolecularGroupDeActivator::MolecularGroupDeActivator(Space& spc, Random& random,
 double MolecularGroupDeActivator::getBondEnergy(const Group& group) const {
     double energy = 0.0;
     if (apply_bond_bias) {
-        auto bonds = group.traits().bonds | ranges::views::transform(&Potential::BondData::clone);
+        auto bonds = group.traits().bonds | ranges::views::transform(&pairpotential::BondData::clone);
         ranges::cpp20::for_each(bonds, [&](auto bond) {
             bond->shiftIndices(spc.getFirstParticleIndex(group));
             bond->setEnergyFunction(spc.particles);

--- a/src/speciation.cpp
+++ b/src/speciation.cpp
@@ -586,7 +586,7 @@ void SpeciationMove::_reject([[maybe_unused]] Change& change) {
 }
 
 SpeciationMove::SpeciationMove(Space& spc, Space& old_spc, std::string_view name, std::string_view cite)
-    : MoveBase(spc, name, cite)
+    : Move(spc, name, cite)
     , random_internal(slump)
     , reaction_validator(spc) {
     molecular_group_bouncer = std::make_unique<Speciation::MolecularGroupDeActivator>(spc, random_internal, true);

--- a/src/speciation.cpp
+++ b/src/speciation.cpp
@@ -336,7 +336,7 @@ GroupDeActivator::ChangeAndBias AtomicGroupDeActivator::deactivate(Group& group,
 
 // ----------------------------------
 
-namespace Faunus::Move {
+namespace Faunus::move {
 
 void SpeciationMove::_to_json(json& j) const {
     direction_ratio.to_json(j);
@@ -598,4 +598,4 @@ SpeciationMove::SpeciationMove(Space& spc, Space& old_spc)
 
 void SpeciationMove::_from_json([[maybe_unused]] const json& j) {}
 
-} // namespace Faunus::Move
+} // namespace Faunus::move

--- a/src/speciation.h
+++ b/src/speciation.h
@@ -96,7 +96,7 @@ class ReactionDirectionRatio {
 
 } // end of namespace Faunus::Speciation
 
-namespace Faunus::Move {
+namespace Faunus::move {
 
 /**
  * @brief Generalised Grand Canonical Monte Carlo Move
@@ -155,4 +155,4 @@ class SpeciationMove : public MoveBase {
     double bias(Change& change, double old_energy, double new_energy) override;
 };
 
-} // namespace Faunus::Move
+} // namespace Faunus::move

--- a/src/speciation.h
+++ b/src/speciation.h
@@ -118,7 +118,7 @@ namespace Faunus::move {
  *
  * @todo Split atom-swap functionality to separate helper class
  */
-class SpeciationMove : public MoveBase {
+class SpeciationMove : public Move {
   private:
     using reaction_iterator = decltype(Faunus::reactions)::iterator;
     Random random_internal; //!< Private generator so as not to touch MoveBase::slump

--- a/src/spherocylinder.cpp
+++ b/src/spherocylinder.cpp
@@ -555,7 +555,7 @@ int cpsc_intersect(const Cigar& cigar1, const Cigar& cigar2, const Point& r_cm, 
 namespace Faunus::Potential {
 
 HardSpheroCylinder::HardSpheroCylinder()
-    : PairPotentialBase("hardspherocylinder", "", false) {}
+    : PairPotential("hardspherocylinder", "", false) {}
 
 void HardSpheroCylinder::to_json([[maybe_unused]] json& j) const {}
 
@@ -678,7 +678,7 @@ void CigarWithCigar<PatchPotential, CylinderPotential>::from_json(const json& j)
 
 template <RequirePairPotential PatchPotential, RequirePairPotential CylinderPotential>
 CigarWithCigar<PatchPotential, CylinderPotential>::CigarWithCigar()
-    : PairPotentialBase("cigar-cigar", ""s, false) {}
+    : PairPotential("cigar-cigar", ""s, false) {}
 
 template class CigarWithCigar<CosAttractMixed, WeeksChandlerAndersen>; // explicit initialization
 
@@ -736,7 +736,7 @@ void CompleteCigarPotential<PatchPotential, CylinderPotential, SphereWithSphere>
 template <RequirePairPotential PatchPotential, RequirePairPotential CylinderPotential,
           RequirePairPotential SphereWithSphere>
 CompleteCigarPotential<PatchPotential, CylinderPotential, SphereWithSphere>::CompleteCigarPotential()
-    : PairPotentialBase("complete cigar", ""s, false) {}
+    : PairPotential("complete cigar", ""s, false) {}
 
 template class CompleteCigarPotential<CosAttractMixed, WeeksChandlerAndersen>; // explicit initialization
 
@@ -744,7 +744,7 @@ template class CompleteCigarPotential<CosAttractMixed, WeeksChandlerAndersen>; /
 
 template <RequirePairPotential PatchPotential, RequirePairPotential CylinderPotential>
 CigarWithSphere<PatchPotential, CylinderPotential>::CigarWithSphere()
-    : PairPotentialBase("cigar-sphere", ""s, false) {}
+    : PairPotential("cigar-sphere", ""s, false) {}
 
 template <RequirePairPotential PatchPotential, RequirePairPotential CylinderPotential>
 void CigarWithSphere<PatchPotential, CylinderPotential>::to_json(json& j) const {

--- a/src/spherocylinder.cpp
+++ b/src/spherocylinder.cpp
@@ -552,7 +552,7 @@ int cpsc_intersect(const Cigar& cigar1, const Cigar& cigar2, const Point& r_cm, 
 }
 } // namespace Faunus::SpheroCylinder
 
-namespace Faunus::Potential {
+namespace Faunus::pairpotential {
 
 HardSpheroCylinder::HardSpheroCylinder()
     : PairPotential("hardspherocylinder", "", false) {}
@@ -567,7 +567,7 @@ void HardSpheroCylinder::from_json([[maybe_unused]] const json& j) {}
  * @param center_separation
  * @return
  */
-template <Potential::RequirePairPotential PatchPotential, Potential::RequirePairPotential CylinderPotential>
+template <pairpotential::RequirePairPotential PatchPotential, pairpotential::RequirePairPotential CylinderPotential>
 double CigarWithCigar<PatchPotential, CylinderPotential>::patchyPatchyEnergy(
     const Particle& particle1, const Particle& particle2,
     const Point& center_separation) const { // patchy sc with patchy sc
@@ -652,7 +652,7 @@ double CigarWithCigar<PatchPotential, CylinderPotential>::patchyPatchyEnergy(
            cylinder_potential(particle1, particle2, rclose_squared, Point::Zero());
 }
 
-template <Potential::RequirePairPotential PatchPotential, Potential::RequirePairPotential CylinderPotential>
+template <pairpotential::RequirePairPotential PatchPotential, pairpotential::RequirePairPotential CylinderPotential>
 double CigarWithCigar<PatchPotential, CylinderPotential>::isotropicIsotropicEnergy(
     const Particle& particle1, const Particle& particle2,
     const Point& center_separation) const { // isotropic sc with isotropic sc
@@ -672,8 +672,8 @@ void CigarWithCigar<PatchPotential, CylinderPotential>::to_json(json& j) const {
 
 template <RequirePairPotential PatchPotential, RequirePairPotential CylinderPotential>
 void CigarWithCigar<PatchPotential, CylinderPotential>::from_json(const json& j) {
-    Potential::from_json(j, patch_potential);
-    Potential::from_json(j, cylinder_potential);
+    pairpotential::from_json(j, patch_potential);
+    pairpotential::from_json(j, cylinder_potential);
 }
 
 template <RequirePairPotential PatchPotential, RequirePairPotential CylinderPotential>
@@ -728,9 +728,9 @@ void CompleteCigarPotential<PatchPotential, CylinderPotential, SphereWithSphere>
 template <RequirePairPotential PatchPotential, RequirePairPotential CylinderPotential,
           RequirePairPotential SphereWithSphere>
 void CompleteCigarPotential<PatchPotential, CylinderPotential, SphereWithSphere>::from_json(const json& j) {
-    Potential::from_json(j, sphere_sphere);
-    Potential::from_json(j, cigar_cigar);
-    Potential::from_json(j, cigar_sphere);
+    pairpotential::from_json(j, sphere_sphere);
+    pairpotential::from_json(j, cigar_cigar);
+    pairpotential::from_json(j, cigar_sphere);
 }
 
 template <RequirePairPotential PatchPotential, RequirePairPotential CylinderPotential,
@@ -754,8 +754,8 @@ void CigarWithSphere<PatchPotential, CylinderPotential>::to_json(json& j) const 
 
 template <RequirePairPotential PatchPotential, RequirePairPotential CylinderPotential>
 void CigarWithSphere<PatchPotential, CylinderPotential>::from_json(const json& j) {
-    Potential::from_json(j, patch_potential);
-    Potential::from_json(j, cylinder_potential);
+    pairpotential::from_json(j, patch_potential);
+    pairpotential::from_json(j, cylinder_potential);
 }
 
 template class CigarWithSphere<CosAttractMixed, WeeksChandlerAndersen>; // explicit initialization

--- a/src/spherocylinder.h
+++ b/src/spherocylinder.h
@@ -108,7 +108,7 @@ inline double fanglscale(const double a, const Cigar& cigar) {
 namespace Faunus::Potential {
 
 /** @brief Hard-sphere pair potential for spherocylinders */
-class HardSpheroCylinder : public PairPotentialBase {
+class HardSpheroCylinder : public PairPotential {
   public:
     double operator()(const Particle& particle1, const Particle& particle2, [[maybe_unused]] double d,
                       const Point& center_to_center_distance) const override {
@@ -135,7 +135,7 @@ class HardSpheroCylinder : public PairPotentialBase {
  * @tparam CylinderPotential Pair potential between sphere and closest cylinder part (isotropic)
  */
 template <Potential::RequirePairPotential PatchPotential, Potential::RequirePairPotential CylinderPotential>
-class CigarWithSphere : public PairPotentialBase {
+class CigarWithSphere : public PairPotential {
   private:
     PatchPotential patch_potential;       //!< Isotropic pair-potential between patches
     CylinderPotential cylinder_potential; //!< Isotropic pair-potential between non-patchy parts
@@ -204,7 +204,7 @@ class CigarWithSphere : public PairPotentialBase {
  * @todo Energy calculation badly needs refactoring!
  */
 template <Potential::RequirePairPotential PatchPotential, Potential::RequirePairPotential CylinderPotential>
-class CigarWithCigar : public PairPotentialBase {
+class CigarWithCigar : public PairPotential {
   private:
     PatchPotential patch_potential;       //!< Isotropic pair-potential for patchy parts
     CylinderPotential cylinder_potential; //!< Isotropic pair-potential for cylindrical parts
@@ -245,7 +245,7 @@ class CigarWithCigar : public PairPotentialBase {
  */
 template <Potential::RequirePairPotential PatchPotential, Potential::RequirePairPotential CylinderPotential,
           Potential::RequirePairPotential SphereWithSphere = CylinderPotential>
-class CompleteCigarPotential : public PairPotentialBase {
+class CompleteCigarPotential : public PairPotential {
   private:
     SphereWithSphere sphere_sphere;                                  // pair potential between spheres
     CigarWithCigar<PatchPotential, CylinderPotential> cigar_cigar;   // pair potential between cigars

--- a/src/spherocylinder.h
+++ b/src/spherocylinder.h
@@ -105,7 +105,7 @@ inline double fanglscale(const double a, const Cigar& cigar) {
 
 // --------------------
 
-namespace Faunus::Potential {
+namespace Faunus::pairpotential {
 
 /** @brief Hard-sphere pair potential for spherocylinders */
 class HardSpheroCylinder : public PairPotential {
@@ -134,7 +134,7 @@ class HardSpheroCylinder : public PairPotential {
  * @tparam PatchPotential Pair potential between sphere and point on patch (isotropic)
  * @tparam CylinderPotential Pair potential between sphere and closest cylinder part (isotropic)
  */
-template <Potential::RequirePairPotential PatchPotential, Potential::RequirePairPotential CylinderPotential>
+template <pairpotential::RequirePairPotential PatchPotential, pairpotential::RequirePairPotential CylinderPotential>
 class CigarWithSphere : public PairPotential {
   private:
     PatchPotential patch_potential;       //!< Isotropic pair-potential between patches
@@ -203,7 +203,7 @@ class CigarWithSphere : public PairPotential {
  * @tparam CylinderPotential Pair potential between closest cylinder parts (isotropic, e.g. WCA)
  * @todo Energy calculation badly needs refactoring!
  */
-template <Potential::RequirePairPotential PatchPotential, Potential::RequirePairPotential CylinderPotential>
+template <pairpotential::RequirePairPotential PatchPotential, pairpotential::RequirePairPotential CylinderPotential>
 class CigarWithCigar : public PairPotential {
   private:
     PatchPotential patch_potential;       //!< Isotropic pair-potential for patchy parts
@@ -243,8 +243,8 @@ class CigarWithCigar : public PairPotential {
  * @tparam CylinderPotential Pair potential used for cylindrical path (isotropic, e.g. WCA)
  * @tparam CylinderPotential Pair potential used sphere-sphere interaction (isotropic, e.g. WCA)
  */
-template <Potential::RequirePairPotential PatchPotential, Potential::RequirePairPotential CylinderPotential,
-          Potential::RequirePairPotential SphereWithSphere = CylinderPotential>
+template <pairpotential::RequirePairPotential PatchPotential, pairpotential::RequirePairPotential CylinderPotential,
+          pairpotential::RequirePairPotential SphereWithSphere = CylinderPotential>
 class CompleteCigarPotential : public PairPotential {
   private:
     SphereWithSphere sphere_sphere;                                  // pair potential between spheres


### PR DESCRIPTION
Use lower case for namespaces and remove "base" from abstract classes