### PR TITLE
Voronoi analysis using Voronota-LT

### DIFF
--- a/cmake/ExternalTools.cmake
+++ b/cmake/ExternalTools.cmake
@@ -5,13 +5,13 @@ include(FetchContent)
 # CPM Packages
 ###############
 
-CPMAddPackage("gh:gabime/spdlog@1.12.0")
+CPMAddPackage("gh:gabime/spdlog@1.13.0")
 CPMAddPackage("gh:ericniebler/range-v3#0.12.0")
 CPMAddPackage("gh:docopt/docopt.cpp#v0.6.3")
 CPMAddPackage("gh:doctest/doctest#v2.4.11")
 CPMAddPackage("gh:mateidavid/zstr#v1.0.7")
 CPMAddPackage("gh:martinus/nanobench#v4.3.11")
-CPMAddPackage("gh:pybind/pybind11#v2.11.1")
+CPMAddPackage("gh:pybind/pybind11#v2.12.0")
 CPMAddPackage("gh:imneme/pcg-cpp#ffd522e7188bef30a00c74dc7eb9de5faff90092")
 CPMAddPackage("gh:ArashPartow/exprtk#93a9f44f99b910bfe07cd1e933371e83cea3841c")
 
@@ -21,7 +21,7 @@ CPMAddPackage(
 )
 
 CPMAddPackage(
-    NAME nlohmann_json VERSION 3.11.2
+    NAME nlohmann_json VERSION 3.11.3
     URL https://github.com/nlohmann/json/releases/download/v3.11.2/include.zip
     OPTIONS "JSON_BuildTests OFF"
 )

--- a/docs/_docs/analysis.md
+++ b/docs/_docs/analysis.md
@@ -364,6 +364,22 @@ is filed to disk, `sasa_histogram.dat`.
 `file`         | Optionally stream area for each `nstep` to file (`.dat|.dat.gz`)
 `radius=1.4`   | Probe radius (Å)
 
+### Voronoi Tessellation (experimental)
+
+Performs Voronoi tessellation to detect contacts and surface areas using
+the [Voronota-LT library](https://doi.org/10/gpfkwh).
+Only the total surface is currently reported, but more is planned for future
+releases.
+The algorithm is significantly faster than the above `sasa` analysis.
+
+`voronoi`      | Description
+-------------- | ---------------------------
+`nstep`        | Interval between samples
+`nskip=0`      | Number of initial steps excluded from the analysis
+`file`         | Optionally stream surface area for each `nstep` to file (`.dat|.dat.gz`)
+`radius=1.4`   | Probe radius (Å)
+
+
 ## Charge Properties
 
 ### Molecular Multipoles

--- a/docs/schema.yml
+++ b/docs/schema.yml
@@ -1263,6 +1263,23 @@ properties:
                         nskip: {type: integer, default: 0, description: Number of steps to initially skip}
                     required: [dL, molecule, nstep]
                     additionalProperties: false
+
+                voronoi:
+                    description: "Voronoi tessellation using Voronota"
+                    type: object
+                    properties:
+                        nstep: {type: integer, description: "Interval between samples"}
+                        nskip: {type: integer, default: 0, description: "Initial steps to skip"}
+                        radius:
+                            type: number
+                            default: 1.4
+                            description: "Probe radius (Å)"
+                        file:
+                            type: string
+                            pattern: "(.*?)\\.(dat|dat.gz)$"
+                            description: "Streaming filename (.dat|.dat.gz)"
+                    required: [nstep]
+                    additionalProperties: false
  
                 widom:
                     description: "Widom ghost particle insertion"

--- a/examples/sasa/sasa.out.json
+++ b/examples/sasa/sasa.out.json
@@ -6,11 +6,20 @@
         "nstep": 1,
         "radius": 2.0,
         "reference": "doi:10/dbjh",
-        "relative time": 0.592,
         "samples": 1,
         "slices_per_atom": 20,
         "⟨SASA²⟩-⟨SASA⟩²": 0.0,
         "⟨SASA⟩": 2177.145143881812
+      }
+    },
+    {
+      "voronota": {
+        "nstep": 1,
+        "radius": 2.0,
+        "reference": "doi:10.1093/bioinformatics/btab448",
+        "samples": 1,
+        "⟨SASA²⟩-⟨SASA⟩²": 0.0,
+        "⟨SASA⟩": 2186.5484868984963
       }
     }
   ],

--- a/examples/sasa/sasa.yml
+++ b/examples/sasa/sasa.yml
@@ -26,4 +26,8 @@ analysis:
         molecule: mymolecule
         radius: 2.0
         nstep: 1
+    - voronoi:
+        file: voronoi_sasa.dat
+        radius: 2.0
+        nstep: 1
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -60,7 +60,7 @@ set(objs actions.cpp analysis.cpp average.cpp atomdata.cpp auxiliary.cpp bonds.c
 	chainmove.cpp clustermove.cpp core.cpp forcemove.cpp units.cpp energy.cpp externalpotential.cpp
 	geometry.cpp group.cpp io.cpp molecule.cpp montecarlo.cpp move.cpp mpicontroller.cpp
 	particle.cpp penalty.cpp potentials.cpp random.cpp reactioncoordinate.cpp regions.cpp rotate.cpp sasa.cpp
-        scatter.cpp smart_montecarlo.cpp space.cpp speciation.cpp spherocylinder.cpp tensor.cpp)
+        scatter.cpp smart_montecarlo.cpp space.cpp speciation.cpp spherocylinder.cpp tensor.cpp voronota.cpp)
 
 set(hdrs actions.h analysis.h average.h atomdata.h auxiliary.h bonds.h celllist.h celllistimpl.h
 	chainmove.h clustermove.h core.h forcemove.h energy.h externalpotential.h geometry.h group.h io.h

--- a/src/analysis.cpp
+++ b/src/analysis.cpp
@@ -26,6 +26,8 @@
 #include <range/v3/numeric/accumulate.hpp>
 #include <range/v3/view/zip.hpp>
 
+#include "voronotalt/voronotalt.h" // assuming that the "voronotalt" directory is in the include path
+
 #include <iomanip>
 #include <iostream>
 #include <memory>
@@ -2710,6 +2712,10 @@ void SavePenaltyEnergy::_sample() {
             penalty_energy->streamHistogram(*stream);
         }
     }
+}
+
+void Voronota::_sample() {
+    voronotalt::RadicalTessellation::Result result;
 }
 
 } // namespace Faunus::analysis

--- a/src/analysis.cpp
+++ b/src/analysis.cpp
@@ -25,9 +25,6 @@
 #include <cereal/archives/binary.hpp>
 #include <range/v3/numeric/accumulate.hpp>
 #include <range/v3/view/zip.hpp>
-
-#include "voronotalt/voronotalt.h" // assuming that the "voronotalt" directory is in the include path
-
 #include <iomanip>
 #include <iostream>
 #include <memory>
@@ -196,6 +193,8 @@ std::unique_ptr<Analysis> createAnalysis(const std::string& name, const json& j,
             return std::make_unique<VirtualVolumeMove>(j, spc, pot);
         } else if (name == "virtualtranslate") {
             return std::make_unique<VirtualTranslate>(j, spc, pot);
+        } else if (name == "voronoi") {
+            return std::make_unique<Voronota>(j, spc);
         } else if (name == "widom") {
             return std::make_unique<WidomInsertion>(j, spc, pot);
         } else if (name == "xtcfile") {
@@ -1881,6 +1880,7 @@ SASAAnalysis::SASAAnalysis(const double probe_radius, const int slices_per_atom,
         break;
     }
     setPolicy(selected_policy);
+    cite = "doi:10/dbjh";
 }
 
 SASAAnalysis::SASAAnalysis(const json& j, const Space& spc)
@@ -1888,7 +1888,6 @@ SASAAnalysis::SASAAnalysis(const json& j, const Space& spc)
                    j.value("policy", Policies::INVALID), spc) {
     from_json(j);
     policy->from_json(j);
-    cite = "doi:10/dbjh";
 }
 
 void SASAAnalysis::_to_json(json& json_ouput) const {
@@ -2712,10 +2711,6 @@ void SavePenaltyEnergy::_sample() {
             penalty_energy->streamHistogram(*stream);
         }
     }
-}
-
-void Voronota::_sample() {
-    voronotalt::RadicalTessellation::Result result;
 }
 
 } // namespace Faunus::analysis

--- a/src/analysis.h
+++ b/src/analysis.h
@@ -1086,32 +1086,27 @@ class SavePenaltyEnergy : public Analysis {
     SavePenaltyEnergy(const json& j, const Space& spc, const Energy::Hamiltonian& pot);
 };
 
+/**
+ * @brief Analysis of Vorononoi tessellation using the Voronota-LT library
+ *
+ * https://doi.org/10.1093/bioinformatics/btab448
+ */
 class Voronota : public Analysis {
   private:
-    using average_type = Average<double>;
-    struct Ball {
-        double x;
-        double y;
-        double z;
-        double r;
-    };
     struct Averages {
-        average_type area;
-        average_type area_squared;
-    };                     //!< Placeholder class for average properties
+        Average<double> area;
+        Average<double> area_squared;
+    }; //!< Placeholder class for average properties
     Averages average_data; //!< Stores all averages for the selected molecule
 
     std::unique_ptr<std::ostream> output_stream; //!< output stream
+    double probe_radius;                         //!< radius of the probe sphere
+    std::string filename;                        //!< output file name
 
-    double probe_radius; //!< radius of the probe sphere
-    int slices_per_atom; //!< number of slices of each sphere in SASA calculation
-
-    std::string filename;                         //!< output file name
-
-    virtual void _to_json(json& j) const override;
-    virtual void _from_json(const json& input) override;
-    virtual void _to_disk() override;
-    virtual void _sample() override;
+    void _to_json(json& j) const override;
+    void _from_json(const json& input) override;
+    void _to_disk() override;
+    void _sample() override;
 
   public:
     Voronota(const json& j, const Space& spc);

--- a/src/analysis.h
+++ b/src/analysis.h
@@ -262,7 +262,7 @@ class ElectricPotential : public Analysis {
     unsigned int calculations_per_sample_event = 1;
     std::string file_prefix; //!< Output filename prefix for potential histogram and correlation
     struct Target {
-        Point position;                                               //!< Target position
+        Point position;                                                //!< Target position
         Average<double> mean_potential;                               //!< mean potential at position
         std::unique_ptr<SparseHistogram<double>> potential_histogram; //!< Histogram of observed potentials
     };
@@ -1084,6 +1084,38 @@ class SavePenaltyEnergy : public Analysis {
 
   public:
     SavePenaltyEnergy(const json& j, const Space& spc, const Energy::Hamiltonian& pot);
+};
+
+class Voronota : public Analysis {
+  private:
+    using average_type = Average<double>;
+    struct Ball {
+        double x;
+        double y;
+        double z;
+        double r;
+    };
+    struct Averages {
+        average_type area;
+        average_type area_squared;
+    };                     //!< Placeholder class for average properties
+    Averages average_data; //!< Stores all averages for the selected molecule
+
+    std::unique_ptr<std::ostream> output_stream; //!< output stream
+
+    double probe_radius; //!< radius of the probe sphere
+    int slices_per_atom; //!< number of slices of each sphere in SASA calculation
+
+    std::string filename;                         //!< output file name
+
+    virtual void _to_json(json& j) const override;
+    virtual void _from_json(const json& input) override;
+    virtual void _to_disk() override;
+    virtual void _sample() override;
+
+  public:
+    Voronota(const json& j, const Space& spc);
+    Voronota(double probe_radius, const Space& spc);
 };
 
 } // namespace analysis

--- a/src/analysis.h
+++ b/src/analysis.h
@@ -9,7 +9,7 @@
 #include "aux/timers.h"
 #include "aux/table_2d.h"
 #include "aux/equidistant_table.h"
-#include <aux/sparsehistogram.h>
+#include "aux/sparsehistogram.h"
 #include <Eigen/SparseCore>
 #include <limits>
 #include <memory>

--- a/src/aux/eigen_cerealisation.h
+++ b/src/aux/eigen_cerealisation.h
@@ -22,10 +22,8 @@
 #ifndef EIGENCEREALISATION_HPP_
 #define EIGENCEREALISATION_HPP_
 
