### PR TITLE
Fix anglescan when the two molecules are different

### DIFF
--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -50,7 +50,8 @@ AngularScan::AngularScan(const json& j, const Space& spc)
  */
 void AngularScan::Molecule::initialize(const Space::GroupVector& groups, int molecule_index)
 {
-    namespace rv = std::views;
+    using std::views::transform;
+
     index = molecule_index;
     const auto& group = groups.at(index);
     if (group.isAtomic()) {
@@ -62,7 +63,7 @@ void AngularScan::Molecule::initialize(const Space::GroupVector& groups, int mol
     auto as_centered_position = [&](const auto& particle) -> Point {
         return particle.pos - group.mass_center;
     };
-    ref_positions = group | rv::transform(as_centered_position) | ranges::to_vector;
+    ref_positions = group | transform(as_centered_position) | ranges::to_vector;
     XYZWriter().save(fmt::format("molecule{}_reference.xyz", index), group.begin(), group.end(),
                      Point::Zero());
 }
@@ -70,12 +71,11 @@ void AngularScan::Molecule::initialize(const Space::GroupVector& groups, int mol
 ParticleVector AngularScan::Molecule::getRotatedReference(const Space::GroupVector& groups,
                                                           const Eigen::Quaterniond& q)
 {
-    namespace rv = std::views;
+    using std::views::transform;
     const auto& group = groups.at(index);
     auto particles = ParticleVector(group.begin(), group.end()); // copy particles from Space
-    auto positions =
-        ref_positions | rv::transform([&](const auto& pos) -> Point { return q * pos; });
-    std::ranges::copy(positions, (particles | rv::transform(&Particle::pos)).begin());
+    auto positions = ref_positions | transform([&](const auto& pos) -> Point { return q * pos; });
+    std::ranges::copy(positions, (particles | transform(&Particle::pos)).begin());
     return particles;
 }
 

--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -56,6 +56,9 @@ void AngularScan::Molecule::initialize(const Space::GroupVector& groups, int mol
     if (group.isAtomic()) {
         throw ConfigurationError("{}: group {} is not molecular", NAME, index);
     }
+
+    faunus_logger->trace("{}: initizalizing group {}", NAME, index);
+
     auto as_centered_position = [&](auto& particle) -> Point {
         return particle.pos - group.mass_center;
     };

--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -75,8 +75,7 @@ ParticleVector AngularScan::Molecule::getRotatedReference(const Space::GroupVect
     auto particles = ParticleVector(group.begin(), group.end()); // copy particles from Space
     auto positions =
         ref_positions | rv::transform([&](const auto& pos) -> Point { return q * pos; });
-    std::ranges::copy(positions,
-              (particles | rv::transform(&Particle::pos)).begin());
+    std::ranges::copy(positions, (particles | rv::transform(&Particle::pos)).begin());
     return particles;
 }
 

--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -59,7 +59,7 @@ void AngularScan::Molecule::initialize(const Space::GroupVector& groups, int mol
 
     faunus_logger->trace("{}: initizalizing group {}", NAME, index);
 
-    auto as_centered_position = [&](auto& particle) -> Point {
+    auto as_centered_position = [&](const auto& particle) -> Point {
         return particle.pos - group.mass_center;
     };
     ref_positions = group | rv::transform(as_centered_position) | ranges::to_vector;
@@ -75,7 +75,7 @@ ParticleVector AngularScan::Molecule::getRotatedReference(const Space::GroupVect
     auto particles = ParticleVector(group.begin(), group.end()); // copy particles from Space
     auto positions =
         ref_positions | rv::transform([&](const auto& pos) -> Point { return q * pos; });
-    std::copy(positions.begin(), positions.end(),
+    std::ranges::copy(positions,
               (particles | rv::transform(&Particle::pos)).begin());
     return particles;
 }
@@ -83,6 +83,9 @@ ParticleVector AngularScan::Molecule::getRotatedReference(const Space::GroupVect
 void AngularScan::report(const Group& group1, const Group& group2, const Eigen::Quaterniond& q1,
                          const Eigen::Quaterniond& q2, Energy::NonbondedBase& nonbonded)
 {
+    using ranges::views::concat;
+    using std::views::transform;
+
     const auto energy = nonbonded.groupGroupEnergy(group1, group2);
     if (energy >= max_energy) {
         return;
@@ -98,8 +101,7 @@ void AngularScan::report(const Group& group1, const Group& group2, const Eigen::
         *stream << format(q1) << format(q2)
                 << fmt::format("{:8.4f} {:>10.3E}\n", group2.mass_center.z(), energy / 1.0_kJmol);
         if (trajectory) {
-            auto positions = ranges::views::concat(group1, group2) |
-                             std::views::transform(&Particle::pos);
+            auto positions = concat(group1, group2) | transform(&Particle::pos);
             trajectory->writeNext({500, 500, 500}, positions.begin(), positions.end());
         }
     }
@@ -122,7 +124,7 @@ void AngularScan::operator()(Space& spc, Energy::Hamiltonian& hamiltonian)
 
 #pragma omp parallel for
         for (const auto& q1 : angles.quaternions_1) {
-            auto particles1 = molecules.second.getRotatedReference(spc.groups, q1);
+            auto particles1 = molecules.first.getRotatedReference(spc.groups, q1);
             auto group1 = Group(0, particles1.begin(), particles1.end());
             group1.updateMassCenter(spc.geometry.getBoundaryFunc(), {0, 0, 0});
 


### PR DESCRIPTION
Anglescan would wrongly assume that both molecules are the same. @IVinterbladh could you verify that the bug is fixed?