### PR TITLE
Add harmonic potential to constraint

### DIFF
--- a/docs/_docs/energy.md
+++ b/docs/_docs/energy.md
@@ -1067,6 +1067,16 @@ energy:
     - constrain: {type: molecule, index: 0, property: end2end, range: [0,200]}
 ~~~
 
+Instead of a range, the constraint can be in the form of a harmonic potential
+where `req` is the value of the reaction coordinate at the minimum and `k` is
+the force constant. If `harmonic` is given, the `range` is ignored.
+The following constrains one box side length to 100 angstroms:
+
+~~~ yaml
+energy:
+    - constrain: {type: system, property: Lx, harmonic: {req: 100.0, k: 500.0}}
+~~~
+
 Tip: placing `constrain` at the _top_ of the energy list is more efficient as the remaining
 energy terms are skipped should an infinite energy arise.
 

--- a/src/energy.cpp
+++ b/src/energy.cpp
@@ -808,9 +808,9 @@ TEST_CASE("Energy::Isobaric") {
 Constrain::Constrain(const json& j, Space& spc) {
     name = "constrain";
     type = j.at("type").get<std::string>();
-    if (const auto b = j.find("harmonic"); b != j.end()) {
+    if (const auto it = j.find("harmonic"); it != j.end()) {
         harmonic = std::make_optional<Faunus::pairpotential::HarmonicBond>();
-        harmonic->from_json(*b);
+        harmonic->from_json(*it);
     }
     coordinate = ReactionCoordinate::createReactionCoordinate({{type, j}}, spc);
 }
@@ -819,7 +819,7 @@ double Constrain::energy(const Change& change) {
     if (change) {
         const auto value = (*coordinate)(); // calculate reaction coordinate
         if (harmonic) {
-            return (*harmonic).half_force_constant * std::pow((*harmonic).equilibrium_distance - value, 2);
+            return harmonic->half_force_constant * std::pow(harmonic->equilibrium_distance - value, 2);
         }
         if (not coordinate->inRange(value)) { // if outside allowed range ...
             return pc::infty;                 // ... return infinite energy
@@ -832,7 +832,7 @@ void Constrain::to_json(json& j) const {
     j.erase("resolution");
     j["type"] = type;
     if (harmonic) {
-        (*harmonic).to_json(j["harmonic"]);
+        harmonic->to_json(j["harmonic"]);
         j["harmonic"].erase("index");
         j.erase("range");
     }

--- a/src/energy.cpp
+++ b/src/energy.cpp
@@ -805,7 +805,7 @@ TEST_CASE("Energy::Isobaric") {
     }
 }
 
-Constrain::Constrain(const json &j, Space &spc) {
+Constrain::Constrain(const json& j, Space& spc) {
     name = "constrain";
     type = j.at("type").get<std::string>();
     if (const auto b = j.find("harmonic"); b != j.end()) {
@@ -818,16 +818,16 @@ Constrain::Constrain(const json &j, Space &spc) {
 double Constrain::energy(const Change& change) {
     if (change) {
         const auto value = (*coordinate)(); // calculate reaction coordinate
-	if (harmonic) {
+        if (harmonic) {
             return (*harmonic).half_force_constant * std::pow((*harmonic).equilibrium_distance - value, 2);
-	}
+        }
         if (not coordinate->inRange(value)) { // if outside allowed range ...
             return pc::infty;                 // ... return infinite energy
-	}
+        }
     }
     return 0.0;
 }
-void Constrain::to_json(json &j) const {
+void Constrain::to_json(json& j) const {
     j = json(*coordinate).at(type);
     j.erase("resolution");
     j["type"] = type;

--- a/src/energy.cpp
+++ b/src/energy.cpp
@@ -809,9 +809,8 @@ Constrain::Constrain(const json &j, Space &spc) {
     name = "constrain";
     type = j.at("type").get<std::string>();
     if (const auto b = j.find("harmonic"); b != j.end()) {
-        auto bond = Faunus::pairpotential::HarmonicBond();
-	bond.from_json(*b);
-	harmonic = bond;
+        harmonic = std::make_optional<Faunus::pairpotential::HarmonicBond>();
+        harmonic->from_json(*b);
     }
     coordinate = ReactionCoordinate::createReactionCoordinate({{type, j}}, spc);
 }

--- a/src/energy.h
+++ b/src/energy.h
@@ -278,6 +278,7 @@ class Constrain : public EnergyTerm {
   private:
     std::string type;
     std::unique_ptr<ReactionCoordinate::ReactionCoordinateBase> coordinate;
+    std::optional<Faunus::pairpotential::HarmonicBond> harmonic;
 
   public:
     Constrain(const json& j, Space& space);

--- a/src/energy.h
+++ b/src/energy.h
@@ -17,6 +17,7 @@
 #include <numeric>
 #include <algorithm>
 #include <concepts>
+#include <optional>
 
 struct freesasa_parameters_fwd; // workaround for freesasa unnamed struct that cannot be forward declared
 


### PR DESCRIPTION
This adds the possibility to use a harmonic potential to constrain systems to a reaction coordinate.