-#include "cereal/cereal.hpp"
-
-#include "Eigen/Core"
-
+#include <cereal/cereal.hpp>
+#include <Eigen/Core>
 #include <cstdint>
 
 /**

--- a/src/aux/eigensupport.h
+++ b/src/aux/eigensupport.h
@@ -2,7 +2,6 @@
 
 #include <Eigen/Core>
 #include <nlohmann/json.hpp>
-
 #include "aux/eigen_cerealisation.h"
 
 // Eigen<->JSON (de)serialization

--- a/src/celllistimpl.h
+++ b/src/celllistimpl.h
@@ -19,7 +19,7 @@
 #include <range/v3/view/transform.hpp>
 #include "celllist.h"
 #include "core.h"
-#include "spdlog/spdlog.h"
+#include <spdlog/spdlog.h>
 
 namespace Faunus {
 

--- a/src/externalpotential.cpp
+++ b/src/externalpotential.cpp
@@ -4,7 +4,7 @@
 #include "aux/eigensupport.h"
 #include "functionparser.h"
 #include "space.h"
-#include "spdlog/spdlog.h"
+#include <spdlog/spdlog.h>
 
 namespace Faunus::Energy {
 

--- a/src/faunus.cpp
+++ b/src/faunus.cpp
@@ -1,14 +1,14 @@
 #define DOCTEST_CONFIG_IMPLEMENT
-#include <doctest/doctest.h>
 #include "mpicontroller.h"
 #include "montecarlo.h"
 #include "analysis.h"
 #include "multipole.h"
 #include "docopt.h"
-#include "progress_tracker.h"
-#include "spdlog/spdlog.h"
 #include "move.h"
 #include "actions.h"
+#include <doctest/doctest.h>
+#include <progress_tracker.h>
+#include <spdlog/spdlog.h>
 #include <spdlog/sinks/null_sink.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
 #include <spdlog/sinks/basic_file_sink.h>

--- a/src/io.h
+++ b/src/io.h
@@ -1,13 +1,13 @@
 #pragma once
 
 #include "particle.h"
-#include "spdlog/spdlog.h"
 #include "units.h"
 #include "group.h"
 #include <fstream>
 #include <type_traits>
 #include <concepts>
 #include <iterator>
+#include <spdlog/spdlog.h>
 #include <range/v3/iterator/operations.hpp>
 #include <range/v3/algorithm/for_each.hpp>
 #include <numeric>

--- a/src/molecule.cpp
+++ b/src/molecule.cpp
@@ -3,9 +3,9 @@
 #include "geometry.h"
 #include "rotate.h"
 #include "bonds.h"
-#include "spdlog/spdlog.h"
 #include "aux/eigensupport.h"
 #include <functional>
+#include <spdlog/spdlog.h>
 #include <range/v3/view/transform.hpp>
 #include <range/v3/view/join.hpp>
 #include <range/v3/view/filter.hpp>
@@ -223,7 +223,7 @@ void NeighboursGenerator::generatePaths(int bonded_distance) {
     // continue wherever the last path generation ended
     for (int distance = (int)paths.size(); distance <= bonded_distance; ++distance) {
         paths.emplace_back();
-        const auto& base_paths = paths.rbegin()[1]; // last but one: a set of paths of length (distance - 1)
+        const auto base_paths = paths.rbegin()[1]; // last but one: a set of paths of length (distance - 1)
         for (const auto& base_path : base_paths) {
             // try to extend the path with every atom bonded to the tail
             for (const auto& appending : bond_map.at(base_path.back())) {

--- a/src/montecarlo.cpp
+++ b/src/montecarlo.cpp
@@ -2,7 +2,7 @@
 #include "speciation.h"
 #include "energy.h"
 #include "move.h"
-#include "spdlog/spdlog.h"
+#include <spdlog/spdlog.h>
 #include <range/v3/algorithm/for_each.hpp>
 
 namespace Faunus {

--- a/src/move.cpp
+++ b/src/move.cpp
@@ -1,4 +1,3 @@
-#include <doctest/doctest.h>
 #include "core.h"
 #include "move.h"
 #include "speciation.h"
@@ -10,7 +9,8 @@
 #include "regions.h"
 #include "aux/iteratorsupport.h"
 #include "aux/eigensupport.h"
-#include "spdlog/spdlog.h"
+#include <spdlog/spdlog.h>
+#include <doctest/doctest.h>
 #include <range/v3/view/counted.hpp>
 #include <range/v3/algorithm/count.hpp>
 #include <range/v3/algorithm/fold_left.hpp>

--- a/src/penalty.cpp
+++ b/src/penalty.cpp
@@ -1,6 +1,6 @@
 #include "penalty.h"
 #include "space.h"
-#include "spdlog/spdlog.h"
+#include <spdlog/spdlog.h>
 
 namespace Faunus::Energy {
 

--- a/src/potentials.cpp
+++ b/src/potentials.cpp
@@ -3,9 +3,9 @@
 #include "units.h"
 #include "auxiliary.h"
 #include "aux/arange.h"
-#include "spdlog/spdlog.h"
 #include "smart_montecarlo.h"
 #include <coulombgalore.h>
+#include <spdlog/spdlog.h>
 
 namespace Faunus::pairpotential {
 

--- a/src/scatter.cpp
+++ b/src/scatter.cpp
@@ -3,7 +3,7 @@
 #include "io.h"
 
 //#define ANKERL_NANOBENCH_IMPLEMENT
-#include "nanobench.h"
+#include <nanobench.h>
 
 namespace Faunus::Scatter {
 

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -1,7 +1,7 @@
 #include "space.h"
 #include "io.h"
-#include "spdlog/spdlog.h"
 #include "aux/eigensupport.h"
+#include <spdlog/spdlog.h>
 #include <range/v3/algorithm/for_each.hpp>
 #include <range/v3/algorithm/count_if.hpp>
 #include <doctest/doctest.h>

--- a/src/speciation.cpp
+++ b/src/speciation.cpp
@@ -1,7 +1,7 @@
 #include "bonds.h"
 #include "speciation.h"
 #include "aux/iteratorsupport.h"
-#include "range/v3/range/conversion.hpp"
+#include <range/v3/range/conversion.hpp>
 #include <algorithm>
 #include <range/v3/algorithm/all_of.hpp>
 #include <range/v3/view/take.hpp>

--- a/src/voronota.cpp
+++ b/src/voronota.cpp
@@ -1,0 +1,62 @@
+#include "analysis.h"
+#include "mpicontroller.h"
+#include "voronotalt/voronotalt.h"
+#include <numeric>
+
+namespace Faunus::analysis {
+
+Voronota::Voronota(double probe_radius, const Faunus::Space& spc)
+    : Analysis(spc, "voronota")
+    , probe_radius(probe_radius) {
+    cite = "doi:10.1093/bioinformatics/btab448";
+}
+
+Voronota::Voronota(const Faunus::json& input, const Faunus::Space& spc)
+    : Voronota(input.value("radius", 1.4_angstrom), spc) {
+    from_json(input);
+}
+
+void Voronota::_from_json(const Faunus::json& input) {
+    if (filename = input.value("file", ""s); !filename.empty()) {
+        output_stream = IO::openCompressedOutputStream(MPI::prefix + filename);
+        *output_stream << "# step SASA\n";
+    }
+}
+
+void Voronota::_to_json(json& json_ouput) const {
+    if (!average_data.area.empty()) {
+        json_ouput = {{"⟨SASA⟩", average_data.area.avg()},
+                      {"⟨SASA²⟩-⟨SASA⟩²", average_data.area_squared.avg() - std::pow(average_data.area.avg(), 2)}};
+    }
+    json_ouput["radius"] = probe_radius;
+}
+
+void Voronota::_to_disk() {
+    if (output_stream) {
+        output_stream->flush();
+    }
+}
+
+void Voronota::_sample() {
+    using namespace ranges::cpp20::views;
+
+    // Convert single `Particle` to Voronota's `SimpleSphere`
+    auto to_sphere = [&](const Particle& p) -> voronotalt::SimpleSphere {
+        return {{p.pos.x(), p.pos.y(), p.pos.z()}, 0.5 * p.traits().sigma + probe_radius};
+    };
+    const auto spheres = spc.activeParticles() | transform(to_sphere) | ranges::to_vector;
+
+    voronotalt::RadicalTessellation::Result result;
+    voronotalt::RadicalTessellation::construct_full_tessellation(spheres, result);
+
+    auto areas = result.cells_summaries | transform([](auto& s) { return s.sas_area; });
+    const auto total_area = std::accumulate(areas.begin(), areas.end(), 0.0);
+    average_data.area.add(total_area);
+    average_data.area_squared.add(total_area * total_area);
+
+    if (output_stream) {
+        *output_stream << this->getNumberOfSteps() << " " << total_area << "\n";
+    }
+}
+
+} // namespace Faunus::analysis

--- a/src/voronotalt/LICENSE.txt
+++ b/src/voronotalt/LICENSE.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2023 Kliment Olechnovic
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/voronotalt/basic_types_and_functions.h
+++ b/src/voronotalt/basic_types_and_functions.h
@@ -1,0 +1,370 @@
+#ifndef VORONOTALT_BASIC_TYPES_AND_FUNCTIONS_H_
+#define VORONOTALT_BASIC_TYPES_AND_FUNCTIONS_H_
+
+#include <cmath>
+
+//#define VORONOTALT_FP32
+#define VORONOTALT_UI32
+
+#ifdef VORONOTALT_FP32
+#define FLOATCONST( v ) v ## f
+#define FLOATEPSILON 0.000001f
+#define PIVALUE 3.14159265358979323846f
+#else
+#define FLOATCONST( v ) v
+#define FLOATEPSILON 0.0000000001
+#define PIVALUE 3.14159265358979323846
+#endif
+
+namespace voronotalt
+{
+
+#ifdef VORONOTALT_FP32
+typedef float Float;
+#else
+typedef double Float;
+#endif
+
+#ifdef VORONOTALT_UI32
+typedef unsigned int UnsignedInt;
+#else
+typedef std::size_t UnsignedInt;
+#endif
+
+struct SimplePoint
+{
+	Float x;
+	Float y;
+	Float z;
+
+	SimplePoint() : x(FLOATCONST(0.0)), y(FLOATCONST(0.0)), z(FLOATCONST(0.0))
+	{
+	}
+
+	SimplePoint(const Float x, const Float y, const Float z) : x(x), y(y), z(z)
+	{
+	}
+};
+
+struct SimpleSphere
+{
+	SimplePoint p;
+	Float r;
+
+	SimpleSphere() : r(FLOATCONST(0.0))
+	{
+	}
+
+	SimpleSphere(const SimplePoint& p, const Float r) : p(p), r(r)
+	{
+	}
+};
+
+struct SimpleQuaternion
+{
+	Float a;
+	Float b;
+	Float c;
+	Float d;
+
+	SimpleQuaternion(const Float a, const Float b, const Float c, const Float d) : a(a), b(b), c(c), d(d)
+	{
+	}
+
+	SimpleQuaternion(const Float a, const SimplePoint& p) : a(a), b(p.x), c(p.y), d(p.z)
+	{
+	}
+};
+
+inline bool equal(const Float a, const Float b, const Float e)
+{
+	return (((a-b)<=e) && ((b-a)<=e));
+}
+
+inline bool equal(const Float a, const Float b)
+{
+	return equal(a, b, FLOATEPSILON);
+}
+
+inline bool less(const Float a, const Float b)
+{
+	return ((a+FLOATEPSILON)<b);
+}
+
+inline bool greater(const Float a, const Float b)
+{
+	return ((a-FLOATEPSILON)>b);
+}
+
+inline bool less_or_equal(const Float a, const Float b)
+{
+	return (less(a, b) || equal(a, b));
+}
+
+inline bool greater_or_equal(const Float a, const Float b)
+{
+	return (greater(a, b) || equal(a, b));
+}
+
+inline void set_close_to_equal(Float& a, const Float b)
+{
+	if(equal(a, b))
+	{
+		a=b;
+	}
+}
+
+inline Float squared_distance_from_point_to_point(const SimplePoint& a, const SimplePoint& b)
+{
+	const Float dx=(a.x-b.x);
+	const Float dy=(a.y-b.y);
+	const Float dz=(a.z-b.z);
+	return (dx*dx+dy*dy+dz*dz);
+}
+
+inline Float distance_from_point_to_point(const SimplePoint& a, const SimplePoint& b)
+{
+	return sqrt(squared_distance_from_point_to_point(a, b));
+}
+
+inline Float squared_point_module(const SimplePoint& a)
+{
+	return (a.x*a.x+a.y*a.y+a.z*a.z);
+}
+
+inline Float point_module(const SimplePoint& a)
+{
+	return sqrt(squared_point_module(a));
+}
+
+inline Float dot_product(const SimplePoint& a, const SimplePoint& b)
+{
+	return (a.x*b.x+a.y*b.y+a.z*b.z);
+}
+
+inline SimplePoint cross_product(const SimplePoint& a, const SimplePoint& b)
+{
+	return SimplePoint(a.y*b.z-a.z*b.y, a.z*b.x-a.x*b.z, a.x*b.y-a.y*b.x);
+}
+
+inline SimplePoint point_and_number_product(const SimplePoint& a, const Float k)
+{
+	return SimplePoint(a.x*k, a.y*k, a.z*k);
+}
+
+inline SimplePoint unit_point(const SimplePoint& a)
+{
+	return ((equal(squared_point_module(a), FLOATCONST(1.0))) ? a : point_and_number_product(a, FLOATCONST(1.0)/point_module(a)));
+}
+
+inline SimplePoint sum_of_points(const SimplePoint& a, const SimplePoint& b)
+{
+	return SimplePoint(a.x+b.x, a.y+b.y, a.z+b.z);
+}
+
+inline SimplePoint sub_of_points(const SimplePoint& a, const SimplePoint& b)
+{
+	return SimplePoint(a.x-b.x, a.y-b.y, a.z-b.z);
+}
+
+inline Float signed_distance_from_point_to_plane(const SimplePoint& plane_point, const SimplePoint& plane_normal, const SimplePoint& x)
+{
+	return dot_product(unit_point(plane_normal), sub_of_points(x, plane_point));
+}
+
+inline int halfspace_of_point(const SimplePoint& plane_point, const SimplePoint& plane_normal, const SimplePoint& x)
+{
+	const Float sd=signed_distance_from_point_to_plane(plane_point, plane_normal, x);
+	if(greater(sd, FLOATCONST(0.0)))
+	{
+		return 1;
+	}
+	else if(less(sd, FLOATCONST(0.0)))
+	{
+		return -1;
+	}
+	return 0;
+}
+
+inline SimplePoint intersection_of_plane_and_segment(const SimplePoint& plane_point, const SimplePoint& plane_normal, const SimplePoint& a, const SimplePoint& b)
+{
+	const Float da=signed_distance_from_point_to_plane(plane_point, plane_normal, a);
+	const Float db=signed_distance_from_point_to_plane(plane_point, plane_normal, b);
+	if((da-db)==0)
+	{
+		return a;
+	}
+	else
+	{
+		const Float t=da/(da-db);
+		return sum_of_points(a, point_and_number_product(sub_of_points(b, a), t));
+	}
+}
+
+inline Float triangle_area(const SimplePoint& a, const SimplePoint& b, const SimplePoint& c)
+{
+	return (point_module(cross_product(sub_of_points(b, a), sub_of_points(c, a)))/FLOATCONST(2.0));
+}
+
+inline Float min_angle(const SimplePoint& o, const SimplePoint& a, const SimplePoint& b)
+{
+	Float cos_val=dot_product(unit_point(sub_of_points(a, o)), unit_point(sub_of_points(b, o)));
+	if(cos_val<FLOATCONST(-1.0))
+	{
+		cos_val=FLOATCONST(-1.0);
+	}
+	else if(cos_val>FLOATCONST(1.0))
+	{
+		cos_val=FLOATCONST(1.0);
+	}
+	return std::acos(cos_val);
+}
+
+inline Float directed_angle(const SimplePoint& o, const SimplePoint& a, const SimplePoint& b, const SimplePoint& c)
+{
+	const Float angle=min_angle(o, a, b);
+	const SimplePoint n=cross_product(unit_point(sub_of_points(a, o)), unit_point(sub_of_points(b, o)));
+	if(dot_product(sub_of_points(c, o), n)>=0)
+	{
+		return angle;
+	}
+	else
+	{
+		return (PIVALUE*FLOATCONST(2.0)-angle);
+	}
+}
+
+SimplePoint any_normal_of_vector(const SimplePoint& a)
+{
+	SimplePoint b=a;
+	if(!equal(b.x, FLOATCONST(0.0)) && (!equal(b.y, FLOATCONST(0.0)) || !equal(b.z, FLOATCONST(0.0))))
+	{
+		b.x=FLOATCONST(0.0)-b.x;
+		return unit_point(cross_product(a, b));
+	}
+	else if(!equal(b.y, FLOATCONST(0.0)) && (!equal(b.x, FLOATCONST(0.0)) || !equal(b.z, FLOATCONST(0.0))))
+	{
+		b.y=FLOATCONST(0.0)-b.y;
+		return unit_point(cross_product(a, b));
+	}
+	else if(!equal(b.x, FLOATCONST(0.0)))
+	{
+		return SimplePoint(FLOATCONST(0.0), FLOATCONST(1.0), FLOATCONST(0.0));
+	}
+	else
+	{
+		return SimplePoint(FLOATCONST(1.0), FLOATCONST(0.0), FLOATCONST(0.0));
+	}
+}
+
+inline bool sphere_intersects_sphere(const SimpleSphere& a, const SimpleSphere& b)
+{
+	return less(squared_distance_from_point_to_point(a.p, b.p), (a.r+b.r)*(a.r+b.r));
+}
+
+inline bool sphere_equals_sphere(const SimpleSphere& a, const SimpleSphere& b)
+{
+	return (equal(a.r, b.r) && equal(a.p.x, b.p.x) && equal(a.p.y, b.p.y) && equal(a.p.z, b.p.z));
+}
+
+inline bool sphere_contains_sphere(const SimpleSphere& a, const SimpleSphere& b)
+{
+	return (greater_or_equal(a.r, b.r) && less_or_equal(squared_distance_from_point_to_point(a.p, b.p), (a.r-b.r)*(a.r-b.r)));
+}
+
+inline Float distance_to_center_of_intersection_circle_of_two_spheres(const SimpleSphere& a, const SimpleSphere& b)
+{
+	const Float cm=distance_from_point_to_point(a.p, b.p);
+	const Float cos_g=(a.r*a.r+cm*cm-b.r*b.r)/(2*a.r*cm);
+	return (a.r*cos_g);
+}
+
+inline SimplePoint center_of_intersection_circle_of_two_spheres(const SimpleSphere& a, const SimpleSphere& b)
+{
+	const SimplePoint cv=sub_of_points(b.p, a.p);
+	const Float cm=point_module(cv);
+	const Float cos_g=(a.r*a.r+cm*cm-b.r*b.r)/(2*a.r*cm);
+	return sum_of_points(a.p, point_and_number_product(cv, a.r*cos_g/cm));
+}
+
+inline SimpleSphere intersection_circle_of_two_spheres(const SimpleSphere& a, const SimpleSphere& b)
+{
+	const SimplePoint cv=sub_of_points(b.p, a.p);
+	const Float cm=point_module(cv);
+	const Float cos_g=(a.r*a.r+cm*cm-b.r*b.r)/(2*a.r*cm);
+	const Float sin_g=std::sqrt(1-cos_g*cos_g);
+	return SimpleSphere(sum_of_points(a.p, point_and_number_product(cv, a.r*cos_g/cm)), a.r*sin_g);
+}
+
+inline bool project_point_inside_line(const SimplePoint& o, const SimplePoint& a, const SimplePoint& b, SimplePoint& result)
+{
+	const SimplePoint v=unit_point(sub_of_points(b, a));
+	const Float l=dot_product(v, sub_of_points(o, a));
+	if(l>FLOATCONST(0.0) && (l*l)<=squared_distance_from_point_to_point(a, b))
+	{
+		result=sum_of_points(a, point_and_number_product(v, l));
+		return true;
+	}
+	return false;
+}
+
+inline bool intersect_segment_with_circle(const SimpleSphere& circle, const SimplePoint& p_in, const SimplePoint& p_out, SimplePoint& result)
+{
+	const Float dist_in_to_out=distance_from_point_to_point(p_in, p_out);
+	if(dist_in_to_out>FLOATCONST(0.0))
+	{
+		const SimplePoint v=point_and_number_product(sub_of_points(p_in, p_out), FLOATCONST(1.0)/dist_in_to_out);
+		const SimplePoint u=sub_of_points(circle.p, p_out);
+		const SimplePoint s=sum_of_points(p_out, point_and_number_product(v, dot_product(v, u)));
+		const Float ll=(circle.r*circle.r)-squared_distance_from_point_to_point(circle.p, s);
+		if(ll>=FLOATCONST(0.0))
+		{
+			result=sum_of_points(s, point_and_number_product(v, FLOATCONST(0.0)-std::sqrt(ll)));
+			return true;
+		}
+	}
+	return false;
+}
+
+inline Float min_dihedral_angle(const SimplePoint& o, const SimplePoint& a, const SimplePoint& b1, const SimplePoint& b2)
+{
+	const SimplePoint oa=unit_point(sub_of_points(a, o));
+	const SimplePoint d1=sub_of_points(b1, sum_of_points(o, point_and_number_product(oa, dot_product(oa, sub_of_points(b1, o)))));
+	const SimplePoint d2=sub_of_points(b2, sum_of_points(o, point_and_number_product(oa, dot_product(oa, sub_of_points(b2, o)))));
+	const Float cos_val=dot_product(unit_point(d1), unit_point(d2));
+	return std::acos(std::max(FLOATCONST(-1.0), std::min(cos_val, FLOATCONST(1.0))));
+}
+
+inline SimpleQuaternion quaternion_product(const SimpleQuaternion& q1, const SimpleQuaternion& q2)
+{
+	return SimpleQuaternion(
+			q1.a*q2.a - q1.b*q2.b - q1.c*q2.c - q1.d*q2.d,
+			q1.a*q2.b + q1.b*q2.a + q1.c*q2.d - q1.d*q2.c,
+			q1.a*q2.c - q1.b*q2.d + q1.c*q2.a + q1.d*q2.b,
+			q1.a*q2.d + q1.b*q2.c - q1.c*q2.b + q1.d*q2.a);
+}
+
+inline SimpleQuaternion inverted_quaternion(const SimpleQuaternion& q)
+{
+	return SimpleQuaternion(q.a, FLOATCONST(0.0)-q.b, FLOATCONST(0.0)-q.c, FLOATCONST(0.0)-q.d);
+}
+
+inline SimplePoint rotate_point_around_axis(const SimplePoint& axis, const Float angle, const SimplePoint& p)
+{
+	if(squared_point_module(axis)>0)
+	{
+		const Float radians_angle_half=(angle*FLOATCONST(0.5));
+		const SimpleQuaternion q1=SimpleQuaternion(std::cos(radians_angle_half), point_and_number_product(unit_point(axis), std::sin(radians_angle_half)));
+		const SimpleQuaternion q2=SimpleQuaternion(FLOATCONST(0.0), p);
+		const SimpleQuaternion q3=quaternion_product(quaternion_product(q1, q2), inverted_quaternion(q1));
+		return SimplePoint(q3.b, q3.c, q3.d);
+	}
+	else
+	{
+		return p;
+	}
+}
+
+}
+
+#endif /* VORONOTALT_BASIC_TYPES_AND_FUNCTIONS_H_ */

