### PR TITLE
Fix: make confine spring constant a floating point number

### DIFF
--- a/docs/schema.yml
+++ b/docs/schema.yml
@@ -680,7 +680,7 @@ properties:
                         low:
                             items: {type: number}
                             type: array
-                        k: {type: [integer, string]}
+                        k: {type: [number, string]}
                         molecules:
                             type: array
                             items: {type: string}


### PR DESCRIPTION
The JSON schema imposed integer spring constant for the confine hamiltonian term.