### PR TITLE
added Random slump parameter for tempering

### DIFF
--- a/src/move.cpp
+++ b/src/move.cpp
@@ -725,11 +725,11 @@ void ParallelTempering::exchangeState(Change& change) {
 
 void ParallelTempering::_move(Change& change) {
     mpi.world.barrier(); // wait until all ranks reach here
-    if (!MPI::checkRandomEngineState(mpi.world, Move::slump)) {
+    if (!MPI::checkRandomEngineState(mpi.world, slump)) {
         faunus_logger->error("Random numbers out of sync across MPI nodes. Do not use 'hardware' seed.");
         mpi.world.abort(1); // neighbor search *requires* that random engines are in sync
     }
-    partner->generate(mpi.world, Move::slump);
+    partner->generate(mpi.world, slump);
     if (partner->rank.has_value()) {
         exchangeState(change);
     }

--- a/src/move.h
+++ b/src/move.h
@@ -532,7 +532,7 @@ class ParallelTempering : public Move {
     std::unique_ptr<MPI::Partner> partner;     //!< Policy for finding MPI partners
     Geometry::VolumeMethod volume_scaling_method = Geometry::VolumeMethod::ISOTROPIC; //!< How to scale volumes
     std::map<MPI::Partner::PartnerPair, Average<double>> acceptance_map;              //!< Exchange statistics
-
+    Random slump; // static instance of Random (shared for all in ParallelTempering)
     void _to_json(json& j) const override;
     void _from_json(const json& j) override;
     void _move(Change& change) override;


### PR DESCRIPTION
added Random slump parameter for tempering so the mpi threads do not get out of sync

# Description

Please edit this text to include a summary of the change and which issue is fixed.

## Checklist

- [x] `make test` passes with no errors
- [x] the source code is well documented
- [x] new functionality includes unittests
- [x] the user-manual has been updated to reflect the changes
- [ ] I have installed the provided commit hook to auto-format commits (requires `clang-format`):

  ``` bash
  ./scripts/git-pre-commit-format install
  ```

- [x] code naming scheme follows the convention:

  Style        | Elements
  ------------ | ---------------------
  `PascalCase` | classes, namespaces
  `camelCase`  | functions
  `snake_case` | variables
