### PR TITLE
Fix nlohmann_json ABI mismatch with system-installed version

### DIFF
--- a/cmake/ExternalTools.cmake
+++ b/cmake/ExternalTools.cmake
@@ -49,6 +49,8 @@ set_property(TARGET docopt PROPERTY POSITION_INDEPENDENT_CODE ON)
 if (nlohmann_json_ADDED)
     add_library(nlohmann_json INTERFACE IMPORTED)
     target_include_directories(nlohmann_json INTERFACE ${nlohmann_json_SOURCE_DIR}/include)
+    # Ensure CPM-downloaded json takes precedence over any system-installed version (e.g., in conda)
+    include_directories(BEFORE SYSTEM ${nlohmann_json_SOURCE_DIR}/include)
 endif()
 
 add_compile_definitions("NLOHMANN_JSON_HPP") # older versions used this macro. Now it's suffixed with "_"


### PR DESCRIPTION
When conda (or other package managers) have nlohmann_json installed, the system include path may be searched before the CPM-downloaded version, causing ABI mismatches between translation units. This resulted in undefined reference errors during linking due to different inline namespace versions (e.g., json_abi_v3_11_3 vs json_abi_v3_12_0).

Add BEFORE SYSTEM include_directories to ensure the CPM-downloaded nlohmann_json always takes precedence over any system-installed version.