### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,4 +1,6 @@
 name: CMake
+permissions:
+  contents: read
 
 on: [push]
 


### PR DESCRIPTION
Potential fix for [https://github.com/mlund/faunus/security/code-scanning/2](https://github.com/mlund/faunus/security/code-scanning/2)

In general, the fix is to explicitly define a minimal `permissions:` block so that the `GITHUB_TOKEN` used in this workflow has only the scopes required. This workflow only needs to read repository contents for `actions/checkout@v4`; no GitHub write actions are performed. Therefore, `contents: read` at the workflow level is sufficient and follows the principle of least privilege.

The best fix without changing existing functionality is to add a top-level `permissions:` block just under the workflow `name:` (or anywhere at the root, e.g., before `jobs:`). This will apply to all jobs in the workflow. Concretely, in `.github/workflows/cmake.yml`, after line 1 (`name: CMake`) insert:

```yaml
permissions:
  contents: read
```

No other steps or jobs need to be altered, and no additional imports or methods are required, because this is a pure configuration change in the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
