### PR TITLE
Migrate from ranges::cpp20::views to std::views where possible

### DIFF
--- a/src/analysis.cpp
+++ b/src/analysis.cpp
@@ -18,6 +18,10 @@
 #include <range/v3/numeric/accumulate.hpp>
 #include <range/v3/algorithm/for_each.hpp>
 #include <range/v3/view/cache1.hpp>
+#include <range/v3/view/transform.hpp>
+#include <range/v3/view/join.hpp>
+#include <range/v3/view/filter.hpp>
+#include <range/v3/range/conversion.hpp>
 #include <spdlog/spdlog.h>
 #include <spdlog/fmt/ostr.h>
 #include <zstr.hpp>
@@ -1187,7 +1191,7 @@ PointVector AtomicDisplacement::getPositions() const
     auto active_and_inactive = [&](const Group& group) {
         return std::ranges::subrange(group.begin(), group.trueend());
     };
-    namespace rv = ranges::cpp20::views;
+    namespace rv = ranges::views;
     return spc.findMolecules(molid, Space::Selection::ALL) | rv::transform(active_and_inactive) |
            rv::join | rv::transform(&Particle::pos) | ranges::to<PointVector>;
 }
@@ -1699,9 +1703,9 @@ XTCtraj::XTCtraj(const Space& spc, const std::string& filename,
                  const std::vector<std::string>& molecule_names)
     : Analysis(spc, "xtcfile")
 {
-    using ranges::cpp20::views::filter;
-    using ranges::cpp20::views::join;
-    using ranges::cpp20::views::transform;
+    using ranges::views::filter;
+    using ranges::views::join;
+    using ranges::views::transform;
     using ranges::views::cache1;
 
     writer = std::make_unique<XTCWriter>(filename);
@@ -1742,7 +1746,7 @@ void XTCtraj::_to_json(json& j) const
  */
 void XTCtraj::_sample()
 {
-    namespace rv = ranges::cpp20::views;
+    namespace rv = ranges::views;
     if (group_ids.empty()) {
         auto positions = spc.particles | std::views::transform(&Particle::pos);
         writer->writeNext(spc.geometry.getLength(), positions.begin(), positions.end());
@@ -2662,7 +2666,7 @@ Multipole::Multipole(const json& j, const Space& spc)
 
 void ScatteringFunction::_sample()
 {
-    namespace rv = ranges::cpp20::views;
+    namespace rv = ranges::views;
     scatter_positions.clear();
     auto groups =
         molecule_ids | rv::transform([&](auto id) { return spc.findMolecules(id); }) | rv::join;

--- a/src/energy.cpp
+++ b/src/energy.cpp
@@ -464,7 +464,7 @@ void PolicyIonIonIPBC::updateComplex(EwaldData& d, const Change& change,
 double PolicyIonIon::surfaceEnergy(const EwaldData& data, [[maybe_unused]] const Change& change,
                                    const Space::GroupVector& groups)
 {
-    using ranges::cpp20::views::join;
+    using std::views::join;
     if (data.const_inf < 0.5 || change.empty()) {
         return 0.0;
     }
@@ -815,7 +815,7 @@ double ContainerOverlap::energy(const Change& change)
 double ContainerOverlap::energyOfAllGroups() const
 {
     auto positions =
-        spc.groups | ranges::cpp20::views::join | std::views::transform(&Particle::pos);
+        spc.groups | std::views::join | std::views::transform(&Particle::pos);
     bool outside = std::any_of(positions.begin(), positions.end(), [&](const auto& position) {
         return spc.geometry.collision(position);
     });

--- a/src/geometry.h
+++ b/src/geometry.h
@@ -11,9 +11,6 @@
 #include <ranges>
 #include <range/v3/view/cartesian_product.hpp>
 #include <range/v3/view/zip.hpp>
-#ifndef __cpp_lib_ranges_join_with
-#include <range/v3/view/join.hpp>
-#endif
 #include <utility>
 
 /** @brief Faunus main namespace */
@@ -648,11 +645,7 @@ Point trigoCom(const Tspace& spc, const GroupIndex& indices,
         throw std::out_of_range("invalid directions");
     }
     namespace rv = std::views;
-#ifdef __cpp_lib_ranges_join_with
     using std::views::join;
-#else
-    using ranges::cpp20::views::join;
-#endif
     auto positions = indices | rv::transform([&](auto i) { return spc.groups.at(i); }) | join |
                      rv::transform(&Particle::pos);
     Point xhi(0, 0, 0);

--- a/src/reactioncoordinate.cpp
+++ b/src/reactioncoordinate.cpp
@@ -6,9 +6,6 @@
 #include <Eigen/Dense>
 #include "aux/eigensupport.h"
 #include <ranges>
-#ifndef __cpp_lib_ranges_join_with
-#include <range/v3/view/join.hpp>
-#endif
 #include "spdlog/spdlog.h"
 
 namespace Faunus::ReactionCoordinate {
@@ -107,11 +104,7 @@ SystemProperty::SystemProperty(const json& j, const Space& spc)
     : ReactionCoordinateBase(j)
 {
     namespace rv = std::views;
-#ifdef __cpp_lib_ranges_join_with
     using std::views::join;
-#else
-    using ranges::cpp20::views::join;
-#endif
     name = "system";
     property = j.at("property").get<std::string>();
     if (property == "V") {


### PR DESCRIPTION
## Summary
- Replace range-v3's `ranges::cpp20::views` with C++20 `std::views` in files where code doesn't depend on range-v3-specific features downstream
- Remove unnecessary conditional includes for `std::views::join`
- Simplify namespace aliases

## Changes
- **molecule.cpp**: Use `std::views` for join, transform, filter
- **reactioncoordinate.cpp**: Remove conditional join include, use `std::views`
- **geometry.h**: Remove conditional join include, use `std::views`
- **energy.cpp**: Use `std::views::join` for container overlap check
- **analysis.cpp**: Simplify namespace from `ranges::cpp20::views` to `ranges::views`

Files using `ranges::cpp20::views` in space.h and move.h are kept unchanged as they require compatibility with range-v3-specific features (`cache1`, `indirect`) used downstream.

## Test plan
- [x] Builds with clang-20
- [x] Builds with GCC