--- a/src/voronotalt/conversion_to_input.h
+++ b/src/voronotalt/conversion_to_input.h
@@ -1,0 +1,52 @@
+#ifndef VORONOTALT_CONVERSION_TO_INPUT_H_
+#define VORONOTALT_CONVERSION_TO_INPUT_H_
+
+#include <vector>
+
+#include "basic_types_and_functions.h"
+
+namespace voronotalt
+{
+
+template<class Ball>
+inline SimpleSphere get_sphere_from_ball(const Ball& ball, const Float probe)
+{
+	return SimpleSphere(SimplePoint(static_cast<Float>(ball.x), static_cast<Float>(ball.y), static_cast<Float>(ball.z)), static_cast<Float>(ball.r)+probe);
+}
+
+template<class Ball>
+inline void fill_sphere_from_ball(const Ball& ball, const Float probe, SimpleSphere& sphere)
+{
+	sphere.p.x=static_cast<Float>(ball.x);
+	sphere.p.y=static_cast<Float>(ball.y);
+	sphere.p.z=static_cast<Float>(ball.z);
+	sphere.r=static_cast<Float>(ball.r)+probe;
+}
+
+template<class BallsContainer>
+inline std::vector<SimpleSphere> get_spheres_from_balls(const BallsContainer& balls, const Float probe)
+{
+	std::vector<SimpleSphere> result;
+	result.reserve(balls.size());
+	for(typename BallsContainer::const_iterator it=balls.begin();it!=balls.end();++it)
+	{
+		result.push_back(get_sphere_from_ball(*it, probe));
+	}
+	return result;
+}
+
+template<class BallsContainer>
+inline void fill_spheres_from_balls(const BallsContainer& balls, const Float probe, std::vector<SimpleSphere>& spheres)
+{
+	spheres.resize(balls.size());
+	std::size_t i=0;
+	for(typename BallsContainer::const_iterator it=balls.begin();it!=balls.end();++it)
+	{
+		fill_sphere_from_ball(*it, probe, spheres[i]);
+		i++;
+	}
+}
+
+}
+
+#endif /* VORONOTALT_CONVERSION_TO_INPUT_H_ */

--- a/src/voronotalt/preparation_for_tessellation.h
+++ b/src/voronotalt/preparation_for_tessellation.h
@@ -1,0 +1,121 @@
+#ifndef VORONOTALT_PREPARATION_FOR_TESSELLATION_H_
+#define VORONOTALT_PREPARATION_FOR_TESSELLATION_H_
+
+#include <algorithm>
+
+#include "spheres_searcher.h"
+#include "time_recorder.h"
+
+namespace voronotalt
+{
+
+class PreparationForTessellation
+{
+public:
+	struct Result
+	{
+		std::vector<int> all_exclusion_statuses;
+		std::vector< std::vector<UnsignedInt> > all_colliding_ids;
+		std::vector< std::pair<UnsignedInt, UnsignedInt> > relevant_collision_ids;
+		UnsignedInt total_spheres;
+		UnsignedInt total_collisions;
+
+		Result() : total_spheres(0), total_collisions(0)
+		{
+		}
+	};
+
+	static void prepare_for_tessellation(
+			const std::vector<SimpleSphere>& spheres,
+			const std::vector<int>& grouping_of_spheres,
+			Result& result,
+			TimeRecorder& time_recorder)
+	{
+		time_recorder.reset();
+
+		result=Result();
+
+		const UnsignedInt N=spheres.size();
+		result.total_spheres=N;
+
+		SpheresSearcher spheres_searcher(spheres);
+
+		time_recorder.record_elapsed_miliseconds_and_reset("init spheres searcher");
+
+		result.all_exclusion_statuses.resize(N, 0);
+
+		result.all_colliding_ids.resize(N);
+		for(UnsignedInt i=0;i<N;i++)
+		{
+			result.all_colliding_ids[i].reserve(100);
+		}
+
+		time_recorder.record_elapsed_miliseconds_and_reset("pre-allocate colliding IDs");
+
+		#pragma omp parallel
+		{
+			std::vector<UnsignedInt> colliding_ids;
+			colliding_ids.reserve(100);
+
+			std::vector< std::pair<Float, UnsignedInt> > distances_of_colliding_ids;
+			distances_of_colliding_ids.reserve(100);
+
+			#pragma omp for
+			for(UnsignedInt i=0;i<N;i++)
+			{
+				spheres_searcher.find_colliding_ids(i, colliding_ids, true, result.all_exclusion_statuses[i]);
+				if(!colliding_ids.empty())
+				{
+					distances_of_colliding_ids.resize(colliding_ids.size());
+					for(std::size_t j=0;j<colliding_ids.size();j++)
+					{
+						distances_of_colliding_ids[j].first=distance_to_center_of_intersection_circle_of_two_spheres(spheres[i], spheres[colliding_ids[j]]);
+						distances_of_colliding_ids[j].second=colliding_ids[j];
+					}
+					std::sort(distances_of_colliding_ids.begin(), distances_of_colliding_ids.end());
+					for(std::size_t j=0;j<colliding_ids.size();j++)
+					{
+						colliding_ids[j]=distances_of_colliding_ids[j].second;
+					}
+					result.all_colliding_ids[i]=colliding_ids;
+				}
+			}
+		}
+
+		time_recorder.record_elapsed_miliseconds_and_reset("detect all collisions");
+
+		for(UnsignedInt i=0;i<result.all_colliding_ids.size();i++)
+		{
+			result.total_collisions+=result.all_colliding_ids[i].size();
+		}
+
+		result.total_collisions=result.total_collisions/2;
+
+		time_recorder.record_elapsed_miliseconds_and_reset("count all collisions");
+
+		result.relevant_collision_ids.reserve(result.total_collisions);
+		for(UnsignedInt id_a=0;id_a<N;id_a++)
+		{
+			if(result.all_exclusion_statuses[id_a]==0)
+			{
+				for(UnsignedInt j=0;j<result.all_colliding_ids[id_a].size();j++)
+				{
+					const UnsignedInt id_b=result.all_colliding_ids[id_a][j];
+					if((result.all_exclusion_statuses[id_b]==0 && result.all_colliding_ids[id_a].size()<result.all_colliding_ids[id_b].size()) || (id_a<id_b && result.all_colliding_ids[id_a].size()==result.all_colliding_ids[id_b].size()))
+					{
+						if(grouping_of_spheres.empty() || id_a>=grouping_of_spheres.size() || id_b>=grouping_of_spheres.size() || grouping_of_spheres[id_a]!=grouping_of_spheres[id_b])
+						{
+							result.relevant_collision_ids.push_back(std::pair<UnsignedInt, UnsignedInt>(id_a, id_b));
+						}
+					}
+				}
+			}
+		}
+
+		time_recorder.record_elapsed_miliseconds_and_reset("collect relevant collision indices");
+	}
+};
+
+}
+
+#endif /* VORONOTALT_PREPARATION_FOR_TESSELLATION_H_ */

--- a/src/voronotalt/radical_tessellation.h
+++ b/src/voronotalt/radical_tessellation.h
@@ -1,0 +1,513 @@
+#ifndef VORONOTALT_RADICAL_TESSELLATION_H_
+#define VORONOTALT_RADICAL_TESSELLATION_H_
+
+#include <map>
+
+#include "preparation_for_tessellation.h"
+#include "radical_tessellation_contact_construction.h"
+#include "time_recorder.h"
+
+namespace voronotalt
+{
+
+class RadicalTessellation
+{
+public:
+	struct ContactDescriptorSummary
+	{
+		Float area;
+		Float arc_length;
+		Float solid_angle_a;
+		Float solid_angle_b;
+		Float pyramid_volume_a;
+		Float pyramid_volume_b;
+		Float distance;
+		UnsignedInt flags;
+		UnsignedInt id_a;
+		UnsignedInt id_b;
+
+		ContactDescriptorSummary() :
+			area(FLOATCONST(0.0)),
+			arc_length(FLOATCONST(0.0)),
+			solid_angle_a(FLOATCONST(0.0)),
+			solid_angle_b(FLOATCONST(0.0)),
+			pyramid_volume_a(FLOATCONST(0.0)),
+			pyramid_volume_b(FLOATCONST(0.0)),
+			distance(FLOATCONST(0.0)),
+			flags(0),
+			id_a(0),
+			id_b(0)
+		{
+		}
+
+		void set(const RadicalTessellationContactConstruction::ContactDescriptor& cd)
+		{
+			if(cd.area>FLOATCONST(0.0))
+			{
+				id_a=cd.id_a;
+				id_b=cd.id_b;
+				area=cd.area;
+				arc_length=(cd.sum_of_arc_angles*cd.intersection_circle_sphere.r);
+				solid_angle_a=cd.solid_angle_a;
+				solid_angle_b=cd.solid_angle_b;
+				pyramid_volume_a=cd.pyramid_volume_a;
+				pyramid_volume_b=cd.pyramid_volume_b;
+				distance=cd.distance;
+				flags=cd.flags;
+			}
+		}
+
+		void ensure_ids_ordered()
+		{
+			if(id_a>id_b)
+			{
+				std::swap(id_a, id_b);
+				std::swap(solid_angle_a, solid_angle_b);
+				std::swap(pyramid_volume_a, pyramid_volume_b);
+			}
+		}
+	};
+
+	struct CellContactDescriptorsSummary
+	{
+		Float area;
+		Float arc_length;
+		Float explained_solid_angle_positive;
+		Float explained_solid_angle_negative;
+		Float explained_pyramid_volume_positive;
+		Float explained_pyramid_volume_negative;
+		Float sas_area;
+		Float sas_inside_volume;
+		UnsignedInt id;
+		UnsignedInt count;
+		int stage;
+
+		CellContactDescriptorsSummary() :
+			area(FLOATCONST(0.0)),
+			arc_length(FLOATCONST(0.0)),
+			explained_solid_angle_positive(FLOATCONST(0.0)),
+			explained_solid_angle_negative(FLOATCONST(0.0)),
+			explained_pyramid_volume_positive(FLOATCONST(0.0)),
+			explained_pyramid_volume_negative(FLOATCONST(0.0)),
+			sas_area(FLOATCONST(0.0)),
+			sas_inside_volume(FLOATCONST(0.0)),
+			id(0),
+			count(0),
+			stage(0)
+		{
+		}
+
+		void add(const ContactDescriptorSummary& cds)
+		{
+			if(cds.area>FLOATCONST(0.0) && (cds.id_a==id || cds.id_b==id))
+			{
+				count++;
+				area+=cds.area;
+				arc_length+=cds.arc_length;
+				explained_solid_angle_positive+=std::max(FLOATCONST(0.0), (cds.id_a==id ? cds.solid_angle_a : cds.solid_angle_b));
+				explained_solid_angle_negative+=FLOATCONST(0.0)-std::min(FLOATCONST(0.0), (cds.id_a==id ? cds.solid_angle_a : cds.solid_angle_b));
+				explained_pyramid_volume_positive+=std::max(FLOATCONST(0.0), (cds.id_a==id ? cds.pyramid_volume_a : cds.pyramid_volume_b));
+				explained_pyramid_volume_negative+=FLOATCONST(0.0)-std::min(FLOATCONST(0.0), (cds.id_a==id ? cds.pyramid_volume_a : cds.pyramid_volume_b));
+				stage=1;
+			}
+		}
+
+		void add(const UnsignedInt new_id, const ContactDescriptorSummary& cds)
+		{
+			if(cds.area>FLOATCONST(0.0))
+			{
+				if(stage==0)
+				{
+					id=new_id;
+				}
+				add(cds);
+			}
+		}
+
+		void compute_sas(const Float r)
+		{
+			if(stage==1)
+			{
+				sas_area=FLOATCONST(0.0);
+				sas_inside_volume=FLOATCONST(0.0);
+				if(arc_length>FLOATCONST(0.0) && !equal(explained_solid_angle_positive, explained_solid_angle_negative))
+				{
+					if(explained_solid_angle_positive>explained_solid_angle_negative)
+					{
+						sas_area=((FLOATCONST(4.0)*PIVALUE)-std::max(FLOATCONST(0.0), explained_solid_angle_positive-explained_solid_angle_negative))*(r*r);
+					}
+					else if(explained_solid_angle_negative>explained_solid_angle_positive)
+					{
+						sas_area=(std::max(FLOATCONST(0.0), explained_solid_angle_negative-explained_solid_angle_positive))*(r*r);
+					}
+					sas_inside_volume=(sas_area*r/FLOATCONST(3.0))+explained_pyramid_volume_positive-explained_pyramid_volume_negative;
+					if(sas_inside_volume>(FLOATCONST(4.0)/FLOATCONST(3.0)*PIVALUE*r*r*r))
+					{
+						sas_area=FLOATCONST(0.0);
+						sas_inside_volume=explained_pyramid_volume_positive-explained_pyramid_volume_negative;
+					}
+				}
+				else
+				{
+					sas_inside_volume=explained_pyramid_volume_positive-explained_pyramid_volume_negative;
+				}
+				stage=2;
+			}
+		}
+
+		void compute_sas_detached(const UnsignedInt new_id, const Float r)
+		{
+			if(stage==0)
+			{
+				id=new_id;
+				sas_area=(FLOATCONST(4.0)*PIVALUE)*(r*r);
+				sas_inside_volume=(sas_area*r/FLOATCONST(3.0));
+				stage=2;
+			}
+		}
+	};
+
+	struct TotalContactDescriptorsSummary
+	{
+		Float area;
+		Float arc_length;
+		Float distance;
+		UnsignedInt count;
+
+		TotalContactDescriptorsSummary() :
+			area(FLOATCONST(0.0)),
+			arc_length(FLOATCONST(0.0)),
+			distance(FLOATCONST(-1.0)),
+			count(0)
+		{
+		}
+
+		void add(const ContactDescriptorSummary& cds)
+		{
+			if(cds.area>FLOATCONST(0.0))
+			{
+				count++;
+				area+=cds.area;
+				arc_length+=cds.arc_length;
+				distance=((distance<FLOATCONST(0.0)) ? cds.distance : std::min(distance, cds.distance));
+			}
+		}
+	};
+
+	struct TotalCellContactDescriptorsSummary
+	{
+		Float sas_area;
+		Float sas_inside_volume;
+		UnsignedInt count;
+
+		TotalCellContactDescriptorsSummary() :
+			sas_area(FLOATCONST(0.0)),
+			sas_inside_volume(FLOATCONST(0.0)),
+			count(0)
+		{
+		}
+
+		void add(const CellContactDescriptorsSummary& ccds)
+		{
+			if(ccds.stage==2)
+			{
+				count++;
+				sas_area+=ccds.sas_area;
+				sas_inside_volume+=ccds.sas_inside_volume;
+			}
+		}
+	};
+
+	struct Result
+	{
+		UnsignedInt total_spheres;
+		UnsignedInt total_collisions;
+		UnsignedInt total_relevant_collisions;
+		std::vector<ContactDescriptorSummary> contacts_summaries;
+		TotalContactDescriptorsSummary total_contacts_summary;
+		std::vector<CellContactDescriptorsSummary> cells_summaries;
+		TotalCellContactDescriptorsSummary total_cells_summary;
+
+		Result() : total_spheres(0), total_collisions(0), total_relevant_collisions(0)
+		{
+		}
+	};
+
+	struct ResultGraphics
+	{
+		std::vector<RadicalTessellationContactConstruction::ContactDescriptorGraphics> contacts_graphics;
+	};
+
+	struct GroupedResult
+	{
+		std::vector<UnsignedInt> grouped_contacts_representative_ids;
+		std::vector<TotalContactDescriptorsSummary> grouped_contacts_summaries;
+		std::vector<UnsignedInt> grouped_cells_representative_ids;
+		std::vector<TotalCellContactDescriptorsSummary> grouped_cells_summaries;
+	};
+
+	static void construct_full_tessellation(
+			const std::vector<SimpleSphere>& spheres,
+			Result& result)
+	{
+		TimeRecorder time_recorder;
+		ResultGraphics result_graphics;
+		construct_full_tessellation(spheres, std::vector<int>(), false, true, result, result_graphics, time_recorder);
+	}
+
+	static void construct_full_tessellation(
+			const std::vector<SimpleSphere>& spheres,
+			const std::vector<int>& grouping_of_spheres,
+			const bool with_graphics,
+			const bool summarize_cells,
+			Result& result,
+			ResultGraphics& result_graphics,
+			TimeRecorder& time_recorder)
+	{
+		PreparationForTessellation::Result preparation_result;
+		PreparationForTessellation::prepare_for_tessellation(spheres, grouping_of_spheres, preparation_result, time_recorder);
+		construct_full_tessellation(spheres, preparation_result, with_graphics, summarize_cells, result, result_graphics, time_recorder);
+	}
+
+	static void construct_full_tessellation(
+			const std::vector<SimpleSphere>& spheres,
+			const PreparationForTessellation::Result& preparation_result,
+			const bool with_graphics,
+			const bool summarize_cells,
+			Result& result,
+			ResultGraphics& result_graphics,
+			TimeRecorder& time_recorder)
+	{
+		time_recorder.reset();
+
+		result=Result();
+		result_graphics=ResultGraphics();
+
+		result.total_spheres=preparation_result.total_spheres;
+		result.total_collisions=preparation_result.total_collisions;
+		result.total_relevant_collisions=preparation_result.relevant_collision_ids.size();
+
+		std::vector<ContactDescriptorSummary> possible_contacts_summaries(preparation_result.relevant_collision_ids.size());
+
+		std::vector<RadicalTessellationContactConstruction::ContactDescriptorGraphics> possible_contacts_graphics;
+		if(with_graphics)
+		{
+			possible_contacts_graphics.resize(possible_contacts_summaries.size());
+		}
+
+		time_recorder.record_elapsed_miliseconds_and_reset("allocate possible contact summaries");
+
+		#pragma omp parallel
+		{
+			RadicalTessellationContactConstruction::ContactDescriptor cd;
+			cd.contour.reserve(12);
+
+			#pragma omp for
+			for(UnsignedInt i=0;i<preparation_result.relevant_collision_ids.size();i++)
+			{
+				const UnsignedInt id_a=preparation_result.relevant_collision_ids[i].first;
+				const UnsignedInt id_b=preparation_result.relevant_collision_ids[i].second;
+				if(RadicalTessellationContactConstruction::construct_contact_descriptor(spheres, preparation_result.all_exclusion_statuses, id_a, id_b, preparation_result.all_colliding_ids[id_a], cd))
+				{
+					possible_contacts_summaries[i].set(cd);
+					if(with_graphics)
+					{
+						RadicalTessellationContactConstruction::construct_contact_descriptor_graphics(cd, 0.2, possible_contacts_graphics[i]);
+					}
+				}
+			}
+		}
+
+		time_recorder.record_elapsed_miliseconds_and_reset("construct contacts");
+
+		UnsignedInt number_of_valid_contact_summaries=0;
+		for(UnsignedInt i=0;i<possible_contacts_summaries.size();i++)
+		{
+			if(possible_contacts_summaries[i].area>FLOATCONST(0.0))
+			{
+				number_of_valid_contact_summaries++;
+			}
+		}
+
+		time_recorder.record_elapsed_miliseconds_and_reset("count valid contact summaries");
+
+		std::vector<UnsignedInt> ids_of_valid_pairs;
+		ids_of_valid_pairs.reserve(number_of_valid_contact_summaries);
+
+		for(UnsignedInt i=0;i<possible_contacts_summaries.size();i++)
+		{
+			if(possible_contacts_summaries[i].area>FLOATCONST(0.0))
+			{
+				ids_of_valid_pairs.push_back(i);
+			}
+		}
+
+		time_recorder.record_elapsed_miliseconds_and_reset("collect indices of valid contact summaries");
+
+		result.contacts_summaries.resize(ids_of_valid_pairs.size());
+
+		#pragma omp parallel
+		{
+			#pragma omp for
+			for(UnsignedInt i=0;i<ids_of_valid_pairs.size();i++)
+			{
+				result.contacts_summaries[i]=possible_contacts_summaries[ids_of_valid_pairs[i]];
+				result.contacts_summaries[i].ensure_ids_ordered();
+			}
+		}
+
+		time_recorder.record_elapsed_miliseconds_and_reset("copy valid contact summaries");
+
+		for(UnsignedInt i=0;i<result.contacts_summaries.size();i++)
+		{
+			result.total_contacts_summary.add(result.contacts_summaries[i]);
+		}
+
+		time_recorder.record_elapsed_miliseconds_and_reset("accumulate total contacts summary");
+
+		if(with_graphics)
+		{
+			result_graphics.contacts_graphics.resize(ids_of_valid_pairs.size());
+
+			for(UnsignedInt i=0;i<ids_of_valid_pairs.size();i++)
+			{
+				result_graphics.contacts_graphics[i]=possible_contacts_graphics[ids_of_valid_pairs[i]];
+			}
+		}
+
+		time_recorder.record_elapsed_miliseconds_and_reset("copy valid contacts graphics");
+
+		if(summarize_cells)
+		{
+			result.cells_summaries.resize(preparation_result.total_spheres);
+
+			for(UnsignedInt i=0;i<result.contacts_summaries.size();i++)
+			{
+				const ContactDescriptorSummary& cds=result.contacts_summaries[i];
+				result.cells_summaries[cds.id_a].add(cds.id_a, cds);
+				result.cells_summaries[cds.id_b].add(cds.id_b, cds);
+			}
+
+			time_recorder.record_elapsed_miliseconds_and_reset("accumulate cell summaries");
+
+			for(UnsignedInt i=0;i<result.cells_summaries.size();i++)
+			{
+				result.cells_summaries[i].compute_sas(spheres[i].r);
+				if(result.cells_summaries[i].stage==0 && preparation_result.all_exclusion_statuses[i]==0 && preparation_result.all_colliding_ids[i].empty())
+				{
+					result.cells_summaries[i].compute_sas_detached(i, spheres[i].r);
+				}
+			}
+
+			time_recorder.record_elapsed_miliseconds_and_reset("compute sas for cell summaries");
+
+			for(UnsignedInt i=0;i<result.cells_summaries.size();i++)
+			{
+				result.total_cells_summary.add(result.cells_summaries[i]);
+			}
+
+			time_recorder.record_elapsed_miliseconds_and_reset("accumulate total cells summary");
+		}
+	}
+
+	static bool group_results(
+			const Result& full_result,
+			const std::vector<int>& grouping_of_spheres,
+			GroupedResult& grouped_result)
+	{
+		TimeRecorder time_recorder;
+		return group_results(full_result, grouping_of_spheres, grouped_result, time_recorder);
+	}
+
+	static bool group_results(
+			const Result& full_result,
+			const std::vector<int>& grouping_of_spheres,
+			GroupedResult& grouped_result,
+			TimeRecorder& time_recorder)
+	{
+		time_recorder.reset();
+
+		grouped_result=GroupedResult();
+
+		if(!grouping_of_spheres.empty() && grouping_of_spheres.size()==full_result.total_spheres)
+		{
+			{
+				grouped_result.grouped_contacts_representative_ids.reserve(full_result.contacts_summaries.size()/5);
+				grouped_result.grouped_contacts_summaries.reserve(full_result.contacts_summaries.size()/5);
+
+				std::map< std::pair<int, int>, UnsignedInt > map_of_groups;
+
+				for(UnsignedInt i=0;i<full_result.contacts_summaries.size();i++)
+				{
+					const ContactDescriptorSummary& cds=full_result.contacts_summaries[i];
+					if(cds.id_a<grouping_of_spheres.size() && cds.id_b<grouping_of_spheres.size())
+					{
+						std::pair<int, int> group_id(grouping_of_spheres[cds.id_a], grouping_of_spheres[cds.id_b]);
+						if(group_id.first!=group_id.second)
+						{
+							if(group_id.first>group_id.second)
+							{
+								std::swap(group_id.first, group_id.second);
+							}
+							UnsignedInt group_index=0;
+							std::map< std::pair<int, int>, UnsignedInt >::const_iterator it=map_of_groups.find(group_id);
+							if(it==map_of_groups.end())
+							{
+								group_index=grouped_result.grouped_contacts_summaries.size();
+								grouped_result.grouped_contacts_representative_ids.push_back(i);
+								grouped_result.grouped_contacts_summaries.push_back(TotalContactDescriptorsSummary());
+								map_of_groups[group_id]=group_index;
+							}
+							else
+							{
+								group_index=it->second;
+							}
+							grouped_result.grouped_contacts_summaries[group_index].add(cds);
+						}
+					}
+				}
+
+				time_recorder.record_elapsed_miliseconds_and_reset("grouped contacts summaries");
+			}
+
+			if(!full_result.cells_summaries.empty() && full_result.cells_summaries.size()==grouping_of_spheres.size())
+			{
+				grouped_result.grouped_cells_representative_ids.reserve(full_result.cells_summaries.size()/5);
+				grouped_result.grouped_cells_summaries.reserve(full_result.cells_summaries.size()/5);
+
+				std::map< int, UnsignedInt > map_of_groups;
+
+				for(UnsignedInt i=0;i<full_result.cells_summaries.size();i++)
+				{
+					const CellContactDescriptorsSummary& ccds=full_result.cells_summaries[i];
+					if(ccds.stage==2 && ccds.id<grouping_of_spheres.size())
+					{
+						const int group_id=grouping_of_spheres[ccds.id];
+						UnsignedInt group_index=0;
+						std::map< int, UnsignedInt >::const_iterator it=map_of_groups.find(group_id);
+						if(it==map_of_groups.end())
+						{
+							group_index=grouped_result.grouped_cells_summaries.size();
+							grouped_result.grouped_cells_representative_ids.push_back(i);
+							grouped_result.grouped_cells_summaries.push_back(TotalCellContactDescriptorsSummary());
+							map_of_groups[group_id]=group_index;
+						}
+						else
+						{
+							group_index=it->second;
+						}
+						grouped_result.grouped_cells_summaries[group_index].add(ccds);
+					}
+				}
+
+				time_recorder.record_elapsed_miliseconds_and_reset("grouped cells summaries");
+			}
+		}
+
+		return (!grouped_result.grouped_contacts_summaries.empty());
+	}
+};
+
+}
+
+#endif /* VORONOTALT_RADICAL_TESSELLATION_H_ */

--- a/src/voronotalt/radical_tessellation_contact_construction.h
+++ b/src/voronotalt/radical_tessellation_contact_construction.h
@@ -1,0 +1,676 @@
+#ifndef VORONOTALT_RADICAL_TESSELLATION_CONTACT_CONSTRUCTION_H_
+#define VORONOTALT_RADICAL_TESSELLATION_CONTACT_CONSTRUCTION_H_
+
+#include <vector>
+
+#include "basic_types_and_functions.h"
+
+namespace voronotalt
+{
+
+class RadicalTessellationContactConstruction
+{
+public:
+	struct ContourPoint
+	{
+		SimplePoint p;
+		Float angle;
+		UnsignedInt left_id;
+		UnsignedInt right_id;
+		int indicator;
+
+
+		ContourPoint(const SimplePoint& p, const UnsignedInt left_id, const UnsignedInt right_id) :
+			p(p),
+			angle(FLOATCONST(0.0)),
+			left_id(left_id),
+			right_id(right_id),
+			indicator(0)
+		{
+		}
+	};
+
+	typedef std::vector<ContourPoint> Contour;
+
+	struct ContactDescriptor
+	{
+		Contour contour;
+		SimpleSphere intersection_circle_sphere;
+		SimplePoint intersection_circle_axis;
+		SimplePoint contour_barycenter;
+		Float sum_of_arc_angles;
+		Float area;
+		Float solid_angle_a;
+		Float solid_angle_b;
+		Float pyramid_volume_a;
+		Float pyramid_volume_b;
+		Float distance;
+		UnsignedInt flags;
+		UnsignedInt id_a;
+		UnsignedInt id_b;
+
+		ContactDescriptor() :
+			sum_of_arc_angles(FLOATCONST(0.0)),
+			area(FLOATCONST(0.0)),
+			solid_angle_a(FLOATCONST(0.0)),
+			solid_angle_b(FLOATCONST(0.0)),
+			pyramid_volume_a(FLOATCONST(0.0)),
+			pyramid_volume_b(FLOATCONST(0.0)),
+			distance(FLOATCONST(0.0)),
+			flags(0),
+			id_a(0),
+			id_b(0)
+		{
+		}
+
+		void clear()
+		{
+			id_a=0;
+			id_b=0;
+			contour.clear();
+			sum_of_arc_angles=FLOATCONST(0.0);
+			area=FLOATCONST(0.0);
+			solid_angle_a=FLOATCONST(0.0);
+			solid_angle_b=FLOATCONST(0.0);
+			pyramid_volume_a=FLOATCONST(0.0);
+			pyramid_volume_b=FLOATCONST(0.0);
+			distance=FLOATCONST(0.0);
+			flags=0;
+		}
+	};
+
+	struct ContactDescriptorGraphics
+	{
+		std::vector<SimplePoint> outer_points;
+		SimplePoint barycenter;
+
+		ContactDescriptorGraphics()
+		{
+		}
+
+		void clear()
+		{
+			outer_points.clear();
+		}
+	};
+
+	static bool construct_contact_descriptor(
+			const std::vector<SimpleSphere>& spheres,
+			const std::vector<int>& spheres_exclusion_statuses,
+			const UnsignedInt a_id,
+			const UnsignedInt b_id,
+			const std::vector<UnsignedInt>& a_neighbor_collisions,
+			ContactDescriptor& result_contact_descriptor)
+	{
+		result_contact_descriptor.clear();
+		if(a_id<spheres.size() && b_id<spheres.size())
+		{
+			result_contact_descriptor.id_a=a_id;
+			result_contact_descriptor.id_b=b_id;
+			const SimpleSphere& a=spheres[a_id];
+			const SimpleSphere& b=spheres[b_id];
+			if(sphere_intersects_sphere(a, b) && !sphere_contains_sphere(a, b) && !sphere_contains_sphere(b, a))
+			{
+				result_contact_descriptor.intersection_circle_sphere=intersection_circle_of_two_spheres(a, b);
+				if(result_contact_descriptor.intersection_circle_sphere.r>FLOATCONST(0.0))
+				{
+					bool discarded=false;
+					bool contour_initialized=false;
+					bool nostop=true;
+					{
+						for(UnsignedInt i=0;i<a_neighbor_collisions.size() && !discarded && nostop;i++)
+						{
+							const UnsignedInt neighbor_id=a_neighbor_collisions[i];
+							if(neighbor_id!=b_id && (neighbor_id>=spheres_exclusion_statuses.size() || spheres_exclusion_statuses[neighbor_id]==0))
+							{
+								const SimpleSphere& c=spheres[neighbor_id];
+								if(sphere_intersects_sphere(result_contact_descriptor.intersection_circle_sphere, c) && sphere_intersects_sphere(b, c))
+								{
+									if(sphere_contains_sphere(c, a) || sphere_contains_sphere(c, b))
+									{
+										discarded=true;
+									}
+									else
+									{
+										const SimplePoint neighbor_ac_plane_center=center_of_intersection_circle_of_two_spheres(a, c);
+										const SimplePoint neighbor_ac_plane_normal=unit_point(sub_of_points(c.p, a.p));
+										const Float cos_val=dot_product(unit_point(sub_of_points(result_contact_descriptor.intersection_circle_sphere.p, a.p)), unit_point(sub_of_points(neighbor_ac_plane_center, a.p)));
+										if(std::abs(cos_val)<FLOATCONST(1.0))
+										{
+											const Float l=std::abs(signed_distance_from_point_to_plane(neighbor_ac_plane_center, neighbor_ac_plane_normal, result_contact_descriptor.intersection_circle_sphere.p));
+											const Float xl=l/std::sqrt(1-(cos_val*cos_val));
+											if(xl>=result_contact_descriptor.intersection_circle_sphere.r)
+											{
+												if(halfspace_of_point(neighbor_ac_plane_center, neighbor_ac_plane_normal, result_contact_descriptor.intersection_circle_sphere.p)>=0)
+												{
+													discarded=true;
+												}
+											}
+											else
+											{
+												if(!contour_initialized)
+												{
+													result_contact_descriptor.intersection_circle_axis=unit_point(sub_of_points(b.p, a.p));
+													init_contour_from_base_and_axis(a_id, result_contact_descriptor.intersection_circle_sphere, result_contact_descriptor.intersection_circle_axis, result_contact_descriptor.contour);
+													contour_initialized=true;
+												}
+												else
+												{
+													nostop=(test_if_contour_is_still_cuttable(a.p, neighbor_ac_plane_center, result_contact_descriptor.contour));
+												}
+												if(nostop)
+												{
+													mark_and_cut_contour(neighbor_ac_plane_center, neighbor_ac_plane_normal, neighbor_id, result_contact_descriptor.contour);
+													if(contour_initialized && result_contact_descriptor.contour.empty())
+													{
+														discarded=true;
+													}
+												}
+											}
+										}
+										else
+										{
+											if(halfspace_of_point(neighbor_ac_plane_center, neighbor_ac_plane_normal, result_contact_descriptor.intersection_circle_sphere.p)>0)
+											{
+												discarded=true;
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+					if(!discarded)
+					{
+						if(!contour_initialized)
+						{
+							result_contact_descriptor.intersection_circle_axis=unit_point(sub_of_points(b.p, a.p));
+							result_contact_descriptor.contour_barycenter=result_contact_descriptor.intersection_circle_sphere.p;
+							result_contact_descriptor.sum_of_arc_angles=(PIVALUE*FLOATCONST(2.0));
+							result_contact_descriptor.area=result_contact_descriptor.intersection_circle_sphere.r*result_contact_descriptor.intersection_circle_sphere.r*PIVALUE;
+						}
+						else
+						{
+							if(!result_contact_descriptor.contour.empty())
+							{
+								restrict_contour_to_circle(result_contact_descriptor.intersection_circle_sphere, result_contact_descriptor.intersection_circle_axis, a_id, result_contact_descriptor.contour, result_contact_descriptor.sum_of_arc_angles);
+								if(!result_contact_descriptor.contour.empty())
+								{
+									result_contact_descriptor.area=calculate_contour_area(result_contact_descriptor.intersection_circle_sphere, result_contact_descriptor.contour, result_contact_descriptor.contour_barycenter);
+								}
+							}
+						}
+
+						if(result_contact_descriptor.area>FLOATCONST(0.0))
+						{
+							result_contact_descriptor.solid_angle_a=calculate_contour_solid_angle(a, b, result_contact_descriptor.intersection_circle_sphere, result_contact_descriptor.contour);
+							result_contact_descriptor.solid_angle_b=calculate_contour_solid_angle(b, a, result_contact_descriptor.intersection_circle_sphere, result_contact_descriptor.contour);
+							result_contact_descriptor.pyramid_volume_a=distance_from_point_to_point(a.p, result_contact_descriptor.intersection_circle_sphere.p)*result_contact_descriptor.area/FLOATCONST(3.0)*(result_contact_descriptor.solid_angle_a<FLOATCONST(0.0) ? FLOATCONST(-1.0) : FLOATCONST(1.0));
+							result_contact_descriptor.pyramid_volume_b=distance_from_point_to_point(b.p, result_contact_descriptor.intersection_circle_sphere.p)*result_contact_descriptor.area/FLOATCONST(3.0)*(result_contact_descriptor.solid_angle_b<FLOATCONST(0.0) ? FLOATCONST(-1.0) : FLOATCONST(1.0));
+							result_contact_descriptor.flags=(check_if_contour_is_central(result_contact_descriptor.intersection_circle_sphere.p, result_contact_descriptor.contour, result_contact_descriptor.contour_barycenter) ? 1 : 0);
+						}
+
+						result_contact_descriptor.distance=distance_from_point_to_point(a.p, b.p);
+					}
+				}
+			}
+		}
+		return (result_contact_descriptor.area>FLOATCONST(0.0));
+	}
+
+	static bool construct_contact_descriptor_graphics(const ContactDescriptor& contact_descriptor, const Float length_step, ContactDescriptorGraphics& result_contact_descriptor_graphics)
+	{
+		result_contact_descriptor_graphics.clear();
+		if(contact_descriptor.area>FLOATCONST(0.0))
+		{
+			const Float angle_step=std::max(std::min(length_step/contact_descriptor.intersection_circle_sphere.r, PIVALUE/FLOATCONST(3.0)), PIVALUE/FLOATCONST(36.0));
+			if(contact_descriptor.contour.empty())
+			{
+				const SimplePoint first_point=point_and_number_product(any_normal_of_vector(contact_descriptor.intersection_circle_axis), contact_descriptor.intersection_circle_sphere.r);
+				result_contact_descriptor_graphics.outer_points.reserve(static_cast<int>((PIVALUE*FLOATCONST(2.0))/angle_step)+2);
+				result_contact_descriptor_graphics.outer_points.push_back(sum_of_points(contact_descriptor.intersection_circle_sphere.p, first_point));
+				for(Float rotation_angle=angle_step;rotation_angle<(PIVALUE*FLOATCONST(2.0));rotation_angle+=angle_step)
+				{
+					result_contact_descriptor_graphics.outer_points.push_back(sum_of_points(contact_descriptor.intersection_circle_sphere.p, rotate_point_around_axis(contact_descriptor.intersection_circle_axis, rotation_angle, first_point)));
+				}
+				result_contact_descriptor_graphics.barycenter=contact_descriptor.intersection_circle_sphere.p;
+			}
+			else
+			{
+				if(contact_descriptor.sum_of_arc_angles>FLOATCONST(0.0))
+				{
+					result_contact_descriptor_graphics.outer_points.reserve(static_cast<UnsignedInt>(contact_descriptor.sum_of_arc_angles/angle_step)+contact_descriptor.contour.size()+4);
+				}
+				else
+				{
+					result_contact_descriptor_graphics.outer_points.reserve(contact_descriptor.contour.size());
+				}
+				for(UnsignedInt i=0;i<contact_descriptor.contour.size();i++)
+				{
+					const ContourPoint& pr=contact_descriptor.contour[i];
+					result_contact_descriptor_graphics.outer_points.push_back(pr.p);
+					if(pr.angle>FLOATCONST(0.0))
+					{
+						if(pr.angle>angle_step)
+						{
+							const SimplePoint first_v=sub_of_points(pr.p, contact_descriptor.intersection_circle_sphere.p);
+							for(Float rotation_angle=angle_step;rotation_angle<pr.angle;rotation_angle+=angle_step)
+							{
+								result_contact_descriptor_graphics.outer_points.push_back(sum_of_points(contact_descriptor.intersection_circle_sphere.p, rotate_point_around_axis(contact_descriptor.intersection_circle_axis, rotation_angle, first_v)));
+							}
+						}
+					}
+				}
+				result_contact_descriptor_graphics.barycenter.x=FLOATCONST(0.0);
+				result_contact_descriptor_graphics.barycenter.y=FLOATCONST(0.0);
+				result_contact_descriptor_graphics.barycenter.z=FLOATCONST(0.0);
+				if(!result_contact_descriptor_graphics.outer_points.empty())
+				{
+					for(UnsignedInt i=0;i<result_contact_descriptor_graphics.outer_points.size();i++)
+					{
+						set_close_to_equal(result_contact_descriptor_graphics.outer_points[i].x, FLOATCONST(0.0));
+						set_close_to_equal(result_contact_descriptor_graphics.outer_points[i].y, FLOATCONST(0.0));
+						set_close_to_equal(result_contact_descriptor_graphics.outer_points[i].z, FLOATCONST(0.0));
+						result_contact_descriptor_graphics.barycenter.x+=result_contact_descriptor_graphics.outer_points[i].x;
+						result_contact_descriptor_graphics.barycenter.y+=result_contact_descriptor_graphics.outer_points[i].y;
+						result_contact_descriptor_graphics.barycenter.z+=result_contact_descriptor_graphics.outer_points[i].z;
+					}
+					result_contact_descriptor_graphics.barycenter.x/=static_cast<Float>(result_contact_descriptor_graphics.outer_points.size());
+					result_contact_descriptor_graphics.barycenter.y/=static_cast<Float>(result_contact_descriptor_graphics.outer_points.size());
+					result_contact_descriptor_graphics.barycenter.z/=static_cast<Float>(result_contact_descriptor_graphics.outer_points.size());
+				}
+			}
+		}
+		return (!result_contact_descriptor_graphics.outer_points.empty());
+	}
+
+private:
+	static void init_contour_from_base_and_axis(
+			const UnsignedInt a_id,
+			const SimpleSphere& base,
+			const SimplePoint& axis,
+			Contour& result)
+	{
+		const SimplePoint first_point=point_and_number_product(any_normal_of_vector(axis), base.r*FLOATCONST(1.19));
+		const Float angle_step=PIVALUE/FLOATCONST(3.0);
+		result.push_back(ContourPoint(sum_of_points(base.p, first_point), a_id, a_id));
+		for(Float rotation_angle=angle_step;rotation_angle<(PIVALUE*FLOATCONST(2.0));rotation_angle+=angle_step)
+		{
+			result.push_back(ContourPoint(sum_of_points(base.p, rotate_point_around_axis(axis, rotation_angle, first_point)), a_id, a_id));
+		}
+	}
+
+	static bool mark_and_cut_contour(
+			const SimplePoint& ac_plane_center,
+			const SimplePoint& ac_plane_normal,
+			const UnsignedInt c_id,
+			Contour& contour)
+	{
+		const UnsignedInt outsiders_count=mark_contour(ac_plane_center, ac_plane_normal, c_id, contour);
+		if(outsiders_count>0)
+		{
+			if(outsiders_count<contour.size())
+			{
+				cut_contour(ac_plane_center, ac_plane_normal, c_id, contour);
+			}
+			else
+			{
+				contour.clear();
+			}
+			return true;
+		}
+		return false;
+	}
+
+	static UnsignedInt mark_contour(
+			const SimplePoint& ac_plane_center,
+			const SimplePoint& ac_plane_normal,
+			const UnsignedInt c_id,
+			Contour& contour)
+	{
+		UnsignedInt outsiders_count=0;
+		for(Contour::iterator it=contour.begin();it!=contour.end();++it)
+		{
+			if(halfspace_of_point(ac_plane_center, ac_plane_normal, it->p)>=0)
+			{
+				it->left_id=c_id;
+				it->right_id=c_id;
+				outsiders_count++;
+			}
+		}
+		return outsiders_count;
+	}
+
+	static void cut_contour(
+			const SimplePoint& ac_plane_center,
+			const SimplePoint& ac_plane_normal,
+			const UnsignedInt c_id,
+			Contour& contour)
+	{
+		if(contour.size()<3)
+		{
+			return;
+		}
+
+		UnsignedInt i_start=0;
+		while(i_start<contour.size() && !(contour[i_start].left_id==c_id && contour[i_start].right_id==c_id))
+		{
+			i_start++;
+		}
+
+		if(i_start>=contour.size())
+		{
+			return;
+		}
+
+		UnsignedInt i_end=(contour.size()-1);
+		while(i_end>0 && !(contour[i_end].left_id==c_id && contour[i_end].right_id==c_id))
+		{
+			i_end--;
+		}
+
+		if(i_start==0 && i_end==(contour.size()-1))
+		{
+			i_end=0;
+			while((i_end+1)<contour.size() && contour[i_end+1].left_id==c_id && contour[i_end+1].right_id==c_id)
+			{
+				i_end++;
+			}
+
+			i_start=(contour.size()-1);
+			while(i_start>0 && contour[i_start-1].left_id==c_id && contour[i_start-1].right_id==c_id)
+			{
+				i_start--;
+			}
+		}
+
+		if(i_start==i_end)
+		{
+			contour.insert(contour.begin()+i_start, contour[i_start]);
+			i_end=i_start+1;
+		}
+		else if(i_start<i_end)
+		{
+			if(i_start+1<i_end)
+			{
+				contour.erase(contour.begin()+i_start+1, contour.begin()+i_end);
+			}
+			i_end=i_start+1;
+		}
+		else if(i_start>i_end)
+		{
+			if(i_start+1<contour.size())
+			{
+				contour.erase(contour.begin()+i_start+1, contour.end());
+			}
+			if(i_end>0)
+			{
+				contour.erase(contour.begin(), contour.begin()+i_end);
+
+			}
+			i_start=contour.size()-1;
+			i_end=0;
+		}
+
+		{
+			const UnsignedInt i_left=((i_start)>0 ? (i_start-1) : (contour.size()-1));
+			contour[i_start]=ContourPoint(intersection_of_plane_and_segment(ac_plane_center, ac_plane_normal, contour[i_start].p, contour[i_left].p), contour[i_left].right_id, contour[i_start].left_id);
+		}
+
+		{
+			const UnsignedInt i_right=((i_end+1)<contour.size() ? (i_end+1) : 0);
+			contour[i_end]=ContourPoint(intersection_of_plane_and_segment(ac_plane_center, ac_plane_normal, contour[i_end].p, contour[i_right].p), contour[i_end].right_id, contour[i_right].left_id);
+		}
+
+		if(!greater(squared_distance_from_point_to_point(contour[i_start].p, contour[i_end].p), FLOATCONST(0.0)))
+		{
+			contour[i_start].right_id=contour[i_end].right_id;
+			contour.erase(contour.begin()+i_end);
+		}
+	}
+
+	static bool test_if_contour_is_still_cuttable(const SimplePoint& a_center, const SimplePoint& closest_possible_cut_point, const Contour& contour)
+	{
+		bool cuttable=false;
+		const Float dist_threshold=squared_distance_from_point_to_point(a_center, closest_possible_cut_point);
+		for(UnsignedInt i=0;!cuttable && i<contour.size();i++)
+		{
+			cuttable=squared_distance_from_point_to_point(a_center, contour[i].p)>=dist_threshold;
+		}
+		return cuttable;
+	}
+
+	static bool restrict_contour_to_circle(
+			const SimpleSphere& ic_sphere,
+			const SimplePoint& ic_axis,
+			const UnsignedInt a_id,
+			Contour& contour,
+			Float& sum_of_arc_angles)
+	{
+		UnsignedInt outsiders_count=0;
+		for(UnsignedInt i=0;i<contour.size();i++)
+		{
+			if(squared_distance_from_point_to_point(contour[i].p, ic_sphere.p)<=(ic_sphere.r*ic_sphere.r))
+			{
+				contour[i].indicator=0;
+			}
+			else
+			{
+				contour[i].indicator=1;
+				outsiders_count++;
+			}
+		}
+
+		if(outsiders_count>0)
+		{
+			UnsignedInt insertions_count=0;
+			{
+				UnsignedInt i=0;
+				while(i<contour.size())
+				{
+					ContourPoint& pr1=contour[i];
+					ContourPoint& pr2=contour[(i+1)<contour.size() ? (i+1) : 0];
+					if(pr1.indicator==1 || pr2.indicator==1)
+					{
+						if(pr1.indicator==1 && pr2.indicator==1)
+						{
+							SimplePoint mp;
+							if(project_point_inside_line(ic_sphere.p, pr1.p, pr2.p, mp))
+							{
+								if(squared_distance_from_point_to_point(mp, ic_sphere.p)<=(ic_sphere.r*ic_sphere.r))
+								{
+									SimplePoint ip1;
+									SimplePoint ip2;
+									if(intersect_segment_with_circle(ic_sphere, mp, pr1.p, ip1) && intersect_segment_with_circle(ic_sphere, mp, pr2.p, ip2))
+									{
+										const UnsignedInt pr2_left_id=pr2.left_id;
+										contour.insert(((i+1)<contour.size() ? (contour.begin()+(i+1)) : contour.end()), 2, ContourPoint(ip1, a_id, pr1.right_id));
+										contour[i+2]=ContourPoint(ip2, pr2_left_id, a_id);
+										insertions_count+=2;
+										i+=2;
+									}
+								}
+							}
+						}
+						else
+						{
+							if(pr1.indicator==1 && pr2.indicator!=1)
+							{
+								SimplePoint ip;
+								if(intersect_segment_with_circle(ic_sphere, pr2.p, pr1.p, ip))
+								{
+									contour.insert(((i+1)<contour.size() ? (contour.begin()+(i+1)) : contour.end()), ContourPoint(ip, a_id, pr1.right_id));
+									insertions_count++;
+									i++;
+								}
+								else
+								{
+									pr2.left_id=a_id;
+									pr2.right_id=pr1.right_id;
+								}
+							}
+							else if(pr1.indicator!=1 && pr2.indicator==1)
+							{
+								SimplePoint ip;
+								if(intersect_segment_with_circle(ic_sphere, pr1.p, pr2.p, ip))
+								{
+									contour.insert(((i+1)<contour.size() ? (contour.begin()+(i+1)) : contour.end()), ContourPoint(ip, pr2.left_id, a_id));
+									insertions_count++;
+									i++;
+								}
+								else
+								{
+									pr1.left_id=pr2.left_id;
+									pr1.right_id=a_id;
+								}
+							}
+						}
+					}
+					i++;
+				}
+			}
+			if(insertions_count==0)
+			{
+				contour.clear();
+			}
+			else if(!contour.empty())
+			{
+				{
+					UnsignedInt i=(contour.size()-1);
+					while(i<contour.size())
+					{
+						if(contour[i].indicator==1)
+						{
+							contour.erase(contour.begin()+i);
+						}
+						i=(i>0 ? (i-1) : contour.size());
+					}
+				}
+				if(contour.size()<2)
+				{
+					contour.clear();
+				}
+				{
+					UnsignedInt i=0;
+					while(i<contour.size())
+					{
+						ContourPoint& pr1=contour[i];
+						ContourPoint& pr2=contour[(i+1)<contour.size() ? (i+1) : 0];
+						if(pr1.right_id==a_id && pr2.left_id==a_id)
+						{
+							pr1.angle=directed_angle(ic_sphere.p, pr1.p, pr2.p, sum_of_points(ic_sphere.p, ic_axis));
+							sum_of_arc_angles+=pr1.angle;
+							pr1.indicator=2;
+							pr2.indicator=3;
+						}
+						i++;
+					}
+				}
+			}
+		}
+
+		return (outsiders_count>0);
+	}
+
+	static Float calculate_contour_area(const SimpleSphere& ic_sphere, const Contour& contour, SimplePoint& contour_barycenter)
+	{
+		Float area=FLOATCONST(0.0);
+
+		contour_barycenter.x=FLOATCONST(0.0);
+		contour_barycenter.y=FLOATCONST(0.0);
+		contour_barycenter.z=FLOATCONST(0.0);
+		for(UnsignedInt i=0;i<contour.size();i++)
+		{
+			contour_barycenter.x+=contour[i].p.x;
+			contour_barycenter.y+=contour[i].p.y;
+			contour_barycenter.z+=contour[i].p.z;
+		}
+		contour_barycenter.x/=static_cast<Float>(contour.size());
+		contour_barycenter.y/=static_cast<Float>(contour.size());
+		contour_barycenter.z/=static_cast<Float>(contour.size());
+
+		for(UnsignedInt i=0;i<contour.size();i++)
+		{
+			const ContourPoint& pr1=contour[i];
+			const ContourPoint& pr2=contour[(i+1)<contour.size() ? (i+1) : 0];
+			area+=triangle_area(contour_barycenter, pr1.p, pr2.p);
+			if(pr1.angle>FLOATCONST(0.0))
+			{
+				area+=ic_sphere.r*ic_sphere.r*(pr1.angle-std::sin(pr1.angle))*0.5;
+			}
+		}
+
+		return area;
+	}
+
+	static Float calculate_contour_solid_angle(const SimpleSphere& a, const SimpleSphere& b, const SimpleSphere& ic_sphere, const Contour& contour)
+	{
+		Float turn_angle=FLOATCONST(0.0);
+
+		if(!contour.empty())
+		{
+			for(UnsignedInt i=0;i<contour.size();i++)
+			{
+				const ContourPoint& pr0=contour[(i>0) ? (i-1) : (contour.size()-1)];
+				const ContourPoint& pr1=contour[i];
+				const ContourPoint& pr2=contour[(i+1)<contour.size() ? (i+1) : 0];
+
+				if(pr0.angle>FLOATCONST(0.0))
+				{
+					SimplePoint d=cross_product(sub_of_points(b.p, a.p), sub_of_points(pr1.p, ic_sphere.p));
+					if((pr0.angle<PIVALUE && dot_product(d, sub_of_points(pr0.p, pr1.p))<FLOATCONST(0.0)) || (pr0.angle>PIVALUE && dot_product(d, sub_of_points(pr0.p, pr1.p))>FLOATCONST(0.0)))
+					{
+						d=point_and_number_product(d, FLOATCONST(-1.0));
+					}
+					turn_angle+=(PIVALUE-min_dihedral_angle(a.p, pr1.p, sum_of_points(pr1.p, d), pr2.p));
+				}
+				else if(pr1.angle>FLOATCONST(0.0))
+				{
+					SimplePoint d=cross_product(sub_of_points(b.p, a.p), sub_of_points(pr1.p, ic_sphere.p));
+					if((pr1.angle<PIVALUE && dot_product(d, sub_of_points(pr2.p, pr1.p))<FLOATCONST(0.0)) || (pr1.angle>PIVALUE && dot_product(d, sub_of_points(pr2.p, pr1.p))>FLOATCONST(0.0)))
+					{
+						d=point_and_number_product(d, FLOATCONST(-1.0));
+					}
+					turn_angle+=(PIVALUE-min_dihedral_angle(a.p, pr1.p, pr0.p, sum_of_points(pr1.p, d)));
+					turn_angle+=pr1.angle*(distance_from_point_to_point(a.p, ic_sphere.p)/a.r);
+				}
+				else
+				{
+					turn_angle+=(PIVALUE-min_dihedral_angle(a.p, pr1.p, pr0.p, pr2.p));
+				}
+			}
+		}
+		else
+		{
+			turn_angle=(PIVALUE*FLOATCONST(2.0))*(distance_from_point_to_point(a.p, ic_sphere.p)/a.r);
+		}
+
+		Float solid_angle=((PIVALUE*FLOATCONST(2.0))-turn_angle);
+
+		if(dot_product(sub_of_points(ic_sphere.p, a.p), sub_of_points(ic_sphere.p, b.p))>FLOATCONST(0.0) && squared_distance_from_point_to_point(ic_sphere.p, a.p)<squared_distance_from_point_to_point(ic_sphere.p, b.p))
+		{
+			solid_angle=(FLOATCONST(0.0)-solid_angle);
+		}
+
+		return solid_angle;
+	}
+
+	static bool check_if_contour_is_central(const SimplePoint& center, const Contour& contour, const SimplePoint& contour_barycenter)
+	{
+		bool central=true;
+		for(UnsignedInt i=0;i<contour.size() && central;i++)
+		{
+			const UnsignedInt j=((i+1)<contour.size() ? (i+1) : 0);
+			const SimplePoint sidepoint=point_and_number_product(sum_of_points(contour[i].p, contour[j].p), FLOATCONST(0.5));
+			if(dot_product(sub_of_points(contour_barycenter, sidepoint), sub_of_points(center, sidepoint))<FLOATCONST(0.0))
+			{
+				central=false;
+			}
+		}
+		return central;
+	}
+};
+
+}
+
+#endif /* VORONOTALT_RADICAL_TESSELLATION_CONTACT_CONSTRUCTION_H_ */

--- a/src/voronotalt/simplified_aw_tessellation.h
+++ b/src/voronotalt/simplified_aw_tessellation.h
@@ -1,0 +1,300 @@
+#ifndef VORONOTALT_SIMPLIFIED_AW_TESSELLATION_H_
+#define VORONOTALT_SIMPLIFIED_AW_TESSELLATION_H_
+
+#include <map>
+
+#include "preparation_for_tessellation.h"
+#include "simplified_aw_tessellation_contact_construction.h"
+#include "time_recorder.h"
+
+namespace voronotalt
+{
+
+class SimplifiedAWTessellation
+{
+public:
+	struct ContactDescriptorSummary
+	{
+		Float area;
+		Float arc_length;
+		Float distance;
+		UnsignedInt id_a;
+		UnsignedInt id_b;
+
+		ContactDescriptorSummary() :
+			area(FLOATCONST(0.0)),
+			arc_length(FLOATCONST(0.0)),
+			distance(FLOATCONST(0.0)),
+			id_a(0),
+			id_b(0)
+		{
+		}
+
+		void set(const SimplifiedAWTessellationContactConstruction::ContactDescriptor& cd)
+		{
+			if(cd.area>FLOATCONST(0.0))
+			{
+				id_a=cd.id_a;
+				id_b=cd.id_b;
+				area=cd.area;
+				arc_length=cd.arc_length;
+				distance=cd.distance;
+			}
+		}
+
+		void ensure_ids_ordered()
+		{
+			if(id_a>id_b)
+			{
+				std::swap(id_a, id_b);
+			}
+		}
+	};
+
+	struct TotalContactDescriptorsSummary
+	{
+		Float area;
+		Float arc_length;
+		Float distance;
+		UnsignedInt count;
+
+		TotalContactDescriptorsSummary() :
+			area(FLOATCONST(0.0)),
+			arc_length(FLOATCONST(0.0)),
+			distance(FLOATCONST(-1.0)),
+			count(0)
+		{
+		}
+
+		void add(const ContactDescriptorSummary& cds)
+		{
+			if(cds.area>FLOATCONST(0.0))
+			{
+				count++;
+				area+=cds.area;
+				arc_length+=cds.arc_length;
+				distance=((distance<FLOATCONST(0.0)) ? cds.distance : std::min(distance, cds.distance));
+			}
+		}
+	};
+
+	struct Result
+	{
+		UnsignedInt total_spheres;
+		UnsignedInt total_collisions;
+		UnsignedInt total_relevant_collisions;
+		std::vector<ContactDescriptorSummary> contacts_summaries;
+		TotalContactDescriptorsSummary total_contacts_summary;
+
+		Result() : total_spheres(0), total_collisions(0), total_relevant_collisions(0)
+		{
+		}
+	};
+
+	struct ResultGraphics
+	{
+		std::vector<SimplifiedAWTessellationContactConstruction::ContactDescriptorGraphics> contacts_graphics;
+	};
+
+	struct GroupedResult
+	{
+		std::vector<UnsignedInt> grouped_contacts_representative_ids;
+		std::vector<TotalContactDescriptorsSummary> grouped_contacts_summaries;
+	};
+
+	static void construct_full_tessellation(
+			const std::vector<SimpleSphere>& spheres,
+			Result& result)
+	{
+		TimeRecorder time_recorder;
+		ResultGraphics result_graphics;
+		construct_full_tessellation(spheres, std::vector<int>(), false, result, result_graphics, time_recorder);
+	}
+
+	static void construct_full_tessellation(
+			const std::vector<SimpleSphere>& spheres,
+			const std::vector<int>& grouping_of_spheres,
+			const bool with_graphics,
+			Result& result,
+			ResultGraphics& result_graphics,
+			TimeRecorder& time_recorder)
+	{
+		PreparationForTessellation::Result preparation_result;
+		PreparationForTessellation::prepare_for_tessellation(spheres, grouping_of_spheres, preparation_result, time_recorder);
+		construct_full_tessellation(spheres, preparation_result, with_graphics, result, result_graphics, time_recorder);
+	}
+
+	static void construct_full_tessellation(
+			const std::vector<SimpleSphere>& spheres,
+			const PreparationForTessellation::Result& preparation_result,
+			const bool with_graphics,
+			Result& result,
+			ResultGraphics& result_graphics,
+			TimeRecorder& time_recorder)
+	{
+		time_recorder.reset();
+
+		result=Result();
+		result_graphics=ResultGraphics();
+
+		result.total_spheres=preparation_result.total_spheres;
+		result.total_collisions=preparation_result.total_collisions;
+		result.total_relevant_collisions=preparation_result.relevant_collision_ids.size();
+
+		std::vector<ContactDescriptorSummary> possible_contacts_summaries(preparation_result.relevant_collision_ids.size());
+
+		std::vector<SimplifiedAWTessellationContactConstruction::ContactDescriptorGraphics> possible_contacts_graphics;
+		if(with_graphics)
+		{
+			possible_contacts_graphics.resize(possible_contacts_summaries.size());
+		}
+
+		time_recorder.record_elapsed_miliseconds_and_reset("allocate possible contact summaries");
+
+		#pragma omp parallel
+		{
+			SimplifiedAWTessellationContactConstruction::ContactDescriptor cd;
+			cd.neighbor_descriptors.reserve(24);
+
+			#pragma omp for
+			for(UnsignedInt i=0;i<preparation_result.relevant_collision_ids.size();i++)
+			{
+				const UnsignedInt id_a=preparation_result.relevant_collision_ids[i].first;
+				const UnsignedInt id_b=preparation_result.relevant_collision_ids[i].second;
+				if(SimplifiedAWTessellationContactConstruction::construct_contact_descriptor(spheres, preparation_result.all_exclusion_statuses, id_a, id_b, preparation_result.all_colliding_ids[id_a], 0.2, 5, with_graphics, cd))
+				{
+					possible_contacts_summaries[i].set(cd);
+					if(with_graphics)
+					{
+						possible_contacts_graphics[i]=cd.graphics;
+					}
+				}
+			}
+		}
+
+		time_recorder.record_elapsed_miliseconds_and_reset("construct contacts");
+
+		UnsignedInt number_of_valid_contact_summaries=0;
+		for(UnsignedInt i=0;i<possible_contacts_summaries.size();i++)
+		{
+			if(possible_contacts_summaries[i].area>FLOATCONST(0.0))
+			{
+				number_of_valid_contact_summaries++;
+			}
+		}
+
+		time_recorder.record_elapsed_miliseconds_and_reset("count valid contact summaries");
+
+		std::vector<UnsignedInt> ids_of_valid_pairs;
+		ids_of_valid_pairs.reserve(number_of_valid_contact_summaries);
+
+		for(UnsignedInt i=0;i<possible_contacts_summaries.size();i++)
+		{
+			if(possible_contacts_summaries[i].area>FLOATCONST(0.0))
+			{
+				ids_of_valid_pairs.push_back(i);
+			}
+		}
+
+		time_recorder.record_elapsed_miliseconds_and_reset("collect indices of valid contact summaries");
+
+		result.contacts_summaries.resize(ids_of_valid_pairs.size());
+
+		#pragma omp parallel
+		{
+			#pragma omp for
+			for(UnsignedInt i=0;i<ids_of_valid_pairs.size();i++)
+			{
+				result.contacts_summaries[i]=possible_contacts_summaries[ids_of_valid_pairs[i]];
+				result.contacts_summaries[i].ensure_ids_ordered();
+			}
+		}
+
+		time_recorder.record_elapsed_miliseconds_and_reset("copy valid contact summaries");
+
+		for(UnsignedInt i=0;i<result.contacts_summaries.size();i++)
+		{
+			result.total_contacts_summary.add(result.contacts_summaries[i]);
+		}
+
+		time_recorder.record_elapsed_miliseconds_and_reset("accumulate total contacts summary");
+
+		if(with_graphics)
+		{
+			result_graphics.contacts_graphics.resize(ids_of_valid_pairs.size());
+
+			for(UnsignedInt i=0;i<ids_of_valid_pairs.size();i++)
+			{
+				result_graphics.contacts_graphics[i]=possible_contacts_graphics[ids_of_valid_pairs[i]];
+			}
+		}
+
+		time_recorder.record_elapsed_miliseconds_and_reset("copy valid contacts graphics");
+	}
+
+	static bool group_results(
+			const Result& full_result,
+			const std::vector<int>& grouping_of_spheres,
+			GroupedResult& grouped_result)
+	{
+		TimeRecorder time_recorder;
+		return group_results(full_result, grouping_of_spheres, grouped_result, time_recorder);
+	}
+
+	static bool group_results(
+			const Result& full_result,
+			const std::vector<int>& grouping_of_spheres,
+			GroupedResult& grouped_result,
+			TimeRecorder& time_recorder)
+	{
+		time_recorder.reset();
+
+		grouped_result=GroupedResult();
+
+		if(!grouping_of_spheres.empty() && grouping_of_spheres.size()==full_result.total_spheres)
+		{
+			grouped_result.grouped_contacts_representative_ids.reserve(full_result.contacts_summaries.size()/5);
+			grouped_result.grouped_contacts_summaries.reserve(full_result.contacts_summaries.size()/5);
+
+			std::map< std::pair<int, int>, UnsignedInt > map_of_groups;
+
+			for(UnsignedInt i=0;i<full_result.contacts_summaries.size();i++)
+			{
+				const ContactDescriptorSummary& cds=full_result.contacts_summaries[i];
+				if(cds.id_a<grouping_of_spheres.size() && cds.id_b<grouping_of_spheres.size())
+				{
+					std::pair<int, int> group_id(grouping_of_spheres[cds.id_a], grouping_of_spheres[cds.id_b]);
+					if(group_id.first!=group_id.second)
+					{
+						if(group_id.first>group_id.second)
+						{
+							std::swap(group_id.first, group_id.second);
+						}
+						UnsignedInt group_index=0;
+						std::map< std::pair<int, int>, UnsignedInt >::const_iterator it=map_of_groups.find(group_id);
+						if(it==map_of_groups.end())
+						{
+							group_index=grouped_result.grouped_contacts_summaries.size();
+							grouped_result.grouped_contacts_representative_ids.push_back(i);
+							grouped_result.grouped_contacts_summaries.push_back(TotalContactDescriptorsSummary());
+							map_of_groups[group_id]=group_index;
+						}
+						else
+						{
+							group_index=it->second;
+						}
+						grouped_result.grouped_contacts_summaries[group_index].add(cds);
+					}
+				}
+			}
+
+			time_recorder.record_elapsed_miliseconds_and_reset("grouped contacts summaries");
+		}
+
+		return (!grouped_result.grouped_contacts_summaries.empty());
+	}
+};
+
+}
+
+#endif /* VORONOTALT_SIMPLIFIED_AW_TESSELLATION_H_ */

--- a/src/voronotalt/simplified_aw_tessellation_contact_construction.h
+++ b/src/voronotalt/simplified_aw_tessellation_contact_construction.h
@@ -1,0 +1,782 @@
+#ifndef VORONOTALT_SIMPLIFIED_AW_TESSELLATION_CONTACT_CONSTRUCTION_H_
+#define VORONOTALT_SIMPLIFIED_AW_TESSELLATION_CONTACT_CONSTRUCTION_H_
+
+#include <vector>
+#include <list>
+#include <algorithm>
+
+#include "basic_types_and_functions.h"
+
+namespace voronotalt
+{
+
+class SimplifiedAWTessellationContactConstruction
+{
+public:
+	struct ContourPoint
+	{
+		SimplePoint p;
+		UnsignedInt left_id;
+		UnsignedInt right_id;
+
+		ContourPoint(const SimplePoint& p, const UnsignedInt left_id, const UnsignedInt right_id) : p(p), left_id(left_id), right_id(right_id)
+		{
+		}
+	};
+
+	typedef std::list<ContourPoint> Contour;
+
+	struct NeighborDescriptor
+	{
+		Float sort_value;
+		UnsignedInt neighbor_id;
+
+		NeighborDescriptor() : sort_value(FLOATCONST(0.0)), neighbor_id(0)
+		{
+		}
+
+		bool operator<(const NeighborDescriptor& d) const
+		{
+			return (sort_value<d.sort_value || (sort_value==d.sort_value && neighbor_id<d.neighbor_id));
+		}
+	};
+
+	struct ContourGraphics
+	{
+		std::vector<SimplePoint> outer_points;
+		SimplePoint barycenter;
+	};
+
+	struct ContactDescriptorGraphics
+	{
+		std::vector<ContourGraphics> contours_graphics;
+
+		ContactDescriptorGraphics()
+		{
+		}
+
+		void clear()
+		{
+			contours_graphics.clear();
+		}
+	};
+
+	struct ContactDescriptor
+	{
+		std::list<Contour> contours;
+		std::vector<NeighborDescriptor> neighbor_descriptors;
+		ContactDescriptorGraphics graphics;
+		SimpleSphere intersection_circle_sphere;
+		SimplePoint intersection_circle_axis;
+		Float area;
+		Float arc_length;
+		Float distance;
+		UnsignedInt id_a;
+		UnsignedInt id_b;
+
+		ContactDescriptor() :
+			area(FLOATCONST(0.0)),
+			arc_length(FLOATCONST(0.0)),
+			distance(FLOATCONST(0.0)),
+			id_a(0),
+			id_b(0)
+		{
+		}
+
+		void clear()
+		{
+			id_a=0;
+			id_b=0;
+			neighbor_descriptors.clear();
+			contours.clear();
+			graphics.clear();
+			area=FLOATCONST(0.0);
+			arc_length=FLOATCONST(0.0);
+			distance=FLOATCONST(0.0);
+		}
+	};
+
+	static bool construct_contact_descriptor(
+			const std::vector<SimpleSphere>& spheres,
+			const std::vector<int>& spheres_exclusion_statuses,
+			const UnsignedInt a_id,
+			const UnsignedInt b_id,
+			const std::vector<UnsignedInt>& a_neighbor_collisions,
+			const Float step,
+			const int projections,
+			const bool record_graphics,
+			ContactDescriptor& result_contact_descriptor)
+	{
+		result_contact_descriptor.clear();
+		if(a_id<spheres.size() && b_id<spheres.size())
+		{
+			result_contact_descriptor.id_a=a_id;
+			result_contact_descriptor.id_b=b_id;
+			const SimpleSphere& a=spheres[a_id];
+			const SimpleSphere& b=spheres[b_id];
+			if(sphere_intersects_sphere(a, b) && !sphere_contains_sphere(a, b) && !sphere_contains_sphere(b, a))
+			{
+				result_contact_descriptor.intersection_circle_sphere=intersection_circle_of_two_spheres(a, b);
+				if(result_contact_descriptor.intersection_circle_sphere.r>FLOATCONST(0.0))
+				{
+					bool discarded=false;
+					{
+						for(UnsignedInt i=0;i<a_neighbor_collisions.size() && !discarded;i++)
+						{
+							const UnsignedInt neighbor_id=a_neighbor_collisions[i];
+							if(neighbor_id!=b_id && (neighbor_id>=spheres_exclusion_statuses.size() || spheres_exclusion_statuses[neighbor_id]==0))
+							{
+								const SimpleSphere& c=spheres[neighbor_id];
+								if(sphere_intersects_sphere(result_contact_descriptor.intersection_circle_sphere, c) && sphere_intersects_sphere(b, c))
+								{
+									if(sphere_contains_sphere(c, a) || sphere_contains_sphere(c, b))
+									{
+										discarded=true;
+									}
+									else
+									{
+										const SimplePoint nd_ac_plane_center=center_of_intersection_circle_of_two_spheres(a, c);
+										const Float dist_from_a_center_to_c_center=distance_from_point_to_point(a.p, c.p);
+										const SimplePoint nd_ac_plane_normal=point_and_number_product(sub_of_points(c.p, a.p), FLOATCONST(1.0)/dist_from_a_center_to_c_center);
+										const Float dist_from_a_center_to_nd_ac_plane_center=distance_from_point_to_point(a.p, nd_ac_plane_center);
+										const Float cos_val=dot_product(unit_point(sub_of_points(result_contact_descriptor.intersection_circle_sphere.p, a.p)), point_and_number_product(sub_of_points(nd_ac_plane_center, a.p), FLOATCONST(1.0)/dist_from_a_center_to_nd_ac_plane_center));
+										const int hsi=halfspace_of_point(nd_ac_plane_center, nd_ac_plane_normal, result_contact_descriptor.intersection_circle_sphere.p);
+										if(std::abs(cos_val)<FLOATCONST(1.0))
+										{
+											const Float l=std::abs(signed_distance_from_point_to_plane(nd_ac_plane_center, nd_ac_plane_normal, result_contact_descriptor.intersection_circle_sphere.p));
+											const Float xl=l/std::sqrt(1-(cos_val*cos_val));
+											const Float dist_from_a_to_midpoint=a.r+((dist_from_a_center_to_c_center-a.r-c.r)/FLOATCONST(2.0));
+											const Float xl_buffer=std::abs(dist_from_a_to_midpoint-dist_from_a_center_to_nd_ac_plane_center);
+											if(xl>=(result_contact_descriptor.intersection_circle_sphere.r+xl_buffer))
+											{
+												if(hsi>=0)
+												{
+													discarded=true;
+												}
+											}
+											else
+											{
+												NeighborDescriptor nd;
+												nd.neighbor_id=neighbor_id;
+												nd.sort_value=(hsi>0 ? (FLOATCONST(0.0)-xl) : xl);
+												result_contact_descriptor.neighbor_descriptors.push_back(nd);
+											}
+										}
+										else
+										{
+											if(hsi>0)
+											{
+												discarded=true;
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+					if(!discarded)
+					{
+						result_contact_descriptor.intersection_circle_axis=unit_point(sub_of_points(b.p, a.p));
+
+						{
+							Contour initial_contour;
+							init_contour_from_base_and_axis(a_id, result_contact_descriptor.intersection_circle_sphere, result_contact_descriptor.intersection_circle_axis, step, initial_contour);
+							if(!initial_contour.empty())
+							{
+								result_contact_descriptor.contours.push_back(initial_contour);
+							}
+						}
+
+						if(!result_contact_descriptor.neighbor_descriptors.empty())
+						{
+							if(!result_contact_descriptor.contours.empty())
+							{
+								std::sort(result_contact_descriptor.neighbor_descriptors.begin(), result_contact_descriptor.neighbor_descriptors.end());
+								for(UnsignedInt i=0;i<result_contact_descriptor.neighbor_descriptors.size();i++)
+								{
+									const UnsignedInt c_id=result_contact_descriptor.neighbor_descriptors[i].neighbor_id;
+									const SimpleSphere& c=spheres[c_id];
+									std::list<Contour>::iterator jt=result_contact_descriptor.contours.begin();
+									while(jt!=result_contact_descriptor.contours.end())
+									{
+										Contour& contour=(*jt);
+										std::list<Contour> segments;
+										if(cut_and_split_contour(a, c, c_id, contour, segments))
+										{
+											if(!contour.empty())
+											{
+												mend_contour(a, b, c, c_id, step, projections, contour);
+												if(check_contour_intersects_sphere(result_contact_descriptor.intersection_circle_sphere, contour))
+												{
+													++jt;
+												}
+												else
+												{
+													jt=result_contact_descriptor.contours.erase(jt);
+												}
+											}
+											else
+											{
+												if(!segments.empty())
+												{
+													for(std::list<Contour>::iterator st=segments.begin();st!=segments.end();++st)
+													{
+														mend_contour(a, b, c, c_id, step, projections, (*st));
+													}
+													filter_contours_intersecting_sphere(result_contact_descriptor.intersection_circle_sphere, segments);
+													if(!segments.empty())
+													{
+														result_contact_descriptor.contours.splice(jt, segments);
+													}
+												}
+												jt=result_contact_descriptor.contours.erase(jt);
+											}
+										}
+										else
+										{
+											++jt;
+										}
+									}
+								}
+							}
+
+							if(!result_contact_descriptor.contours.empty())
+							{
+								const Float tolerated_deviation=FLOATCONST(0.5);
+								bool strangely_extended=false;
+								for(std::list<Contour>::const_iterator it=result_contact_descriptor.contours.begin();it!=result_contact_descriptor.contours.end() && !strangely_extended;++it)
+								{
+									const Contour& contour=(*it);
+									for(Contour::const_iterator jt=contour.begin();jt!=contour.end() && !strangely_extended;++jt)
+									{
+										strangely_extended=strangely_extended || (distance_from_point_to_point(jt->p, a.p)-a.r>tolerated_deviation);
+										strangely_extended=strangely_extended || (distance_from_point_to_point(jt->p, b.p)-b.r>tolerated_deviation);
+									}
+								}
+								if(strangely_extended)
+								{
+									SimplePoint safe_center=point_and_number_product(sum_of_points(a.p, b.p), FLOATCONST(0.5));
+									std::list<Contour> forcibly_shrunk_result=result_contact_descriptor.contours;
+									for(std::list<Contour>::iterator it=forcibly_shrunk_result.begin();it!=forcibly_shrunk_result.end();++it)
+									{
+										Contour& contour=(*it);
+										for(Contour::iterator jt=contour.begin();jt!=contour.end();++jt)
+										{
+											if((distance_from_point_to_point(jt->p, a.p)-a.r>tolerated_deviation) || (distance_from_point_to_point(jt->p, b.p)-b.r>tolerated_deviation))
+											{
+												jt->p=sum_of_points(safe_center, point_and_number_product(unit_point(sub_of_points(jt->p, safe_center)), std::min(a.r, b.r)));
+											}
+										}
+									}
+									result_contact_descriptor.contours.swap(forcibly_shrunk_result);
+								}
+							}
+						}
+
+						if(!result_contact_descriptor.contours.empty())
+						{
+							for(std::list<Contour>::const_iterator it=result_contact_descriptor.contours.begin();it!=result_contact_descriptor.contours.end();++it)
+							{
+								const Contour& contour=(*it);
+								SimplePoint barycenter;
+								result_contact_descriptor.area+=calculate_area_from_contour(contour, a, b, barycenter);
+								result_contact_descriptor.arc_length+=calculate_arc_length_from_contour(a_id, contour);
+								if(record_graphics && result_contact_descriptor.area>FLOATCONST(0.0))
+								{
+									result_contact_descriptor.graphics.contours_graphics.push_back(ContourGraphics());
+									result_contact_descriptor.graphics.contours_graphics.back().barycenter=barycenter;
+									collect_points_from_contour(contour, result_contact_descriptor.graphics.contours_graphics.back().outer_points);
+								}
+							}
+						}
+
+						result_contact_descriptor.distance=distance_from_point_to_point(a.p, b.p);
+					}
+				}
+			}
+		}
+		return (result_contact_descriptor.area>FLOATCONST(0.0));
+	}
+
+private:
+	class HyperboloidBetweenTwoSpheres
+	{
+	public:
+		static inline SimplePoint project_point_on_hyperboloid(const SimplePoint& p, const SimpleSphere& s1, const SimpleSphere& s2)
+		{
+			if(s1.r>s2.r)
+			{
+				return project_point_on_hyperboloid(p, s2, s1);
+			}
+			else
+			{
+				const SimplePoint dv=point_and_number_product(sub_of_points(s1.p, s2.p), FLOATCONST(0.5));
+				const SimplePoint dv_unit=unit_point(dv);
+				const SimplePoint c=sum_of_points(s2.p, dv);
+				const SimplePoint cp=sub_of_points(p, c);
+				const Float lz=dot_product(dv_unit, cp);
+				const Float lx=std::sqrt(std::max(squared_point_module(cp)-(lz*lz), FLOATCONST(0.0)));
+				const Float z=project_point_on_simple_hyperboloid(lx, 0, point_module(dv), s1.r, s2.r);
+				return sum_of_points(sub_of_points(p, point_and_number_product(dv_unit, lz)), point_and_number_product(dv_unit, z));
+			}
+		}
+
+		static inline Float intersect_vector_with_hyperboloid(const SimplePoint& a, const SimplePoint& b, const SimpleSphere& s1, const SimpleSphere& s2)
+		{
+			if(s1.r>s2.r)
+			{
+				return intersect_vector_with_hyperboloid(a, b, s2, s1);
+			}
+			else
+			{
+				const SimplePoint dv=point_and_number_product(sub_of_points(s1.p, s2.p), FLOATCONST(0.5));
+				const SimplePoint dv_unit=unit_point(dv);
+				const SimplePoint c=sum_of_points(s2.p, dv);
+
+				const SimplePoint ca=sub_of_points(a, c);
+				const Float maz=dot_product(dv_unit, ca);
+				const SimplePoint cax=sub_of_points(sub_of_points(a, point_and_number_product(dv_unit, maz)), c);
+				const SimplePoint cax_unit=unit_point(cax);
+				const Float max=dot_product(cax_unit, ca);
+				const Float may=FLOATCONST(0.0);
+
+				const SimplePoint cb=sub_of_points(b, c);
+				const Float mbz=dot_product(dv_unit, cb);
+				const Float mbx=dot_product(cax_unit, cb);
+				const Float mby=std::sqrt(std::max(squared_point_module(cb)-mbz*mbz-mbx*mbx, FLOATCONST(0.0)));
+
+				return intersect_vector_with_simple_hyperboloid(SimplePoint(max, may, maz), SimplePoint(mbx, mby, mbz), point_module(dv), s1.r, s2.r);
+			}
+		}
+
+	private:
+		static inline Float project_point_on_simple_hyperboloid(const Float x, const Float y, const Float d, const Float r1, const Float r2)
+		{
+			if(r1>r2)
+			{
+				return project_point_on_simple_hyperboloid(x, y, d, r2, r1);
+			}
+			else
+			{
+				const Float r=r2-r1;
+				return 2*r*std::sqrt(std::max((0-r*r+4*d*d)*(4*x*x+4*y*y+4*d*d-r*r), FLOATCONST(0.0)))/(0-4*r*r+16*d*d);
+			}
+		}
+
+		static inline Float intersect_vector_with_simple_hyperboloid(const SimplePoint& a, const SimplePoint& b, const Float d, const Float r1, const Float r2)
+		{
+			if(r1>r2)
+			{
+				return intersect_vector_with_simple_hyperboloid(a, b, d, r2, r1);
+			}
+			else
+			{
+				const Float r=r2-r1;
+				SimplePoint ab=sub_of_points(b, a);
+				SimplePoint v=unit_point(ab);
+				const Float k=(4*r*r/((0-4*r*r+16*d*d)*(0-4*r*r+16*d*d))) * (0-r*r+4*d*d) * 4;
+				const Float m=(4*d*d-r*r)*k/4;
+
+				const Float x0=a.x;
+				const Float y0=a.y;
+				const Float z0=a.z;
+				const Float vx=v.x;
+				const Float vy=v.y;
+				const Float vz=v.z;
+
+				const Float t1 =  (std::sqrt((k*vy*vy+k*vx*vx)*z0*z0+(-2*k*vy*vz*y0-2*k*vx*vz*x0)*z0+(k*vz*vz-k*k*vx*vx)*y0*y0+2*k*k*vx*vy*x0*y0+(k*vz*vz-k*k*vy*vy)*x0*x0+m*vz*vz-k*m*vy*vy-k*m*vx*vx)-vz*z0+k*vy*y0+k*vx*x0)/(vz*vz-k*vy*vy-k*vx*vx);
+
+				const Float t2 = -(std::sqrt((k*vy*vy+k*vx*vx)*z0*z0+(-2*k*vy*vz*y0-2*k*vx*vz*x0)*z0+(k*vz*vz-k*k*vx*vx)*y0*y0+2*k*k*vx*vy*x0*y0+(k*vz*vz-k*k*vy*vy)*x0*x0+m*vz*vz-k*m*vy*vy-k*m*vx*vx)+vz*z0-k*vy*y0-k*vx*x0)/(vz*vz-k*vy*vy-k*vx*vx);
+
+				const SimplePoint tp1=sum_of_points(a, point_and_number_product(v, t1));
+				const SimplePoint tp2=sum_of_points(a, point_and_number_product(v, t2));
+				if(greater(t1, FLOATCONST(0.0)) && less(t1, point_module(ab)) && equal(tp1.z, std::sqrt(k*tp1.x*tp1.x+k*tp1.y*tp1.y+m), FLOATCONST(0.000001)))
+				{
+					return t1;
+				}
+				else if(greater(t2, FLOATCONST(0.0)) && less(t2, point_module(ab)) && equal(tp2.z, std::sqrt(k*tp2.x*tp2.x+k*tp2.y*tp2.y+m), FLOATCONST(0.000001)))
+				{
+					return t2;
+				}
+				else
+				{
+					return FLOATCONST(0.0);
+				}
+			}
+		}
+	};
+
+	static void init_contour_from_base_and_axis(
+			const UnsignedInt a_id,
+			const SimpleSphere& base,
+			const SimplePoint& axis,
+			const Float length_step,
+			Contour& result)
+	{
+		const Float angle_step=std::max(std::min(length_step/base.r, PIVALUE/FLOATCONST(3.0)), PIVALUE/FLOATCONST(36.0));
+		const SimplePoint first_point=point_and_number_product(any_normal_of_vector(axis), base.r);
+		result.push_back(ContourPoint(sum_of_points(base.p, first_point), a_id, a_id));
+		for(Float rotation_angle=angle_step;rotation_angle<(PIVALUE*FLOATCONST(2.0));rotation_angle+=angle_step)
+		{
+			result.push_back(ContourPoint(sum_of_points(base.p, rotate_point_around_axis(axis, rotation_angle, first_point)), a_id, a_id));
+		}
+	}
+
+	static bool cut_and_split_contour(
+			const SimpleSphere& a,
+			const SimpleSphere& c,
+			const UnsignedInt c_id,
+			Contour& contour,
+			std::list<Contour>& segments)
+	{
+		const UnsignedInt outsiders_count=mark_contour(a, c, c_id, contour);
+		if(outsiders_count>0)
+		{
+			if(outsiders_count<contour.size())
+			{
+				std::list<Contour::iterator> cuts;
+				const int cuts_count=cut_contour(a, c, c_id, contour, cuts);
+				if(cuts_count>0 && cuts_count%2==0)
+				{
+					if(cuts_count>2)
+					{
+						order_cuts(cuts);
+						split_contour(contour, cuts, segments);
+					}
+				}
+			}
+			else
+			{
+				contour.clear();
+			}
+			return true;
+		}
+		return false;
+	}
+
+	static UnsignedInt mark_contour(
+			const SimpleSphere& a,
+			const SimpleSphere& c,
+			const UnsignedInt c_id,
+			Contour& contour)
+	{
+		UnsignedInt outsiders_count=0;
+		for(Contour::iterator it=contour.begin();it!=contour.end();++it)
+		{
+			if((distance_from_point_to_point(it->p, c.p)-c.r)<(distance_from_point_to_point(it->p, a.p)-a.r))
+			{
+				it->left_id=c_id;
+				it->right_id=c_id;
+				outsiders_count++;
+			}
+		}
+		return outsiders_count;
+	}
+
+	static UnsignedInt cut_contour(
+			const SimpleSphere& a,
+			const SimpleSphere& c,
+			const UnsignedInt c_id,
+			Contour& contour,
+			std::list<Contour::iterator>& cuts)
+	{
+		UnsignedInt cuts_count=0;
+		Contour::iterator it=contour.begin();
+		while(it!=contour.end())
+		{
+			if(it->left_id==c_id && it->right_id==c_id)
+			{
+				const Contour::iterator left_it=get_left_iterator(contour, it);
+				const Contour::iterator right_it=get_right_iterator(contour, it);
+
+				if(left_it->right_id!=c_id)
+				{
+					const SimplePoint& p0=it->p;
+					const SimplePoint& p1=left_it->p;
+					const Float l=HyperboloidBetweenTwoSpheres::intersect_vector_with_hyperboloid(p0, p1, a, c);
+					cuts.push_back(contour.insert(it, ContourPoint(sum_of_points(p0, point_and_number_product(unit_point(sub_of_points(p1, p0)), l)), left_it->right_id, it->left_id)));
+					cuts_count++;
+				}
+
+				if(right_it->left_id!=c_id)
+				{
+					const SimplePoint& p0=it->p;
+					const SimplePoint& p1=right_it->p;
+					const Float l=HyperboloidBetweenTwoSpheres::intersect_vector_with_hyperboloid(p0, p1, a, c);
+					cuts.push_back(contour.insert(right_it, ContourPoint(sum_of_points(p0, point_and_number_product(unit_point(sub_of_points(p1, p0)), l)), it->right_id, right_it->left_id)));
+					cuts_count++;
+				}
+
+				it=contour.erase(it);
+			}
+			else
+			{
+				++it;
+			}
+		}
+		return cuts_count;
+	}
+
+	static void order_cuts(std::list<Contour::iterator>& cuts)
+	{
+		Float sums[2]={FLOATCONST(0.0), FLOATCONST(0.0)};
+		for(int i=0;i<2;i++)
+		{
+			if(i==1)
+			{
+				shift_list(cuts, false);
+			}
+			std::list<Contour::iterator>::const_iterator it=cuts.begin();
+			while(it!=cuts.end())
+			{
+				std::list<Contour::iterator>::const_iterator next=it;
+				++next;
+				if(next!=cuts.end())
+				{
+					sums[i]+=distance_from_point_to_point((*it)->p, (*next)->p);
+					it=next;
+					++it;
+				}
+				else
+				{
+					it=cuts.end();
+				}
+			}
+		}
+		if(sums[0]<sums[1])
+		{
+			shift_list(cuts, true);
+		}
+	}
+
+	static UnsignedInt split_contour(
+			Contour& contour,
+			const std::list<Contour::iterator>& ordered_cuts,
+			std::list<Contour>& segments)
+	{
+		UnsignedInt segments_count=0;
+		std::list<Contour::iterator>::const_iterator it=ordered_cuts.begin();
+		while(it!=ordered_cuts.end())
+		{
+			std::list<Contour::iterator>::const_iterator next=it;
+			++next;
+			if(next!=ordered_cuts.end())
+			{
+				if((*next)!=get_right_iterator(contour, (*it)))
+				{
+					segments_count++;
+					Contour segment;
+					Contour::iterator jt=(*it);
+					do
+					{
+						segment.push_back(*jt);
+						jt=get_right_iterator(contour, jt);
+					}
+					while(jt!=(*next));
+					segments.push_back(segment);
+				}
+				it=next;
+				++it;
+			}
+			else
+			{
+				it=ordered_cuts.end();
+			}
+		}
+		if(segments_count>0)
+		{
+			contour.clear();
+		}
+		return segments_count;
+	}
+
+	static void mend_contour(
+			const SimpleSphere& a,
+			const SimpleSphere& b,
+			const SimpleSphere& c,
+			const UnsignedInt c_id,
+			const Float step,
+			const int projections,
+			Contour& contour)
+	{
+		Contour::iterator it=contour.begin();
+		while(it!=contour.end())
+		{
+			if(it->left_id!=c_id && it->right_id==c_id)
+			{
+				const Contour::iterator jt=get_right_iterator(contour, it);
+				if(jt->left_id==c_id)
+				{
+					SimplePoint& p0=it->p;
+					SimplePoint& p1=jt->p;
+					for(int e=0;e<projections;e++)
+					{
+						p0=HyperboloidBetweenTwoSpheres::project_point_on_hyperboloid(p0, b, c);
+						p0=HyperboloidBetweenTwoSpheres::project_point_on_hyperboloid(p0, a, c);
+						p0=HyperboloidBetweenTwoSpheres::project_point_on_hyperboloid(p0, a, b);
+						p1=HyperboloidBetweenTwoSpheres::project_point_on_hyperboloid(p1, b, c);
+						p1=HyperboloidBetweenTwoSpheres::project_point_on_hyperboloid(p1, a, c);
+						p1=HyperboloidBetweenTwoSpheres::project_point_on_hyperboloid(p1, a, b);
+					}
+					const Float distance=distance_from_point_to_point(p0, p1);
+					if(distance>step)
+					{
+						const int leap_distance=static_cast<int>(std::floor(distance/step+FLOATCONST(0.5)));
+						const Float leap_size=distance/static_cast<Float>(leap_distance);
+						const SimplePoint direction=unit_point(sub_of_points(p1, p0));
+						for(int leap=1;leap<leap_distance;leap++)
+						{
+							SimplePoint p=sum_of_points(p0, point_and_number_product(direction, (leap_size*static_cast<Float>(leap))));
+							for(int e=0;e<projections;e++)
+							{
+								p=HyperboloidBetweenTwoSpheres::project_point_on_hyperboloid(p, b, c);
+								p=HyperboloidBetweenTwoSpheres::project_point_on_hyperboloid(p, a, c);
+								p=HyperboloidBetweenTwoSpheres::project_point_on_hyperboloid(p, a, b);
+							}
+							contour.insert(jt, ContourPoint(p, c_id, c_id));
+						}
+					}
+				}
+			}
+			++it;
+		}
+	}
+
+	static bool check_contour_intersects_sphere(const SimpleSphere& shell, const Contour& contour)
+	{
+		for(Contour::const_iterator it=contour.begin();it!=contour.end();++it)
+		{
+			if(distance_from_point_to_point(shell.p, it->p)<=shell.r)
+			{
+				return true;
+			}
+		}
+		return false;
+	}
+
+	static void filter_contours_intersecting_sphere(const SimpleSphere& shell, std::list<Contour>& contours)
+	{
+		std::list<Contour>::iterator it=contours.begin();
+		while(it!=contours.end())
+		{
+			if(!check_contour_intersects_sphere(shell, (*it)))
+			{
+				it=contours.erase(it);
+			}
+			else
+			{
+				++it;
+			}
+		}
+	}
+
+	template<typename List, typename Iterator>
+	static Iterator get_left_iterator(List& container, const Iterator& iterator)
+	{
+		Iterator left_it=iterator;
+		if(left_it==container.begin())
+		{
+			left_it=container.end();
+		}
+		--left_it;
+		return left_it;
+	}
+
+	template<typename List, typename Iterator>
+	static Iterator get_right_iterator(List& container, const Iterator& iterator)
+	{
+		Iterator right_it=iterator;
+		++right_it;
+		if(right_it==container.end())
+		{
+			right_it=container.begin();
+		}
+		return right_it;
+	}
+
+	template<typename List>
+	static void shift_list(List& list, const bool reverse)
+	{
+		if(!reverse)
+		{
+			list.push_front(*list.rbegin());
+			list.pop_back();
+		}
+		else
+		{
+			list.push_back(*list.begin());
+			list.pop_front();
+		}
+	}
+
+	static bool collect_points_from_contour(const Contour& contour, std::vector<SimplePoint>& contour_points)
+	{
+		contour_points.clear();
+		if(!contour.empty())
+		{
+			contour_points.reserve(contour.size());
+			for(Contour::const_iterator jt=contour.begin();jt!=contour.end();++jt)
+			{
+				contour_points.push_back(jt->p);
+			}
+		}
+		return (!contour_points.empty());
+	}
+
+	static Float calculate_area_from_contour(const Contour& contour, const SimpleSphere& sphere1, const SimpleSphere& sphere2, SimplePoint& contour_barycenter)
+	{
+		Float area=FLOATCONST(0.0);
+		if(!contour.empty())
+		{
+			contour_barycenter.x=FLOATCONST(0.0);
+			contour_barycenter.y=FLOATCONST(0.0);
+			contour_barycenter.z=FLOATCONST(0.0);
+			for(Contour::const_iterator jt=contour.begin();jt!=contour.end();++jt)
+			{
+				contour_barycenter.x+=jt->p.x;
+				contour_barycenter.y+=jt->p.y;
+				contour_barycenter.z+=jt->p.z;
+			}
+			contour_barycenter.x/=static_cast<Float>(contour.size());
+			contour_barycenter.y/=static_cast<Float>(contour.size());
+			contour_barycenter.z/=static_cast<Float>(contour.size());
+
+			contour_barycenter=HyperboloidBetweenTwoSpheres::project_point_on_hyperboloid(contour_barycenter, sphere1, sphere2);
+
+			for(Contour::const_iterator jt=contour.begin();jt!=contour.end();++jt)
+			{
+				Contour::const_iterator jt_next=jt;
+				++jt_next;
+				if(jt_next==contour.end())
+				{
+					jt_next=contour.begin();
+				}
+				area+=triangle_area(contour_barycenter, jt->p, jt_next->p);
+			}
+		}
+		return area;
+	}
+
+	static Float calculate_arc_length_from_contour(const UnsignedInt a_id, const Contour& contour)
+	{
+		Float arc_length=FLOATCONST(0.0);
+		for(Contour::const_iterator jt=contour.begin();jt!=contour.end();++jt)
+		{
+			Contour::const_iterator jt_next=jt;
+			++jt_next;
+			if(jt_next==contour.end())
+			{
+				jt_next=contour.begin();
+			}
+			if(jt->right_id==a_id && jt_next->left_id==a_id)
+			{
+				arc_length+=distance_from_point_to_point(jt->p, jt_next->p);
+			}
+		}
+		return arc_length;
+	}
+};
+
+}
+
+#endif /* VORONOTALT_SIMPLIFIED_AW_TESSELLATION_CONTACT_CONSTRUCTION_H_ */

--- a/src/voronotalt/spheres_searcher.h
+++ b/src/voronotalt/spheres_searcher.h
@@ -1,0 +1,175 @@
+#ifndef VORONOTALT_SPHERES_SEARCHER_H_
+#define VORONOTALT_SPHERES_SEARCHER_H_
+
+#include <vector>
+
+#include "basic_types_and_functions.h"
+
+namespace voronotalt
+{
+
+class SpheresSearcher
+{
+public:
+	explicit SpheresSearcher(const std::vector<SimpleSphere>& spheres) : spheres_(spheres), box_size_(FLOATCONST(1.0))
+	{
+		for(UnsignedInt i=0;i<spheres_.size();i++)
+		{
+			const SimpleSphere& s=spheres_[i];
+			box_size_=std::max(box_size_, s.r*FLOATCONST(2.0)+FLOATCONST(0.25));
+		}
+
+		for(UnsignedInt i=0;i<spheres_.size();i++)
+		{
+			const GridPoint gp(spheres_[i], box_size_);
+			if(i==0)
+			{
+				grid_offset_=gp;
+				grid_size_=gp;
+			}
+			else
+			{
+				grid_offset_.x=std::min(grid_offset_.x, gp.x);
+				grid_offset_.y=std::min(grid_offset_.y, gp.y);
+				grid_offset_.z=std::min(grid_offset_.z, gp.z);
+				grid_size_.x=std::max(grid_size_.x, gp.x);
+				grid_size_.y=std::max(grid_size_.y, gp.y);
+				grid_size_.z=std::max(grid_size_.z, gp.z);
+			}
+		}
+
+		grid_size_.x=grid_size_.x-grid_offset_.x+1;
+		grid_size_.y=grid_size_.y-grid_offset_.y+1;
+		grid_size_.z=grid_size_.z-grid_offset_.z+1;
+
+		map_of_boxes_.resize(grid_size_.x*grid_size_.y*grid_size_.z, -1);
+
+		for(UnsignedInt i=0;i<spheres_.size();i++)
+		{
+			const GridPoint gp(spheres_[i], box_size_, grid_offset_);
+			const int index=gp.index(grid_size_);
+			const int box_id=map_of_boxes_[index];
+			if(box_id<0)
+			{
+				map_of_boxes_[index]=static_cast<int>(boxes_.size());
+				boxes_.push_back(std::vector<UnsignedInt>(1, i));
+			}
+			else
+			{
+				boxes_[box_id].push_back(i);
+			}
+		}
+	}
+
+	bool find_colliding_ids(const UnsignedInt& central_id, std::vector<UnsignedInt>& colliding_ids, const bool discard_hidden, int& exclusion_status) const
+	{
+		colliding_ids.clear();
+		exclusion_status=0;
+		if(central_id<spheres_.size())
+		{
+			const SimpleSphere& central_sphere=spheres_[central_id];
+			const GridPoint gp(central_sphere, box_size_, grid_offset_);
+			GridPoint dgp=gp;
+			for(int dx=-1;dx<=1;dx++)
+			{
+				dgp.x=gp.x+dx;
+				for(int dy=-1;dy<=1;dy++)
+				{
+					dgp.y=gp.y+dy;
+					for(int dz=-1;dz<=1;dz++)
+					{
+						dgp.z=gp.z+dz;
+						const int index=dgp.index(grid_size_);
+						if(index>=0)
+						{
+							const int box_id=map_of_boxes_[index];
+							if(box_id>=0)
+							{
+								const std::vector<UnsignedInt>& ids=boxes_[box_id];
+								for(UnsignedInt i=0;i<ids.size();i++)
+								{
+									const UnsignedInt id=ids[i];
+									const SimpleSphere& candidate_sphere=spheres_[id];
+									if(id!=central_id && sphere_intersects_sphere(central_sphere, candidate_sphere))
+									{
+										if(discard_hidden
+												&& sphere_contains_sphere(candidate_sphere, central_sphere)
+												&& (!sphere_equals_sphere(candidate_sphere, central_sphere) || central_id>id))
+										{
+											colliding_ids.clear();
+											exclusion_status=1;
+											return false;
+										}
+										else if(!discard_hidden
+												|| !sphere_contains_sphere(central_sphere, candidate_sphere))
+										{
+											colliding_ids.push_back(id);
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+		return (!colliding_ids.empty());
+	}
+
+private:
+	struct GridPoint
+	{
+		int x;
+		int y;
+		int z;
+
+		GridPoint() : x(0), y(0), z(0)
+		{
+		}
+
+		GridPoint(const SimpleSphere& s, const Float grid_step)
+		{
+			init(s, grid_step);
+		}
+
+		GridPoint(const SimpleSphere& s, const Float grid_step, const GridPoint& grid_offset)
+		{
+			init(s, grid_step, grid_offset);
+		}
+
+		void init(const SimpleSphere& s, const Float grid_step)
+		{
+			x=static_cast<int>(s.p.x/grid_step);
+			y=static_cast<int>(s.p.y/grid_step);
+			z=static_cast<int>(s.p.z/grid_step);
+		}
+
+		void init(const SimpleSphere& s, const Float grid_step, const GridPoint& grid_offset)
+		{
+			x=static_cast<int>(s.p.x/grid_step)-grid_offset.x;
+			y=static_cast<int>(s.p.y/grid_step)-grid_offset.y;
+			z=static_cast<int>(s.p.z/grid_step)-grid_offset.z;
+		}
+
+		int index(const GridPoint& grid_size) const
+		{
+			return ((x>=0 && y>=0 && z>=0 && x<grid_size.x && y<grid_size.y &&z<grid_size.z) ? (z*grid_size.x*grid_size.y+y*grid_size.x+x) : (-1));
+		}
+
+		bool operator<(const GridPoint& gp) const
+		{
+			return (x<gp.x || (x==gp.x && y<gp.y) || (x==gp.x && y==gp.y && z<gp.z));
+		}
+	};
+
+	const std::vector<SimpleSphere>& spheres_;
+	GridPoint grid_offset_;
+	GridPoint grid_size_;
+	std::vector<int> map_of_boxes_;
+	std::vector< std::vector<UnsignedInt> > boxes_;
+	Float box_size_;
+};
+
+}
+
+#endif /* VORONOTALT_SPHERES_SEARCHER_H_ */

--- a/src/voronotalt/time_recorder.h
+++ b/src/voronotalt/time_recorder.h
@@ -1,0 +1,29 @@
+#ifndef VORONOTALT_TIME_RECORDER_H_
+#define VORONOTALT_TIME_RECORDER_H_
+
+namespace voronotalt
+{
+
+class TimeRecorder
+{
+public:
+	TimeRecorder()
+	{
+	}
+
+	virtual ~TimeRecorder()
+	{
+	}
+
+	virtual void reset()
+	{
+	}
+
+	virtual void record_elapsed_miliseconds_and_reset(const char* /*message*/)
+	{
+	}
+};
+
+}
+
+#endif /* VORONOTALT_TIME_RECORDER_H_ */

--- a/src/voronotalt/voronotalt.h
+++ b/src/voronotalt/voronotalt.h
@@ -1,0 +1,8 @@
+#ifndef VORONOTALT_VORONOTALT_H_
+#define VORONOTALT_VORONOTALT_H_
+
+#include "conversion_to_input.h"
+#include "radical_tessellation.h"
+#include "simplified_aw_tessellation.h"
+
+#endif /* VORONOTALT_VORONOTALT_H_ */


### PR DESCRIPTION
This adds support for analysing configurations using the Voronoa-LT library. Currently only accessible surface areas are reported, but contact maps are already calculated. On a 500-mer polymer, the algorithm is 4-5 times faster than the current `sasa` analysis.